### PR TITLE
fixes line preprocessor with opencl

### DIFF
--- a/src/main/java/rs117/hd/opengl/shader/Template.java
+++ b/src/main/java/rs117/hd/opengl/shader/Template.java
@@ -41,7 +41,7 @@ public class Template
 
 	private int includeCounter = 0;
 
-	public String process(String str)
+	public String process(String str, String filename)
 	{
 		StringBuilder sb = new StringBuilder();
 		int lineCount = 0;
@@ -65,9 +65,20 @@ public class Template
 						.append(contents)
 						.append("#line ")
 						.append(lineCount + 1)
-						.append(" ")
-						.append(includeCounter - 1)
-						.append("\n");
+						.append(" ");
+
+					if (filename.endsWith(".cl")) {
+						sb
+							.append("\"")
+							.append(resource)
+							.append("\"");
+					} else {
+						sb
+							.append(includeCounter - 1);
+					}
+
+					sb.append("\n");
+
 				}
 				includeCounter--;
 			}
@@ -86,7 +97,7 @@ public class Template
 			String value = loader.apply(filename);
 			if (value != null)
 			{
-				return process(value);
+				return process(value, filename);
 			}
 		}
 


### PR DESCRIPTION
OpenCL expects this argument of the line preprocessor to be a quoted filename: https://opensource.apple.com/source/clang/clang-425.0.24/src/tools/clang/test/Preprocessor/line-directive.c.auto.html

Whereas OpenGL expects this to be an integer: https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)#Preprocessor_directives

This fixes the following issue on Mac:

```
2022-08-24 19:33:11 [Client] ERROR rs117.hd.HdPlugin - Error starting HD plugin
org.jocl.CLException: CL_BUILD_PROGRAM_FAILURE
Build log for device 0:
<program source>:56:10: error: invalid filename for #line directive
#line 28 0
         ^
<program source>:82:15: warning: comparison of integers of different signs: 'size_t' (aka 'unsigned int') and 'int'
  if (localId >= size) {
      ~~~~~~~ ^  ~~~~


    at org.jocl.CL.clBuildProgram(CL.java:11322)
    at rs117.hd.opengl.compute.OpenCLManager.compileProgram(OpenCLManager.java:354)
    at rs117.hd.opengl.compute.OpenCLManager.compilePrograms(OpenCLManager.java:391)
    at rs117.hd.opengl.compute.OpenCLManager.init(OpenCLManager.java:114)
    at rs117.hd.HdPlugin.initPrograms(HdPlugin.java:752)
    at rs117.hd.HdPlugin.lambda$startUp$1(HdPlugin.java:528)
    at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:99)
    at net.runelite.client.callback.Hooks.tick(Hooks.java:203)
    at client.of(client.java:17085)
    at client.g(client.java)
    at ab.ya(ab.java:362)
    at ab.run(ab.java:341)
    at java.base/java.lang.Thread.run(Thread.java:830)
```

This has yet to be tested outside of Mac.