### PR TITLE
Gradle Latest Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.+'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion


### PR DESCRIPTION
Changed Gradle to use 'latest.release' as the old way using '+' was breaking the plugin hub