### PR TITLE
Fixed a few floors of Falador Castle being lit by a red light

### DIFF
--- a/src/main/resources/rs117/hd/scene/lighting/lights.json
+++ b/src/main/resources/rs117/hd/scene/lighting/lights.json
@@ -27168,24 +27168,6 @@
     ]
   },
   {
-    "description": "HALLOWED_TORCH",
-    "height": 300,
-    "alignment": "CENTER",
-    "radius": 700,
-    "strength": 12.5,
-    "color": [
-      140,
-      0,
-      0
-    ],
-    "type": "FLICKER",
-    "duration": 0,
-    "range": 30,
-    "objectIds": [
-      6384
-    ]
-  },
-  {
     "description": "WIZARD_TOWER_RIFT_PORTAL",
     "height": 100,
     "alignment": "CENTER",


### PR DESCRIPTION
Issue was that an incorrect/erroneous Ground Object Id (6384) was being used. It seems it was intended to provide a light for a "HALLOWED_TORCH" object, but I checked around Darkmeyer and the Hallowed Sepulchre, and no objects appear to be using that Id (and the Red Street Lamps already have their own entry, so it's not those).

![FaladorCastleRedLightsBefore1](https://user-images.githubusercontent.com/13398702/184532391-bec4a517-27db-4f5c-bfaf-7c71583ff3c5.png)
![FaladorCastleRedLightsAfter1](https://user-images.githubusercontent.com/13398702/184532390-6778f076-24ec-4fd8-8631-5c1f3cb11dea.png)

![FaladorCastleRedLightsBefore2](https://user-images.githubusercontent.com/13398702/184532394-93ac052e-7a6b-4288-85b7-402200e68811.png)
![FaladorCastleRedLightsAfter2](https://user-images.githubusercontent.com/13398702/184532398-3829173f-276a-4f91-96af-779d602535de.png)

![FaladorCastleRedLightsBefore3](https://user-images.githubusercontent.com/13398702/184532407-0416ceaf-2c08-4f14-9c0b-5d449401f5e4.png)
![FaladorCastleRedLightsAfter3](https://user-images.githubusercontent.com/13398702/184532408-b319b361-07a4-4e3f-ab67-24f82e178175.png)