### PR TITLE
Add code style, inspection and run configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = tab
+indent_size = 4
+
+# IntelliJ saves XML configs in this format
+[*.xml]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .gradle
 build
 .idea/*
+!.idea/codeStyles/
+!.idea/runConfigurations/
+!.idea/inspectionProfiles/
 !.idea/jsonSchemas.xml
 .project
 .settings/
@@ -8,3 +11,4 @@ build
 nbactions.xml
 nb-configuration.xml
 nbproject/
+hs_err_pid*

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,127 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="AUTODETECT_INDENTS" value="false" />
+    <option name="LINE_SEPARATOR" value="&#10;" />
+    <option name="RIGHT_MARGIN" value="140" />
+    <option name="FORMATTER_TAGS_ENABLED" value="true" />
+    <option name="DO_NOT_FORMAT">
+      <list>
+        <fileSet type="globPattern" pattern="*.{glsl,cl}" />
+      </list>
+    </option>
+    <JSON>
+      <option name="ARRAY_WRAPPING" value="5" />
+    </JSON>
+    <JavaCodeStyleSettings>
+      <option name="ANNOTATION_PARAMETER_WRAP" value="5" />
+      <option name="NEW_LINE_AFTER_LPAREN_IN_ANNOTATION" value="true" />
+      <option name="RPAREN_ON_NEW_LINE_IN_ANNOTATION" value="true" />
+      <option name="CLASS_COUNT_TO_USE_IMPORT_ON_DEMAND" value="999" />
+      <option name="NAMES_COUNT_TO_USE_IMPORT_ON_DEMAND" value="10" />
+      <option name="PACKAGES_TO_USE_IMPORT_ON_DEMAND">
+        <value>
+          <package name="org.lwjgl.opengl" withSubpackages="true" static="true" />
+          <package name="org.lwjgl.opencl" withSubpackages="true" static="true" />
+          <package name="net.runelite.api" withSubpackages="true" static="false" />
+        </value>
+      </option>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="true" />
+        </value>
+      </option>
+      <option name="RECORD_COMPONENTS_WRAP" value="5" />
+      <option name="ALIGN_MULTILINE_RECORDS" value="false" />
+      <option name="NEW_LINE_AFTER_LPAREN_IN_RECORD_HEADER" value="true" />
+      <option name="RPAREN_ON_NEW_LINE_IN_RECORD_HEADER" value="true" />
+      <option name="MULTI_CATCH_TYPES_WRAP" value="5" />
+    </JavaCodeStyleSettings>
+    <editorconfig>
+      <option name="ENABLED" value="false" />
+    </editorconfig>
+    <codeStyleSettings language="GLSL">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Groovy">
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="USE_TAB_CHARACTER" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <option name="RIGHT_MARGIN" value="140" />
+      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+      <option name="ALIGN_MULTILINE_RESOURCES" value="false" />
+      <option name="ALIGN_MULTILINE_FOR" value="false" />
+      <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="true" />
+      <option name="SPACE_WITHIN_ARRAY_INITIALIZER_BRACES" value="true" />
+      <option name="SPACE_BEFORE_ARRAY_INITIALIZER_LBRACE" value="true" />
+      <option name="CALL_PARAMETERS_WRAP" value="5" />
+      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_WRAP" value="5" />
+      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="RESOURCE_LIST_WRAP" value="5" />
+      <option name="RESOURCE_LIST_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="RESOURCE_LIST_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="THROWS_LIST_WRAP" value="5" />
+      <option name="METHOD_CALL_CHAIN_WRAP" value="5" />
+      <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
+      <option name="PARENTHESES_EXPRESSION_LPAREN_WRAP" value="true" />
+      <option name="PARENTHESES_EXPRESSION_RPAREN_WRAP" value="true" />
+      <option name="BINARY_OPERATION_WRAP" value="1" />
+      <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+      <option name="TERNARY_OPERATION_WRAP" value="5" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_LAMBDAS_IN_ONE_LINE" value="true" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="true" />
+      <option name="FOR_STATEMENT_WRAP" value="5" />
+      <option name="FOR_STATEMENT_LPAREN_ON_NEXT_LINE" value="true" />
+      <option name="FOR_STATEMENT_RPAREN_ON_NEXT_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="5" />
+      <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+      <option name="ASSERT_STATEMENT_WRAP" value="5" />
+      <option name="DOWHILE_BRACE_FORCE" value="3" />
+      <option name="ENUM_CONSTANTS_WRAP" value="5" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="USE_TAB_CHARACTER" value="true" />
+      </indentOptions>
+      <arrangement>
+        <groups>
+          <group>
+            <type>GETTERS_AND_SETTERS</type>
+            <order>KEEP</order>
+          </group>
+          <group>
+            <type>OVERRIDDEN_METHODS</type>
+            <order>BY_NAME</order>
+          </group>
+        </groups>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSON">
+      <option name="RIGHT_MARGIN" value="140" />
+      <option name="SPACE_WITHIN_BRACKETS" value="true" />
+      <option name="SPACE_WITHIN_BRACES" value="true" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="USE_TAB_CHARACTER" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true"/>
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,20 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="SameParameterValue" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedReturnValue" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="UnusedSymbol" enabled="true" level="INFORMATION" enabled_by_default="true" />
+    <inspection_tool class="unused" enabled="true" level="WEAK WARNING" enabled_by_default="true" checkParameterExcludingHierarchy="false">
+      <option name="LOCAL_VARIABLE" value="true" />
+      <option name="FIELD" value="true" />
+      <option name="METHOD" value="true" />
+      <option name="CLASS" value="true" />
+      <option name="PARAMETER" value="true" />
+      <option name="REPORT_PARAMETER_FOR_PUBLIC_METHODS" value="true" />
+      <option name="ADD_MAINS_TO_ENTRIES" value="true" />
+      <option name="ADD_APPLET_TO_ENTRIES" value="true" />
+      <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
+      <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/runConfigurations/HdPluginTest.xml
+++ b/.idea/runConfigurations/HdPluginTest.xml
@@ -1,0 +1,19 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HdPluginTest" type="Application" factoryName="Application" singleton="false">
+    <option name="ALTERNATIVE_JRE_PATH" value="11" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="MAIN_CLASS_NAME" value="rs117.hd.HdPluginTest" />
+    <module name="hd.test" />
+    <option name="PROGRAM_PARAMETERS" value="--developer-mode --debug" />
+    <option name="VM_PARAMETERS" value="-ea -Xmx512M" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="rs117.hd.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -14,15 +14,15 @@ repositories {
 def runeLiteVersion = '1.10.+'
 
 dependencies {
-	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
+	compileOnly group: 'net.runelite', name: 'client', version: runeLiteVersion
 
 	compileOnly 'org.projectlombok:lombok:1.18.20'
 	annotationProcessor 'org.projectlombok:lombok:1.18.20'
 
 	testImplementation 'junit:junit:4.13.2'
 	testImplementation 'org.mockito:mockito-core:3.1.0'
-	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
-	testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+	testImplementation group: 'net.runelite', name: 'client', version: runeLiteVersion
+	testImplementation group: 'net.runelite', name: 'jshell', version: runeLiteVersion
 
 	testCompileOnly 'org.projectlombok:lombok:1.18.20'
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.20'
@@ -32,7 +32,7 @@ group = 'rs117.hd'
 version = '1.2.8'
 sourceCompatibility = '11'
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
 }
 

--- a/src/main/java/rs117/hd/config/ColorBlindMode.java
+++ b/src/main/java/rs117/hd/config/ColorBlindMode.java
@@ -24,10 +24,9 @@
  */
 package rs117.hd.config;
 
-public enum ColorBlindMode
-{
+public enum ColorBlindMode {
 	NONE,
 	PROTANOPE,
 	DEUTERANOPE,
-	TRITANOPE;
+	TRITANOPE
 }

--- a/src/main/java/rs117/hd/config/ParallaxMappingMode.java
+++ b/src/main/java/rs117/hd/config/ParallaxMappingMode.java
@@ -29,7 +29,6 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum ParallaxMappingMode
-{
-	OFF, BASIC, FULL, EXTREME;
+public enum ParallaxMappingMode {
+	OFF, BASIC, FULL, EXTREME
 }

--- a/src/main/java/rs117/hd/data/environments/Area.java
+++ b/src/main/java/rs117/hd/data/environments/Area.java
@@ -24,12 +24,10 @@
  */
 package rs117.hd.data.environments;
 
-import lombok.Getter;
-import net.runelite.api.Constants;
-import net.runelite.api.coords.WorldPoint;
-import rs117.hd.utils.AABB;
-
 import java.util.Arrays;
+import lombok.Getter;
+import net.runelite.api.coords.*;
+import rs117.hd.utils.AABB;
 
 @Getter
 public enum Area

--- a/src/main/java/rs117/hd/data/materials/TileOverrideBuilder.java
+++ b/src/main/java/rs117/hd/data/materials/TileOverrideBuilder.java
@@ -1,16 +1,14 @@
 package rs117.hd.data.materials;
 
+import java.util.Arrays;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import rs117.hd.HdPlugin;
-import rs117.hd.HdPluginConfig;
 import rs117.hd.data.WaterType;
 import rs117.hd.data.environments.Area;
-
-import java.util.Arrays;
-import java.util.function.Consumer;
-import java.util.function.Function;
 
 @Setter
 @Accessors(fluent = true)

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -377,7 +377,7 @@ public class ModelPusher {
 	}
 
 	public int packMaterialData(Material material, @NonNull ModelOverride modelOverride, UvType uvType, boolean isOverlay) {
-		// TODO: only the lower 24 bits can be safely used due to imprecise casting to float in shaders
+		// Only the lower 24 bits can be safely used due to imprecise casting to float in shaders
 		return // This needs to return zero by default, since we often fall back to writing all zeroes to UVs
 			(material.ordinal() & MAX_MATERIAL_COUNT) << 12
 			| ((int) (modelOverride.shadowOpacityThreshold * 0x3F) & 0x3F) << 5

--- a/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
+++ b/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
@@ -114,7 +114,7 @@ public class TileInfoOverlay extends net.runelite.client.ui.overlay.Overlay
 				poly = getCanvasTilePoly(client, bridge);
 				if (poly != null && poly.contains(mousePos.getX(), mousePos.getY()))
 				{
-					rect = drawTileInfo(g, bridge, poly, rect);
+					rect = drawTileInfo(g, bridge, poly, null);
 					if (rect != null)
 					{
 						infoDrawn = true;
@@ -250,9 +250,9 @@ public class TileInfoOverlay extends net.runelite.client.ui.overlay.Overlay
 				int b = CB[face];
 				int c = CC[face];
 				if (a == b && b == c) {
-					lines.add("" + face + ": " + (a == 12345678 ? "HIDDEN" : a));
+					lines.add(face + ": " + (a == 12345678 ? "HIDDEN" : a));
 				} else {
-					lines.add("" + face + ": [ " +
+					lines.add(face + ": [ " +
 						(a == 12345678 ? "HIDDEN" : a) + ", " +
 						(b == 12345678 ? "HIDDEN" : b) + ", " +
 						(c == 12345678 ? "HIDDEN" : c) + " ]");
@@ -273,16 +273,17 @@ public class TileInfoOverlay extends net.runelite.client.ui.overlay.Overlay
 			GameObject[] gameObjects = tile.getGameObjects();
 			if (gameObjects.length > 0) {
 				int counter = 0;
-				for (int i = 0; i < gameObjects.length; i++) {
-					GameObject gameObject = gameObjects[i];
+				for (GameObject gameObject : gameObjects) {
 					if (gameObject == null)
 						continue;
 					counter++;
-					lines.add(String.format("ID %d: x=%d y=%d ori=%d",
+					lines.add(String.format(
+						"ID %d: x=%d y=%d ori=%d",
 						gameObject.getId(),
 						ModelHash.getSceneX(gameObject.getHash()),
 						ModelHash.getSceneY(gameObject.getHash()),
-						gameObject.getModelOrientation()));
+						gameObject.getModelOrientation()
+					));
 				}
 				if (counter > 0)
 					lines.add(lines.size() - counter, "Game objects: ");

--- a/src/main/java/rs117/hd/scene/LightManager.java
+++ b/src/main/java/rs117/hd/scene/LightManager.java
@@ -770,7 +770,7 @@ public class LightManager
 		assert light.worldPoint != null;
 
 		Optional<LocalPoint> firstLocalPoint = sceneContext.worldInstanceToLocals(light.worldPoint).stream().findFirst();
-		if (!firstLocalPoint.isPresent())
+		if (firstLocalPoint.isEmpty())
 		{
 			return;
 		}

--- a/src/main/java/rs117/hd/scene/SceneContext.java
+++ b/src/main/java/rs117/hd/scene/SceneContext.java
@@ -8,9 +8,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import net.runelite.api.Scene;
-import net.runelite.api.coords.LocalPoint;
-import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.*;
+import net.runelite.api.coords.*;
 import rs117.hd.data.environments.Environment;
 import rs117.hd.data.materials.Material;
 import rs117.hd.scene.lights.SceneLight;
@@ -18,8 +17,7 @@ import rs117.hd.utils.HDUtils;
 import rs117.hd.utils.buffer.GpuFloatBuffer;
 import rs117.hd.utils.buffer.GpuIntBuffer;
 
-import static net.runelite.api.Perspective.LOCAL_HALF_TILE_SIZE;
-import static net.runelite.api.Perspective.LOCAL_TILE_SIZE;
+import static net.runelite.api.Perspective.*;
 import static rs117.hd.HdPlugin.UV_SIZE;
 import static rs117.hd.HdPlugin.VERTEX_SIZE;
 

--- a/src/main/java/rs117/hd/scene/TextureManager.java
+++ b/src/main/java/rs117/hd/scene/TextureManager.java
@@ -205,7 +205,7 @@ public class TextureManager
 				continue;
 			}
 
-			String textureName = material == Material.NONE ? "" + i : material.name().toLowerCase();
+			String textureName = material == Material.NONE ? String.valueOf(i) : material.name().toLowerCase();
 
 			BufferedImage image = loadTextureImage(textureName);
 			if (image == null)
@@ -396,9 +396,6 @@ public class TextureManager
 
 	/**
 	 * Check if all textures have been loaded and cached yet.
-	 *
-	 * @param textureProvider
-	 * @return
 	 */
 	private boolean allTexturesLoaded(TextureProvider textureProvider)
 	{

--- a/src/main/java/rs117/hd/scene/lights/Light.java
+++ b/src/main/java/rs117/hd/scene/lights/Light.java
@@ -4,6 +4,7 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
+import javax.annotation.Nonnull;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -25,7 +26,7 @@ public class Light
 	@Nullable
 	public Integer worldX, worldY;
 	public int plane;
-	@NonNull
+	@Nonnull
 	public Alignment alignment = Alignment.CENTER;
 	public int height;
 	public int radius;

--- a/src/main/java/rs117/hd/utils/FileWatcher.java
+++ b/src/main/java/rs117/hd/utils/FileWatcher.java
@@ -177,7 +177,7 @@ public class FileWatcher
 
 	private static void watchRecursively(Path path) {
 		try {
-			Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+			Files.walkFileTree(path, new SimpleFileVisitor<>() {
 				@Override
 				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
 					WatchKey key = dir.register(watchService, eventKinds);

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -218,8 +218,7 @@ public class HDUtils
 		s /= 8f;
 		l /= 128f;
 
-		float q = 0;
-
+		float q;
 		if (l < 0.5)
 			q = l * (1 + s);
 		else

--- a/src/main/java/rs117/hd/utils/Mat4.java
+++ b/src/main/java/rs117/hd/utils/Mat4.java
@@ -114,6 +114,7 @@ public class Mat4
 			};
 	}
 
+	@SuppressWarnings("PointlessArithmeticExpression")
 	public static void mul(final float[] a, final float[] b)
 	{
 		final float b00 = b[0 + 0 * 4];

--- a/src/main/java/rs117/hd/utils/ModelHash.java
+++ b/src/main/java/rs117/hd/utils/ModelHash.java
@@ -4,23 +4,21 @@ import net.runelite.api.Client;
 import net.runelite.api.NPC;
 
 public class ModelHash {
-    /**
-     * Model hashes are constructed as follows:
-     * | 1111 1111 1111 111 | 1  1111 1111 1111 1111 1111 1111 1111 111 |   1 |   11 |    11 1111 1 |     111 1111 |
-     * |     15 unused bits |                        32-bit id or index | ??? | type | 7-bit sceneY | 7-bit sceneX |
-     *
-     * type:
-     * - 0 = player
-     * - 1 = NPC
-     * - 2 = object
-     * - 3 = ground item
-     *
-     * id_or_index for different types:
-     * - player = index
-     * - NPC = index
-     * - object = id
-     * - ground item = ???
-     */
+    // Model hashes are constructed as follows:
+    // | 1111 1111 1111 111 | 1  1111 1111 1111 1111 1111 1111 1111 111 |   1 |   11 |    11 1111 1 |     111 1111 |
+    // |     15 unused bits |                        32-bit id or index | ??? | type | 7-bit sceneY | 7-bit sceneX |
+    //
+    // type:
+    // - 0 = player
+    // - 1 = NPC
+    // - 2 = object
+    // - 3 = ground item
+    //
+    // id_or_index for different types:
+    // - player = index
+    // - NPC = index
+    // - object = id
+    // - ground item = ???
 
     public static final int TYPE_PLAYER = 0;
     public static final int TYPE_NPC = 1;


### PR DESCRIPTION
This adds code style configuration for IntelliJ, primarily for Java, and a clang-format config file for shader source files. The IntelliJ style is based off of RuneLite's code style, but there's no line break before opening curly brackets, as per our poll on Discord. A few other minor differences to RuneLite I didn't want to bother people for with additional polls. Feel free to tear this to pieces and/or suggest changes.

<details>
    <summary>Preview of JSON changes since the diff is too large for GitHub</summary>

```json
	{
		"description": "CORRUPTED_YOUNGLLEF",
		"height": 40,
		"alignment": "CENTER",
		"radius": 100,
		"strength": 17.5,
		"color": [ 255, 0, 0 ],
		"type": "PULSE",
		"duration": 3000,
		"range": 15,
		"npcIds": [
			"CORRUPTED_YOUNGLLEF_8738",
			"CORRUPTED_YOUNGLLEF"
		]
	},
	{
		"description": "TINY_TEMPOR",
		"height": 30,
		"alignment": "CENTER",
		"radius": 200,
		"strength": 15,
		"color": [ 0, 255, 255 ],
		"type": "PULSE",
		"duration": 3200,
		"range": 20,
		"npcIds": [ "TINY_TEMPOR", "TINY_TEMPOR_10637" ]
	},
	{
		"description": "PYREFIEND",
		"height": 60,
		"alignment": "CENTER",
		"radius": 280,
		"strength": 7.5,
		"color": [ 252, 122, 3 ],
		"type": "FLICKER",
		"duration": 0,
		"range": 20,
		"npcIds": [
			"PYREFIEND",
			"PYREFIEND_434",
			"PYREFIEND_435",
			"PYREFIEND_3139",
			"PYREFIEND_436"
		]
	},
```

</details>