### PR TITLE
Use sRGB EOTF instead of gamma 2.2

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1746,7 +1746,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			float[] fogColor = hasLoggedIn ? environmentManager.getFogColor() : EnvironmentManager.BLACK_COLOR;
 			for (int i = 0; i < fogColor.length; i++)
 			{
-				fogColor[i] = HDUtils.linearToGamma(fogColor[i]);
+				fogColor[i] = HDUtils.linearToSrgb(fogColor[i]);
 			}
 			glClearColor(fogColor[0], fogColor[1], fogColor[2], 1f);
 			glClear(GL_COLOR_BUFFER_BIT);
@@ -1781,15 +1781,15 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			float[] waterColorDark = new Color(Color.HSBtoRGB(waterColorHSB[0], waterColorHSB[1], waterColorHSB[2] * darkBrightnessMultiplier)).getRGBColorComponents(null);
 			for (int i = 0; i < waterColorLight.length; i++)
 			{
-				waterColorLight[i] = HDUtils.linearToGamma(waterColorLight[i]);
+				waterColorLight[i] = HDUtils.linearToSrgb(waterColorLight[i]);
 			}
 			for (int i = 0; i < waterColorMid.length; i++)
 			{
-				waterColorMid[i] = HDUtils.linearToGamma(waterColorMid[i]);
+				waterColorMid[i] = HDUtils.linearToSrgb(waterColorMid[i]);
 			}
 			for (int i = 0; i < waterColorDark.length; i++)
 			{
-				waterColorDark[i] = HDUtils.linearToGamma(waterColorDark[i]);
+				waterColorDark[i] = HDUtils.linearToSrgb(waterColorDark[i]);
 			}
 			glUniform3f(uniWaterColorLight, waterColorLight[0], waterColorLight[1], waterColorLight[2]);
 			glUniform3f(uniWaterColorMid, waterColorMid[0], waterColorMid[1], waterColorMid[2]);

--- a/src/main/java/rs117/hd/config/DefaultSkyColor.java
+++ b/src/main/java/rs117/hd/config/DefaultSkyColor.java
@@ -61,9 +61,9 @@ public enum DefaultSkyColor
 			b = sky & 0xFF;
 		}
 		return new float[]{
-			HDUtils.gammaToLinear(r / 255f),
-			HDUtils.gammaToLinear(g / 255f),
-			HDUtils.gammaToLinear(b / 255f)
+			HDUtils.srgbToLinear(r / 255f),
+			HDUtils.srgbToLinear(g / 255f),
+			HDUtils.srgbToLinear(b / 255f)
 		};
 	}
 }

--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -1211,9 +1211,9 @@ public enum Environment
 	public static float[] rgb(int r, int g, int b)
 	{
 		return new float[]{
-			HDUtils.gammaToLinear(r / 255f),
-			HDUtils.gammaToLinear(g / 255f),
-			HDUtils.gammaToLinear(b / 255f)
+			HDUtils.srgbToLinear(r / 255f),
+			HDUtils.srgbToLinear(g / 255f),
+			HDUtils.srgbToLinear(b / 255f)
 		};
 	}
 }

--- a/src/main/java/rs117/hd/scene/lighting/LightConfig.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightConfig.java
@@ -73,7 +73,7 @@ public class LightConfig
 				float[] linearRGBA = { 0, 0, 0, 1 };
 				for (int i = 0; i < Math.min(l.color.length, linearRGBA.length); i++)
 				{
-					linearRGBA[i] = HDUtils.gammaToLinear(l.color[i] /= 255f);
+					linearRGBA[i] = HDUtils.srgbToLinear(l.color[i] /= 255f);
 				}
 				l.color = linearRGBA;
 

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -245,14 +245,18 @@ public class HDUtils
 		return p;
 	}
 
-	public static float linearToGamma(float c)
+	// Conversion functions to and from sRGB and linear color space.
+	// The implementation is based on the sRGB EOTF given in the Khronos Data Format Specification.
+	// Source: https://web.archive.org/web/20220808015852/https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.pdf
+	// Page number 130 (146 in the PDF)
+	public static float linearToSrgb(float c)
 	{
 		return c <= 0.0031308 ?
 			c * 12.92f :
 			(float) (1.055 * Math.pow(c, 1 / 2.4) - 0.055);
 	}
 
-	public static float gammaToLinear(float c)
+	public static float srgbToLinear(float c)
 	{
 		return c <= 0.04045f ?
 			c / 12.92f :

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -247,14 +247,16 @@ public class HDUtils
 
 	public static float linearToGamma(float c)
 	{
-		float gamma = 2.2f;
-		return (float)Math.pow(c, 1.0f / gamma);
+		return c <= 0.0031308 ?
+			c * 12.92f :
+			(float) (1.055 * Math.pow(c, 1 / 2.4) - 0.055);
 	}
 
 	public static float gammaToLinear(float c)
 	{
-		float gamma = 2.2f;
-		return (float)Math.pow(c, gamma);
+		return c <= 0.04045f ?
+			c / 12.92f :
+			(float) Math.pow((c + 0.055) / 1.055, 2.4);
 	}
 
 	public static float dotNormal3Lights(float[] normals)

--- a/src/main/resources/rs117/hd/color_utils.glsl
+++ b/src/main/resources/rs117/hd/color_utils.glsl
@@ -112,14 +112,16 @@ vec3 hsvToRgb(vec3 c)
     return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
 }
 
-vec3 linearToGamma(vec3 c)
-{
-    float gamma = 2.2;
-    return pow(c, vec3(1.0 / gamma));
+vec3 gammaToLinear(vec3 srgb) {
+  return mix(
+    srgb / 12.92,
+    pow((srgb + vec3(0.055)) / vec3(1.055), vec3(2.4)),
+    step(vec3(0.04045), srgb));
 }
 
-vec3 gammaToLinear(vec3 c)
-{
-    float gamma = 2.2;
-    return pow(c, vec3(gamma));
+vec3 linearToGamma(vec3 rgb) {
+  return mix(
+    rgb * 12.92,
+    1.055 * pow(rgb, vec3(1 / 2.4)) - 0.055,
+    step(vec3(0.0031308), rgb));
 }

--- a/src/main/resources/rs117/hd/color_utils.glsl
+++ b/src/main/resources/rs117/hd/color_utils.glsl
@@ -112,14 +112,18 @@ vec3 hsvToRgb(vec3 c)
     return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
 }
 
-vec3 gammaToLinear(vec3 srgb) {
+// Conversion functions to and from sRGB and linear color space.
+// The implementation is based on the sRGB EOTF given in the Khronos Data Format Specification.
+// Source: https://web.archive.org/web/20220808015852/https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.pdf
+// Page number 130 (146 in the PDF)
+vec3 srgbToLinear(vec3 srgb) {
   return mix(
     srgb / 12.92,
     pow((srgb + vec3(0.055)) / vec3(1.055), vec3(2.4)),
     step(vec3(0.04045), srgb));
 }
 
-vec3 linearToGamma(vec3 rgb) {
+vec3 linearToSrgb(vec3 rgb) {
   return mix(
     rgb * 12.92,
     1.055 * pow(rgb, vec3(1 / 2.4)) - 0.055,

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -844,7 +844,7 @@ void main() {
     {
         vec3 litColor = compositeColor * compositeLight;
         compositeColor = mix(litColor, compositeColor, emissive);
-        compositeColor = linearToGamma(compositeColor);
+        compositeColor = linearToSrgb(compositeColor);
     }
 
 

--- a/src/main/resources/rs117/hd/vert.glsl
+++ b/src/main/resources/rs117/hd/vert.glsl
@@ -76,7 +76,7 @@ void main() {
 
     vPosition = vertex;
     vNormal = normal;
-    vColor = vec4(gammaToLinear(rgb), 1.f - a);
+    vColor = vec4(srgbToLinear(rgb), 1.f - a);
     vUv = uv;
 
     if (fogDepth > 0)

--- a/src/test/java/rs117/hd/lighting/ExportLightsToJson.java
+++ b/src/test/java/rs117/hd/lighting/ExportLightsToJson.java
@@ -83,7 +83,7 @@ public class ExportLightsToJson
 			{
 				for (int i = 0; i < l.color.length; i++)
 				{
-					l.color[i] = HDUtils.linearToGamma(l.color[i]) * 255f;
+					l.color[i] = HDUtils.linearToSrgb(l.color[i]) * 255f;
 					int nearestInt = Math.round(l.color[i]);
 					if (Math.abs(nearestInt - l.color[i]) <= eps)
 					{


### PR DESCRIPTION
This replaces the linear to gamma color space conversion functions with more accurate linear to sRGB conversion functions. The sRGB EOTF is taken from the [Khronos Data Format Specification](https://registry.khronos.org/DataFormat/specs/1.3/dataformat.1.3.pdf#page=146). This change has the overall effect of giving slightly more resolution for darker colors, which in turn brightens them up a bit. We may have to tune some environment lighting slightly to better match the original intent after this change.

Here are some screenshots for comparison. Note, the difference is larger in darker areas. For lighter areas, the difference is more noticeable in shadows. If you don't really notice a difference, you may be color blind or have a very dimly lit display.
<details>
  <summary>Darkmeyer</summary>

![image](https://user-images.githubusercontent.com/831317/183320846-4c9c9a18-81c9-4aba-b889-5ac543c7e2d7.png)
![image](https://user-images.githubusercontent.com/831317/183320861-71731711-3842-4834-9b92-d58360c6b64f.png)
</details>

<details>
  <summary>Varrock</summary>

![image](https://user-images.githubusercontent.com/831317/183320898-3fede5a3-1a8f-429b-be8b-0c2002601fe1.png)
![image](https://user-images.githubusercontent.com/831317/183320910-40fd2e98-3b93-4168-a598-4ea44272d7b3.png)
</details>

<details>
  <summary>Prifddinas</summary>

![image](https://user-images.githubusercontent.com/831317/183320918-f9f38625-e994-4bb8-96cc-d732792a87fa.png)
![image](https://user-images.githubusercontent.com/831317/183320926-768b557e-2990-4c18-89a0-97225dc146ed.png)
</details>

<details>
  <summary>Karuulm</summary>

![image](https://user-images.githubusercontent.com/831317/183320940-78fdca70-15aa-4e2c-b759-2c772877cdb1.png)
![image](https://user-images.githubusercontent.com/831317/183320944-4a35d8ae-e074-438d-adf5-fbef879dca0f.png)
</details>

<details>
  <summary>Blood Altar</summary>

![image](https://user-images.githubusercontent.com/831317/183320951-26437694-3c79-462a-b10f-b2454d43dee7.png)
![image](https://user-images.githubusercontent.com/831317/183320959-09418041-252d-4fa2-83d1-49205e2e584a.png)
</details>