### PR TITLE
Fixed inhereting color for rubble and above cave walls

### DIFF
--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -387,12 +387,11 @@ public class ModelPusher
             color1L = color2L = color3L = 127;
         }
 
-        if (objectProperties != null && objectProperties.getInheritTileColorType() != InheritTileColorType.NONE) {
-
+        if (tile != null && objectProperties != null && objectProperties.getInheritTileColorType() != InheritTileColorType.NONE) {
             SceneTileModel tileModel = tile.getSceneTileModel();
             SceneTilePaint tilePaint = tile.getSceneTilePaint();
 
-            if (tile != null && (tilePaint != null || tileModel != null)) {
+            if (tilePaint != null || tileModel != null) {
                 int[] tileColorHSL;
 
                 // No point in inheriting tilepaint color if the ground tile does not have a color, for example above a cave wall

--- a/src/main/java/rs117/hd/model/objects/InheritTileColorType.java
+++ b/src/main/java/rs117/hd/model/objects/InheritTileColorType.java
@@ -1,27 +1,3 @@
-/*
- * Copyright (c) 2021, 117 <https://twitter.com/117scape>
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this
- *    list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package rs117.hd.model.objects;
 
 public enum InheritTileColorType

--- a/src/main/java/rs117/hd/model/objects/InheritTileColorType.java
+++ b/src/main/java/rs117/hd/model/objects/InheritTileColorType.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, 117 <https://twitter.com/117scape>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package rs117.hd.model.objects;
+
+public enum InheritTileColorType
+{
+	NONE, OVERLAY, UNDERLAY
+}

--- a/src/main/java/rs117/hd/model/objects/ObjectProperties.java
+++ b/src/main/java/rs117/hd/model/objects/ObjectProperties.java
@@ -43,9 +43,9 @@ public enum ObjectProperties
 	FARMING_PATCH_1(Material.DIRT_1, new Properties().setUvType(UvType.GROUND_PLANE), 7517),
 	FARMING_PATCH_2(Material.GRUNGE_1, new Properties().setUvType(UvType.GROUND_PLANE), 7522),
 
-	GRASS(Material.NONE, new Properties().setFlatNormals(true).setInheritTileColor(true), 1257, 1258, 3547, 3548, 3549, 4333, 4334, 4335, 4336, 4530, 4735, 4736, 4737, 4738, 4739, 4740, 4741, 4742, 4809, 4810, 4811, 4812, 4813, 4814, 5335, 5336, 5337, 5338, 5339, 5340, 5341, 5342, 5533, 5534, 5535, 5536, 6817, 6818, 6819, 6835, 6836, 6837, 6838, 7049, 7050, 9485, 9486, 9487, 9488, 9489, 9490, 9491, 9502, 9503, 9504, 9505, 9506, 9507, 13861, 13862, 13863, 14775, 14776, 14777, 14778, 16382, 16383, 16384, 16385, 19823, 19824, 19825, 19826, 19827, 19828, 19829, 19830, 19831, 19832, 19833, 19834, 19835, 19836, 19837, 19838, 20742, 20743, 20744, 20745, 23914, 23915, 31777, 31778, 31779, 31780, 34490, 34491, 34492),
+	GRASS(Material.NONE, new Properties().setFlatNormals(true).setInheritTileColorType(InheritTileColorType.UNDERLAY), 1257, 1258, 3547, 3548, 3549, 4333, 4334, 4335, 4336, 4530, 4735, 4736, 4737, 4738, 4739, 4740, 4741, 4742, 4809, 4810, 4811, 4812, 4813, 4814, 5335, 5336, 5337, 5338, 5339, 5340, 5341, 5342, 5533, 5534, 5535, 5536, 6817, 6818, 6819, 6835, 6836, 6837, 6838, 7049, 7050, 9485, 9486, 9487, 9488, 9489, 9490, 9491, 9502, 9503, 9504, 9505, 9506, 9507, 13861, 13862, 13863, 14775, 14776, 14777, 14778, 16382, 16383, 16384, 16385, 19823, 19824, 19825, 19826, 19827, 19828, 19829, 19830, 19831, 19832, 19833, 19834, 19835, 19836, 19837, 19838, 20742, 20743, 20744, 20745, 23914, 23915, 31777, 31778, 31779, 31780, 34490, 34491, 34492),
 	GRASS_MAINTAIN_ORIGINAL_COLOR(Material.NONE, new Properties().setFlatNormals(true), 16823, 16824, 16825, 16826),
-	FERN(Material.NONE, new Properties().setInheritTileColor(true), 19827, 19833, 19839),
+	FERN(Material.NONE, new Properties().setInheritTileColorType(InheritTileColorType.UNDERLAY), 19827, 19833, 19839),
 
 	// Wooden Fences
 	WOODEN_FENCES(Material.WOOD_GRAIN,new Properties().setFlatNormals(true),  814, 980, 981, 991, 992,993, 1007, 1008, 1558, 1559, 1560,1561,1562,1563,1564, 1565, 1566, 1567, 1739, 1740, 5432, 5433,5434,5435,5436,5437, 5438, 7055,7527, 9511, 9623),
@@ -124,8 +124,8 @@ public enum ObjectProperties
 	COX_PILLAR(Material.GRUNGE_1, new Properties().setFlatNormals(true), 29806, 29807, 29808, 29809, 29810),
 
 	// Ground decoration rocks
-	GROUND_DECORATION_TAN_ROCK(Material.DIRT_1, new Properties().setInheritTileColor(true),  7105, 7106, 7107),
-	GROUND_DECORATION_GRAY_ROCK(Material.ROCK_1, new Properties().setInheritTileColor(true), 7103, 7104, 7057),
+	GROUND_DECORATION_TAN_ROCK(Material.DIRT_1, new Properties().setInheritTileColorType(InheritTileColorType.OVERLAY),  7105, 7106, 7107),
+	GROUND_DECORATION_GRAY_ROCK(Material.ROCK_1, new Properties().setInheritTileColorType(InheritTileColorType.OVERLAY), 7103, 7104, 7057),
 	// environment rock objects such as piles of rocks, stalagmites, or rock like structures.
 	ROCK_LIKE_OBJECT(Material.ROCK_1,new Properties().setFlatNormals(true), 84, 3634,3635,3636,3637,3638, 3639, 5950, 5953, 22541, 22542,22543, 25077,25078,25079,25080,25081,25082,25083,25084,25085,25086, 25102, 25103, 25104, 25105, 25106, 25107, 25108, 25109, 25110, 25112,25113,25114,25161),
 
@@ -158,14 +158,14 @@ public enum ObjectProperties
 	private final boolean flatNormals;
 	private final UvType uvType;
 	private final TzHaarRecolorType tzHaarRecolorType;
-	private final boolean inheritTileColor;
+	private final InheritTileColorType inheritTileColorType;
 
 	private static class Properties
 	{
 		private boolean flatNormals = false;
 		private UvType uvType = UvType.GEOMETRY;
 		private TzHaarRecolorType tzHaarRecolorType = TzHaarRecolorType.NONE;
-		private boolean inheritTileColor = false;
+		private InheritTileColorType inheritTileColorType = InheritTileColorType.NONE;
 
 		public Properties setFlatNormals(boolean flatNormals)
 		{
@@ -185,9 +185,9 @@ public enum ObjectProperties
 			return this;
 		}
 
-		public Properties setInheritTileColor(boolean inheritTileColor)
+		public Properties setInheritTileColorType(InheritTileColorType inheritTileColorType)
 		{
-			this.inheritTileColor = inheritTileColor;
+			this.inheritTileColorType = inheritTileColorType;
 			return this;
 		}
 	}
@@ -199,7 +199,7 @@ public enum ObjectProperties
 		this.flatNormals = false;
 		this.uvType = UvType.GEOMETRY;
 		this.tzHaarRecolorType = TzHaarRecolorType.NONE;
-		this.inheritTileColor = false;
+		this.inheritTileColorType = InheritTileColorType.NONE;
 	}
 
 	ObjectProperties(Material material, Properties properties, int... ids)
@@ -209,7 +209,7 @@ public enum ObjectProperties
 		this.flatNormals = properties.flatNormals;
 		this.uvType = properties.uvType;
 		this.tzHaarRecolorType = properties.tzHaarRecolorType;
-		this.inheritTileColor = properties.inheritTileColor;
+		this.inheritTileColorType = properties.inheritTileColorType;
 	}
 
 	private static final HashMap<Integer, ObjectProperties> OBJECT_ID_MAP;


### PR DESCRIPTION
Added two options for inhertTileColor. 

- OVERLAY which this is useful for making rocks/rubbles blend. the other one is 
- UNDERLAY meant for grass/ferns as it takes the color from green tile color under a path(need this option for grass in front of houses/paths/ or any other overaly). 
- I also removed inheretingColor for ground tiles without rgb so there isn't a blend if there isn't a ground tile color. Doesn't add tile color blending to objects above cave walls.

Before blending fix, notice the tan rocks turning green
![image](https://user-images.githubusercontent.com/12689117/184054186-f7c5a8aa-e55d-4650-a465-6f700e453f3b.png)
![image](https://user-images.githubusercontent.com/12689117/184054453-1367cd99-7ff5-4d3b-995a-4e3246c0acf8.png)

After blending fix,
![image](https://user-images.githubusercontent.com/12689117/184053998-ddda40b4-19b3-4003-8ca3-5f4bc993f2a3.png)
![image](https://user-images.githubusercontent.com/12689117/184055390-6fc3900e-a5d6-4356-aa2e-54a8d01b6c10.png)


There aren't many rock ids currently but #30 fixed that. Below are some pics with inheretingColor working with the mapped rocks. Rocks shown below are not textured in this PR.

Smoother look in desert mine
![alkharid_afterblend](https://user-images.githubusercontent.com/12689117/184055230-9eafa2bc-aef3-4645-ada7-aa43eedc1a0e.png)

notice how the same rock object above the cave walls are textured and the ground ones are textured/blended
![Above cave wall inheit tile fix](https://user-images.githubusercontent.com/12689117/184055123-cda7fb68-eb00-4a62-a7db-b18a492f71fc.png)

Before
![desertmine_before](https://user-images.githubusercontent.com/12689117/184055175-ae5fa18f-5fa3-4719-8d82-7bf21488d7a2.png)
After
![desertmine_after](https://user-images.githubusercontent.com/12689117/184055183-6e3b507b-dd43-43e5-ae6d-ab856a45ba95.png)






