### PR TITLE
Removed the check for npcs on -1 (#327)

### DIFF
--- a/src/main/java/rs117/hd/scene/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightManager.java
@@ -226,12 +226,6 @@ public class LightManager
 			if (light.npc != null)
 			{
 
-				// prevent npcs at plane -1 and under from having lights
-				if (light.npc.getWorldLocation().getPlane() <= -1) {
-					lightIterator.remove();
-					continue;
-				}
-
 				if (light.npc != client.getCachedNPCs()[light.npc.getIndex()])
 				{
 					lightIterator.remove();


### PR DESCRIPTION
Adam said its not needed as npcs are never on "-1" where objects can be EG: Underside of bridges