### PR TITLE
Pet Light Fix

### DIFF
--- a/src/main/java/rs117/hd/scene/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightManager.java
@@ -398,10 +398,18 @@ public class LightManager
 		if (pluginManager.isPluginEnabled(entityHiderPlugin))
 		{
 			boolean isPet = npc.getComposition().isFollower();
+
+			if(client.getFollower() != null) {
+				if (client.getFollower().getIndex() == npc.getIndex()) {
+					return true;
+				}
+			}
+
 			if (entityHiderConfig.hideNPCs() && !isPet)
 			{
 				return false;
 			}
+
 			if (entityHiderConfig.hidePets() && isPet)
 			{
 				return false;


### PR DESCRIPTION
Fixed how "Hide Pets" Would remove the players pet lights as Entity hider does not hide your personal pet.