### PR TITLE
Improve FileWatcher

### DIFF
--- a/src/main/java/rs117/hd/scene/lighting/LightManager.java
+++ b/src/main/java/rs117/hd/scene/lighting/LightManager.java
@@ -130,9 +130,7 @@ public class LightManager
 
 			try
 			{
-				fileWatcher = new FileWatcher()
-					.watchFile(lightsConfigPath)
-					.addChangeHandler(path -> hotswapScheduled = true);
+				fileWatcher = new FileWatcher(lightsConfigPath, path -> hotswapScheduled = true);
 			}
 			catch (IOException ex)
 			{

--- a/src/main/java/rs117/hd/utils/DeveloperTools.java
+++ b/src/main/java/rs117/hd/utils/DeveloperTools.java
@@ -56,16 +56,12 @@ public class DeveloperTools implements KeyListener
 		{
 			try
 			{
-				shaderSourceWatcher = new FileWatcher()
-					.watchPath(shaderPath)
-					.addChangeHandler(path ->
-					{
-						if (path.getFileName().toString().endsWith(".glsl"))
-						{
-							log.info("Reloading shaders...");
-							plugin.recompilePrograms();
-						}
-					});
+				shaderSourceWatcher = new FileWatcher(shaderPath, path -> {
+					if (path.getFileName().toString().endsWith(".glsl")) {
+						log.info("Reloading shaders...");
+						plugin.recompilePrograms();
+					}
+				});
 			}
 			catch (IOException ex)
 			{


### PR DESCRIPTION
This adds support for recursive file watching, so that shaders in sub folders get hotswapped as well.

If anyone could confirm this works properly on Windows, that would be great! (Try modifying a shader in a sub folder and see if anything changes)