### PR TITLE
Add 1.1.2 update notes

### DIFF
--- a/117HD v1.1.2.md
+++ b/117HD v1.1.2.md
@@ -42,7 +42,7 @@
 * Added environment for the Spirits of the Elid cave and fixed to have correctly colored water instead of blue dirt
 
 # Lights
-New lights:
+**New lights:**
 * Giants' Foundry lava and entrance
 
 * Fossil Island volcano and lava vents

--- a/117HD v1.1.2.md
+++ b/117HD v1.1.2.md
@@ -76,9 +76,9 @@ If you have any bugs to report or want to help out with feedback/development the
 # Other
 * Updated support link
   
-* Add settings guide
-* Enable atmospheric lighting by default
-* Add 117hd tile info overlay for development assistance
+* Added settings guide
+* Enabled atmospheric lighting by default
+* Added 117hd tile info overlay for development assistance
 
 # Contributors
 - [Aeryn](https://github.com/xxEzri)

--- a/117HD v1.1.2.md
+++ b/117HD v1.1.2.md
@@ -46,6 +46,7 @@ New lights:
 * Giants' Foundry lava and entrance
 
 * Fossil Island volcano and lava vents
+* Karuulm - Liquid sulphur, sulphur vents, furnace
 * Barbarian Village cooking fire
 * Lovakite Furnace
 * Evil Chicken shrine

--- a/117HD v1.1.2.md
+++ b/117HD v1.1.2.md
@@ -1,0 +1,71 @@
+﻿# 117HD v1.1.2 Update Notes
+
+# Contents
+1.  [Engine](#engine)
+2.  [General Fixes/Improvements](#general)
+3.  [Environments](#environments)
+4.  [Lights](#lights)
+5.  [Ground](#ground)
+6.  [Other](#other)
+
+# Engine
+* Lots of code cleanup
+
+* Updated OpenGL backend to use RLAWT/LWJGL instead of JOGL. This can give large performance uplifts for Mac users and allows the plugin to run on some older GPU's, usually with support below OpenGL 4.6 but >=4.0.
+* Fixed kernel loading for mac
+* Updated Gradle version
+
+# General Fixes/Improvements
+* Fixed winter theme toggle bug and moved to misc settings
+
+* Fixed incorrect water tiles in GOTR with low detail mode turned on
+* Fixed desert treasure pyramid tile texture to be sand bricks again instead of snow
+* Fixed true blood altar to be surrounded by liquid blood instead of red dirt
+* Improved instant environment transition logic so that it activates more appropriately
+* Made switching between different plugins based on Runelite's GPU plugin much more reliable (GPU, 117HD, Region-locked GPU etc)
+* Fixed Gu'tanoth cave to have swamp water instead of green dirt
+* Fixed bug in sky color update function which could cause the sky to be the wrong color
+* Fixed hard crash when loading certain rare light sources, improved handling of certain lights/npcs/objects
+* Updated interaction with Entity Hider to correctly show your own pet and its lighting, consistent with the base game and GPU plugin
+* Added Ancient Wyverns, Kovac, Youngllef and the Magic Carpets to the list of baked shadows/lights which can be hidden
+* Updated water color controls to allow for greater dev configuration
+
+# Environments
+* Changed water in cave environments to be teal-blue instead of brown (Keldagrim, MLM etcetc)
+
+* Changed Lovakengj water to be light blue instead of grey
+* Changed DS2 ship scene water to be light blue instead of pink
+* Updated GWD environment and water to look more correct
+* Updated Ancient Cavern upper floor water to look more correct
+* Added environment for Giants' Foundry
+* Added environment for the Mage Arena bank
+* Added environment for the Spirits of the Elid cave and fixed to have correctly colored water instead of blue dirt
+
+# Lights
+New lights:
+* Giants' Foundry lava and entrance
+
+* Fossil Island volcano and lava vents
+* Barbarian Village cooking fire
+* Lovakite Furnace
+* Evil Chicken shrine
+* Falador/misc cooking range (WIP)
+* Small crystals, big crystals, glowing carving under Mt. Quidamortem (seen in A Kingdom Divided, maybe more)
+* Red fires during Beneath Cursed Sands final boss fight
+* Sacrificial Pyres in Ape Atoll temple
+* MM2 crash cite cave skylight
+* Lithkren lava
+
+# Ground
+* Improved tile blending in front of GOTR's blue portal
+  
+* Improved tile blending at East ardy castle path and dirt (WIP)
+* Improved tile blending at Falador east bank path
+* Improved tile blending on the Entrana glass furnace building floor
+
+# Other
+* Updated support link
+  
+* Add settings guide
+* Enable atmospheric lighting by default
+* Add 117hd tile info overlay for development assistance

--- a/117HD v1.1.2.md
+++ b/117HD v1.1.2.md
@@ -1,4 +1,6 @@
 ﻿# 117HD v1.1.2 Update Notes
+ 
+ ![Giants' Foundry](https://user-images.githubusercontent.com/73786759/181764405-c4ab648b-697a-4c24-a86d-661623680116.png)
 
 # Contents
 1.  [Engine](#engine)

--- a/117HD v1.1.2.md
+++ b/117HD v1.1.2.md
@@ -1,14 +1,21 @@
 ﻿# 117HD v1.1.2 Update Notes
- 
- ![Giants' Foundry](https://user-images.githubusercontent.com/73786759/181764405-c4ab648b-697a-4c24-a86d-661623680116.png)
+
+![Giants' Foundry](https://user-images.githubusercontent.com/73786759/181764405-c4ab648b-697a-4c24-a86d-661623680116.png)
 
 # Contents
-1.  [Engine](#engine)
-2.  [General Fixes/Improvements](#general)
-3.  [Environments](#environments)
-4.  [Lights](#lights)
-5.  [Ground](#ground)
-6.  [Other](#other)
+1.  [Intro](#intro)
+2.  [Engine](#engine)
+3.  [General Improvements](#general-improvements)
+4.  [Environments](#environments)
+5.  [Lights](#lights)
+6.  [Ground](#ground)
+7.  [Other](#other)
+8.  [Contributors](#contributors)
+
+# Intro
+Greetings from the 117hd team! Today's update is focused on bug fixing, polish and technology updates.
+
+If you have any bugs to report or want to help out with feedback/development then please drop by the discord server at https://discord.gg/U4p6ChjgSE!
 
 # Engine
 * Lots of code cleanup
@@ -17,7 +24,7 @@
 * Fixed kernel loading for mac
 * Updated Gradle version
 
-# General Fixes/Improvements
+# General Improvements
 * Fixed winter theme toggle bug and moved to misc settings
 
 * Fixed incorrect water tiles in GOTR with low detail mode turned on
@@ -69,6 +76,16 @@
 # Other
 * Updated support link
   
-* Added settings guide
-* Enabled atmospheric lighting by default
-* Added 117hd tile info overlay for development assistance
+* Add settings guide
+* Enable atmospheric lighting by default
+* Add 117hd tile info overlay for development assistance
+
+# Contributors
+- [Aeryn](https://github.com/xxEzri)
+- [aHooder](https://github.com/aHooder)
+- [Ben Puryear](https://github.com/Ben10164)
+- [Mark7625](https://github.com/Mark7625)
+- [SirFancyBacon](https://github.com/SirFancyBacon)
+- [sosodev](https://github.com/sosodev)
+- [testing-ongithub](https://github.com/testing-ongithub)
+- All those who posted bugs, feedback and opinions on the Discord server! (https://discord.gg/U4p6ChjgSE)

--- a/117HD v1.1.2.md
+++ b/117HD v1.1.2.md
@@ -69,6 +69,6 @@
 # Other
 * Updated support link
   
-* Add settings guide
-* Enable atmospheric lighting by default
-* Add 117hd tile info overlay for development assistance
+* Added settings guide
+* Enabled atmospheric lighting by default
+* Added 117hd tile info overlay for development assistance


### PR DESCRIPTION
Dropping this here so we can collab

I'm thinking we should probably have a folder that has one of these for each update to document development

Direct link so that markdown formatting works properly: https://github.com/xxEzri/RLHD/blob/1.1.2-patch-notes/117HD%20v1.1.2.md