### PR TITLE
Fix DS2 water

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -663,6 +663,7 @@ public enum Environment
 		.setAmbientStrength(0.8f)
 		.setDirectionalColor("#FF8700")
 		.setDirectionalStrength(4.0f)
+		.setWaterColor(102, 234, 255)
 	),
 	DS2_SHIPS(Area.DS2_SHIPS, new Properties()
 		.setFogColor("#FFD3C7")
@@ -671,6 +672,7 @@ public enum Environment
 		.setAmbientStrength(0.8f)
 		.setDirectionalColor("#FF8700")
 		.setDirectionalStrength(4.0f)
+		.setWaterColor(102, 234, 255)
 	),
 
 	// The Gauntlet


### PR DESCRIPTION
Currently same as the custom sky color ![image](https://user-images.githubusercontent.com/73786759/180355212-30629fd0-28bd-4278-9f60-defd7803401f.png)


should be standard overworld/ocean blue