### PR TITLE
sRGB Corrupted Gauntlet changes

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Environment.java
+++ b/src/main/java/rs117/hd/data/environments/Environment.java
@@ -688,9 +688,9 @@ public enum Environment
 	THE_GAUNTLET_CORRUPTED(Area.THE_GAUNTLET_CORRUPTED, new Properties()
 		.setFogColor("#090606")
 		.setFogDepth(20)
-		.setAmbientColor("#95B6F7")
+		.setAmbientColor("#BB9EAE")
 		.setAmbientStrength(1.5f)
-		.setDirectionalColor("#FF7878")
+		.setDirectionalColor("#C58C9E")
 		.setDirectionalStrength(3.0f)
 		.setLightDirection(260f, 10f)
 	),


### PR DESCRIPTION
This makes Corrupted Gauntlet more red again after the switch to sRGB made the blue ambient lighting more apparent. Feel free to suggest further changes.
Before:
![image](https://user-images.githubusercontent.com/831317/184683792-a0378b40-2690-4e58-9b77-68935547ccbf.png)
After:
![image](https://user-images.githubusercontent.com/831317/184683803-fe9aed99-24c2-4553-a020-f1bce85aedeb.png)
