### PR TITLE
Water color stuff

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Area.java
+++ b/src/main/java/rs117/hd/data/environments/Area.java
@@ -578,6 +578,10 @@ public enum Area
 		new Rect(1751, 3833, 1791, 3815)
 	),
 	DARK_ALTAR(1660, 3904, 1747, 3864),
+	SOUL_ALTAR(
+			new Rect(1790,3833,1851,3940),
+			new Rect(1745,3910, 1790, 3970)// Includes all visible soul river
+	),
 	ARCEUUS(
 		new Rect(1572, 3838, 1597, 3799),
 		new Rect(1566, 3832, 1586, 3805),

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -622,7 +622,7 @@ public enum Environment
 		.setDirectionalStrength(1.0f)
 	),
 	BLOOD_ALTAR(Area.BLOOD_ALTAR, new Properties()
-		.setFogColor(0, 0, 0)
+		.setFogColor(6, 7, 25)
 		.setFogDepth(30)
 		.setAmbientColor(255, 150, 150)
 		.setAmbientStrength(1.5f)

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -624,7 +624,6 @@ public enum Environment
 		.setAmbientStrength(1.0f)
 		.setDirectionalColor(125, 141, 179)
 		.setDirectionalStrength(4.0f)
-		.setWaterColor(185, 214, 255)
 	),
 
 	// Zanaris
@@ -663,7 +662,6 @@ public enum Environment
 		.setAmbientStrength(0.8f)
 		.setDirectionalColor("#FF8700")
 		.setDirectionalStrength(4.0f)
-		.setWaterColor(102, 234, 255)
 	),
 	DS2_SHIPS(Area.DS2_SHIPS, new Properties()
 		.setFogColor("#FFD3C7")
@@ -672,7 +670,6 @@ public enum Environment
 		.setAmbientStrength(0.8f)
 		.setDirectionalColor("#FF8700")
 		.setDirectionalStrength(4.0f)
-		.setWaterColor(102, 234, 255)
 	),
 
 	// The Gauntlet

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -954,6 +954,7 @@ public enum Environment
 
 	// overrides 'ALL' to provide default daylight conditions for the overworld area
 	OVERWORLD(Area.OVERWORLD, new Properties()),
+
 	// used for underground, instances, etc.
 	ALL(Area.ALL, new Properties()
 		.setFogColor("#241809")
@@ -963,7 +964,7 @@ public enum Environment
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
-		.setWaterColor(102, 234, 255)
+		.setWaterColor(102, 234, 255) // Teal-blue like vanilla, matches many water models in caves which 117hd does not recolor
 	),
 
 	;
@@ -994,7 +995,6 @@ public enum Environment
 	private final float[] underwaterCausticsColor;
 	private final float underwaterCausticsStrength;
 	private final float[] waterColor;
-	private final boolean customWaterColor;
 
 	private static class Properties
 	{
@@ -1022,8 +1022,7 @@ public enum Environment
 		private boolean underwater = false;
 		private float[] underwaterCausticsColor = null;
 		private float underwaterCausticsStrength = 0;
-		private float[] waterColor = rgb(185, 214, 255);
-		private boolean customWaterColor = false;
+		private float[] waterColor = rgb(185, 214, 255); // Regular overworld water, failsafe
 
 		public Properties setFogDepth(int depth)
 		{
@@ -1064,7 +1063,6 @@ public enum Environment
 		public Properties setWaterColor(int r, int g, int b)
 		{
 			this.waterColor = rgb(r, g, b);
-			this.customWaterColor = true;
 			return this;
 		}
 
@@ -1205,7 +1203,6 @@ public enum Environment
 		this.underwaterCausticsStrength = properties.underwaterCausticsStrength == 0 ?
 			properties.directionalStrength : properties.underwaterCausticsStrength;
 		this.waterColor = properties.waterColor;
-		this.customWaterColor = properties.customWaterColor;
 	}
 
 	public static float[] rgb(int r, int g, int b)

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -49,6 +49,7 @@ public enum Environment
 		.setDirectionalColor("#AECFC9")
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	RFD_QUIZ(Area.RFD_QUIZ, new Properties()
 		.setFogColor("#000000")
@@ -100,6 +101,7 @@ public enum Environment
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(0.5f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	// A Soul's Bane
 	TOLNA_DUNGEON_ANGER(Area.TOLNA_DUNGEON_ANGER, new Properties()
@@ -110,6 +112,7 @@ public enum Environment
 		.setDirectionalColor("#CB4848")
 		.setDirectionalStrength(1.8f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	TOLNA_DUNGEON_FEAR(Area.TOLNA_DUNGEON_FEAR, new Properties()
 		.setFogColor("#000B0F")
@@ -119,6 +122,7 @@ public enum Environment
 		.setDirectionalColor("#4C78B6")
 		.setDirectionalStrength(1.5f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	TOLNA_DUNGEON_CONFUSION(Area.TOLNA_DUNGEON_CONFUSION, new Properties()
 		.setFogColor("#2E0C23")
@@ -128,6 +132,7 @@ public enum Environment
 		.setDirectionalColor("#4E9DD0")
 		.setDirectionalStrength(1.5f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Dorgesh-Kaan
@@ -139,6 +144,7 @@ public enum Environment
 		.setDirectionalColor("#A29B71")
 		.setDirectionalStrength(1.5f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	THE_INFERNO(Area.THE_INFERNO, new Properties()
@@ -151,6 +157,7 @@ public enum Environment
 		.setDirectionalColor(255, 246, 202)
 		.setDirectionalStrength(0.7f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	TZHAAR(Area.TZHAAR, new Properties()
 		.setFogColor("#1A0808")
@@ -160,6 +167,7 @@ public enum Environment
 		.setDirectionalColor("#FFA400")
 		.setDirectionalStrength(1.8f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 
@@ -173,6 +181,7 @@ public enum Environment
 		.setDirectionalStrength(1.0f)
 		.setDirectionalColor("#A0BBE2")
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	HALLOWED_SEPULCHRE_FLOOR_1(Area.HALLOWED_SEPULCHRE_FLOOR_1, new Properties()
 		.setFogColor(17, 28, 26)
@@ -182,6 +191,7 @@ public enum Environment
 		.setDirectionalStrength(1.8f)
 		.setDirectionalColor(117, 231, 255)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	HALLOWED_SEPULCHRE_FLOOR_2(Area.HALLOWED_SEPULCHRE_FLOOR_2, new Properties()
 		.setFogColor(17, 28, 27)
@@ -191,6 +201,7 @@ public enum Environment
 		.setDirectionalStrength(1.5f)
 		.setDirectionalColor(116, 214, 247)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	HALLOWED_SEPULCHRE_FLOOR_3(Area.HALLOWED_SEPULCHRE_FLOOR_3, new Properties()
 		.setFogColor(18, 28, 29)
@@ -200,6 +211,7 @@ public enum Environment
 		.setDirectionalStrength(1.5f)
 		.setDirectionalColor(115, 196, 240)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	HALLOWED_SEPULCHRE_FLOOR_4(Area.HALLOWED_SEPULCHRE_FLOOR_4, new Properties()
 		.setFogColor(18, 27, 31)
@@ -209,6 +221,7 @@ public enum Environment
 		.setDirectionalStrength(1.5f)
 		.setDirectionalColor(114, 178, 233)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	HALLOWED_SEPULCHRE_FLOOR_5(Area.HALLOWED_SEPULCHRE_FLOOR_5, new Properties()
 		.setFogColor(19, 27, 33)
@@ -218,6 +231,7 @@ public enum Environment
 		.setDirectionalStrength(1.5f)
 		.setDirectionalColor(113, 160, 226)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	VER_SINHAZA(Area.VER_SINHAZA, new Properties()
 		.setFogColor("#1E314B")
@@ -236,6 +250,7 @@ public enum Environment
 		.setDirectionalStrength(1.0f)
 		.setDirectionalColor("#DDA6A6")
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	THEATRE_OF_BLOOD(Area.THEATRE_OF_BLOOD, new Properties()
 		.setFogColor("#0E0C2C")
@@ -253,6 +268,7 @@ public enum Environment
 		.setDirectionalColor(255, 200, 117)
 		.setDirectionalStrength(0.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	BARROWS_TUNNELS(Area.BARROWS_TUNNELS, new Properties()
 		.setFogColor(0, 0, 0)
@@ -262,6 +278,7 @@ public enum Environment
 		.setDirectionalColor(255, 200, 117)
 		.setDirectionalStrength(0.5f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	BARROWS(Area.BARROWS, new Properties()
 		.setFogColor("#242D3A")
@@ -311,6 +328,7 @@ public enum Environment
 		.setDirectionalColor(76, 120, 182)
 		.setDirectionalStrength(0.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	DRAYNOR(Area.DRAYNOR, new Properties()),
 
@@ -332,6 +350,7 @@ public enum Environment
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	GAMES_ROOM(Area.GAMES_ROOM, new Properties()
@@ -342,6 +361,7 @@ public enum Environment
 		.setDirectionalColor(162, 151, 148)
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	SOUL_WARS_RED_TEAM(Area.SOUL_WARS_RED_BASE, new Properties()
@@ -360,6 +380,7 @@ public enum Environment
 		.setDirectionalColor(86, 86, 86)
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	KHARIDIAN_DESERT_DEEP(Area.KHARIDIAN_DESERT_DEEP, new Properties()
 		.setFogColor("#CDAF7A")
@@ -401,6 +422,7 @@ public enum Environment
 		.setDirectionalColor(138, 158, 182)
 		.setDirectionalStrength(0.75f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	GIELINOR_SNOWY_NORTHERN_REGION(Area.GIELINOR_SNOWY_NORTHERN_REGION, new Properties()
@@ -449,6 +471,7 @@ public enum Environment
 		.setDirectionalColor(76, 120, 182)
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	KARAMJA(Area.KARAMJA, new Properties()),
 
@@ -471,6 +494,7 @@ public enum Environment
 		.setDirectionalStrength(1.8f)
 		.setLightDirection(260f, 10f)
 		.setWaterColor(56, 188, 255)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	TAR_SWAMP(Area.TAR_SWAMP, new Properties()
@@ -534,6 +558,7 @@ public enum Environment
 		.setDirectionalColor("#97DDFF")
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Tree Gnome Stronghold
@@ -548,6 +573,7 @@ public enum Environment
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Last Man Standing
@@ -575,6 +601,7 @@ public enum Environment
 		.setDirectionalColor("#9AEAFF")
 		.setDirectionalStrength(0.75f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	KOUREND_CATACOMBS(Area.KOUREND_CATACOMBS, new Properties()
 		.setFogColor("#0E0022")
@@ -583,6 +610,7 @@ public enum Environment
 		.setAmbientStrength(3.5f)
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(1.0f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	MOUNT_QUIDAMORTEM(Area.MOUNT_QUIDAMORTEM, new Properties()),
 	KEBOS_LOWLANDS(Area.KEBOS_LOWLANDS, new Properties()
@@ -635,6 +663,7 @@ public enum Environment
 		.setDirectionalColor("#57FF00")
 		.setLightDirection(260f, 10f)
 		.setAllowSkyOverride(false)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	ZANARIS(Area.ZANARIS, new Properties()
 		.setFogColor(22, 63, 71)
@@ -644,6 +673,7 @@ public enum Environment
 		.setDirectionalColor(245, 214, 122)
 		.setDirectionalStrength(1.3f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Dragon Slayer II
@@ -681,6 +711,7 @@ public enum Environment
 		.setDirectionalColor("#78FFE3")
 		.setDirectionalStrength(3.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	THE_GAUNTLET_CORRUPTED(Area.THE_GAUNTLET_CORRUPTED, new Properties()
 		.setFogColor("#090606")
@@ -690,6 +721,7 @@ public enum Environment
 		.setDirectionalColor("#FF7878")
 		.setDirectionalStrength(3.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	THE_GAUNTLET_LOBBY(Area.THE_GAUNTLET_LOBBY, new Properties()
 		.setFogColor("#090606")
@@ -699,6 +731,7 @@ public enum Environment
 		.setDirectionalColor("#78FFE3")
 		.setDirectionalStrength(3.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Islands
@@ -728,6 +761,7 @@ public enum Environment
 		.setDirectionalStrength(0.0f)
 		.setLightDirection(260f, 10f)
 		.setAllowSkyOverride(false)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Fishing Trawler
@@ -742,6 +776,7 @@ public enum Environment
 		.setDirectionalStrength(0.0f)
 		.setDirectionalColor("#6DC5FF")
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Tempoross
@@ -778,6 +813,7 @@ public enum Environment
 		.setDirectionalStrength(0.0f)
 		.setLightDirection(260f, 10f)
 		.setAllowSkyOverride(false)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Chambers of Xeric
@@ -789,6 +825,7 @@ public enum Environment
 		.setDirectionalStrength(1.0f)
 		.setDirectionalColor("#ACFF68")
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Nightmare of Ashihama
@@ -801,6 +838,7 @@ public enum Environment
 		.setDirectionalColor("#00FF60")
 		.setLightDirection(260f, 10f)
 		.setAllowSkyOverride(false)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Underwater areas
@@ -850,6 +888,7 @@ public enum Environment
 		.setDirectionalStrength(0.7f)
 		.setLightDirection(260f, 10f)
 		.setAllowSkyOverride(false)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Runecrafting altars
@@ -865,6 +904,7 @@ public enum Environment
 		.setDirectionalStrength(3.0f)
 		.setLightDirection(260f, 10f)
 		.setAllowSkyOverride(false)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 	TRUE_BLOOD_ALTAR(Area.TRUE_BLOOD_ALTAR, new Properties()
 			.setFogColor("#000000")
@@ -879,6 +919,7 @@ public enum Environment
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
+		.setUnderwaterCausticsStrength(1.0f)
 	),
 
 	// Random events
@@ -914,9 +955,11 @@ public enum Environment
 			.setWaterColor(102, 234, 255)
 			.setAmbientStrength(1.75f)
 			.setDirectionalStrength(1.0f)
+			.setUnderwaterCausticsStrength(1.0f)
 	),
 	ANCIENT_CAVERN_UPPER(Area.ANCIENT_CAVERN_UPPER, new Properties()
 			.setWaterColor(79, 178, 255)
+			.setUnderwaterCausticsStrength(1.0f)
 	),
 
 
@@ -963,6 +1006,7 @@ public enum Environment
 		.setDirectionalStrength(1.0f)
 		.setLightDirection(260f, 10f)
 		.setWaterColor(102, 234, 255) // Teal-blue like vanilla, matches many water models in caves which 117hd does not recolor
+		.setUnderwaterCausticsStrength(1.0f) // Very weak
 	),
 
 	;

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -939,7 +939,7 @@ public enum Environment
 		.setAmbientStrength(3.5f)
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(1.5f)
-		.setWaterColor(184,197,219) // ice
+		.setWaterColor(184,197,219) // Ice
 	),
 
 	MAGE_ARENA_BANK(Area.MAGE_ARENA_BANK, new Properties()

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -622,12 +622,13 @@ public enum Environment
 		.setDirectionalStrength(1.0f)
 	),
 	BLOOD_ALTAR(Area.BLOOD_ALTAR, new Properties()
-		.setFogColor(79, 19, 37)
+		.setFogColor(0, 0, 0)
 		.setFogDepth(30)
-		.setAmbientColor(190, 72, 174)
-		.setAmbientStrength(1.0f)
-		.setDirectionalColor(78, 238, 255)
-		.setDirectionalStrength(2.5f)
+		.setAmbientColor(255, 150, 150)
+		.setAmbientStrength(1.5f)
+		.setDirectionalColor(255, 251, 212)
+		.setDirectionalStrength(1.0f)
+		.setWaterColor(64,64,64) // Compromise for red blood water and ocean water in the background to look good, carried by their shader values
 	),
 	ZEAH_SNOWY_NORTHERN_REGION(Area.ZEAH_SNOWY_NORTHERN_REGION, new Properties()
 		.setFogColor("#AEBDE0")
@@ -637,6 +638,15 @@ public enum Environment
 		.setDirectionalColor("#F4E5C9")
 		.setDirectionalStrength(2.5f)
 	),
+	SOUL_ALTAR(Area.SOUL_ALTAR, new Properties()
+			.setFogColor(153, 157, 204)
+			.setFogDepth(20)
+			.setAmbientColor(191, 196, 255)
+			.setAmbientStrength(0.8f)
+			.setDirectionalColor(191, 196, 255)
+			.setDirectionalStrength(2.5f)
+			.setWaterColor(100,100,100) //Compromise to make river of souls, nearby ocean and blood water all look okay; carried by shader values
+	),
 	ARCEUUS(Area.ARCEUUS, new Properties()
 		.setFogColor(19, 24, 79)
 		.setFogDepth(30)
@@ -644,6 +654,7 @@ public enum Environment
 		.setAmbientStrength(1.0f)
 		.setDirectionalColor(78, 238, 255)
 		.setDirectionalStrength(3.5f)
+		.setWaterColor(100,100,100) //Compromise to make river of souls, nearby ocean and blood water all look okay; carried by shader values
 	),
 	LOVAKENGJ(Area.LOVAKENGJ, new Properties()
 		.setFogColor(21, 10, 5)
@@ -909,6 +920,7 @@ public enum Environment
 	TRUE_BLOOD_ALTAR(Area.TRUE_BLOOD_ALTAR, new Properties()
 			.setFogColor("#000000")
 			.setFogDepth(25)
+			.setWaterColor(20,0,0) /// Dark blood red
 	),
 
 	TARNS_LAIR(Area.TARNS_LAIR, new Properties()

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -939,6 +939,7 @@ public enum Environment
 		.setAmbientStrength(3.5f)
 		.setDirectionalColor("#FFFFFF")
 		.setDirectionalStrength(1.5f)
+		.setWaterColor(184,197,219) // ice
 	),
 
 	MAGE_ARENA_BANK(Area.MAGE_ARENA_BANK, new Properties()

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -187,6 +187,7 @@ public enum Overlay
 	XERICS_LOOKOUT_TILE_2(2, Area.XERICS_LOOKOUT, GroundMaterial.TILES_2x2_2, new Properties().setBlended(false)),
 	HOSIDIUS_STONE_FLOOR(123, Area.HOSIDIUS, GroundMaterial.FALADOR_PATHS),
 	BLOOD_ALTAR_BLOOD(72, Area.BLOOD_ALTAR, WaterType.BLOOD),
+	SOUL_ALTAR_RIVER(-128, Area.SOUL_ALTAR, WaterType.ICE_FLAT),
 	SHAYZIEN_PAVED_AREA_1(2, Area.SHAYZIEN, GroundMaterial.GRAVEL, new Properties().setBlended(false)),
 	SHAYZIEN_PAVED_AREA_2(-117, Area.SHAYZIEN, GroundMaterial.GRAVEL, new Properties().setBlended(false)),
 	SHAYZIEN_COMBAT_RING_FLOOR_1(30, Area.SHAYZIEN_COMBAT_RING, GroundMaterial.CARPET, new Properties().setBlended(false)),

--- a/src/main/java/rs117/hd/scene/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/scene/EnvironmentManager.java
@@ -391,7 +391,8 @@ public class EnvironmentManager
 
 	public void updateWaterColor()
 	{
-		targetWaterColor = currentEnvironment.getWaterColor();
+		Environment env = hdPlugin.configWinterTheme ? Environment.WINTER : currentEnvironment; // grab the water color from Winter theme if it's enabled, else use the one from current environment
+		targetWaterColor = env.getWaterColor();
 	}
 
 	/**

--- a/src/main/java/rs117/hd/scene/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/scene/EnvironmentManager.java
@@ -277,6 +277,7 @@ public class EnvironmentManager
 		startUnderwaterCausticsStrength = currentUnderwaterCausticsStrength;
 
 		updateSkyColor();
+		updateWaterColor();
 
 		targetFogDepth = newEnvironment.getFogDepth();
 		if (hdPlugin.configWinterTheme)
@@ -381,19 +382,16 @@ public class EnvironmentManager
 			{
 				sky = DefaultSkyColor.DEFAULT;
 			}
-			targetWaterColor = sky.getRgb(client);
 		}
 		else
 		{
-			targetFogColor = targetWaterColor = env.getFogColor();
+			targetFogColor = env.getFogColor();
 		}
+	}
 
-
-		//override with decoupled water/sky color if present
-		if(currentEnvironment.isCustomWaterColor())
-		{
-			targetWaterColor = currentEnvironment.getWaterColor();
-		}
+	public void updateWaterColor()
+	{
+		targetWaterColor = currentEnvironment.getWaterColor();
 	}
 
 	/**


### PR DESCRIPTION
This patch changes the water stuff in environment manager to always use the environment's water color (defaulted to 185, 214, 255 - i.e. regular overworld water) rather than only using one when a custom color is set.

It's more failsafe than the prior approach which had a lot of weird edge cases where the water color was bad in particular zones or quests, e.g.

![image](https://user-images.githubusercontent.com/73786759/181178113-2e2821cc-c1f7-44e2-b16b-9f6463608446.png)

Since we're not setting the baseline water color based on the sky color any more (and don't plan to in future), i put it in its own update function which isn't called as often. Since the behavior is now the same with or without a custom color i removed the custom color bool as well. Also removed the water color settings for some environments as they are no longer needed now that they fallback to the default.

For now this removes the influence of sky color on water but for the future we have explored several ways of blending sky & water colors with fake or real reflections/effects that are much more accurate and less weird looking for edge cases. At the moment i think this is the best thing to do.