### PR TITLE
Improve shader compile errors for development

### DIFF
--- a/src/main/java/rs117/hd/opengl/shader/Shader.java
+++ b/src/main/java/rs117/hd/opengl/shader/Shader.java
@@ -35,7 +35,10 @@ import rs117.hd.utils.Env;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.lwjgl.opengl.GL43C.*;
@@ -64,6 +67,8 @@ public class Shader
 		return this;
 	}
 
+	Pattern NVIDIA_ERROR_REGEX = Pattern.compile("^(\\d+)\\((\\d+)\\) : (.*)");
+
 	public int compile(Template template) throws ShaderException
 	{
 		int program = glCreateProgram();
@@ -89,6 +94,48 @@ public class Shader
 				{
 					String err = glGetShaderInfoLog(shader);
 					glDeleteShader(shader);
+
+					if (template.includeType == Template.IncludeType.GLSL) {
+						Matcher m = NVIDIA_ERROR_REGEX.matcher(err);
+						if (m.find()) {
+							try {
+								int index = Integer.parseInt(m.group(1));
+								int lineNumber = Integer.parseInt(m.group(2));
+								String error = m.group(3);
+								String include = template.includeList.get(index);
+								err = String.format(
+									"Compile error in '%s' on line %d when compiling shader '%s':\n\n%s\n",
+									include, lineNumber, unit.filename, error);
+							} catch (Exception ex) {
+								log.error("Error while parsing shader compilation error:", ex);
+							}
+						}
+						else
+						{
+							// Unknown error format, so include a mapping from source file index to filename
+							StringBuilder sb = new StringBuilder();
+							sb
+								.append("Compile error while compiling shader '")
+								.append(unit.filename)
+								.append("':\n\n")
+								.append(err)
+								.append("\nIncluded sources: [\n");
+							for (int j = 0; j < template.includeList.size(); j++) {
+								String s = String.valueOf(j);
+								sb
+									.append("  ")
+									.append(String.join("", Collections.nCopies( // Left pad
+										1 + (int) Math.log10(template.includeList.size()) - s.length(), " ")))
+									.append(s)
+									.append(": ")
+									.append(template.includeList.get(j))
+									.append("\n");
+							}
+							sb.append("]\n");
+							err = sb.toString();
+						}
+					}
+
 					throw new ShaderException(err);
 				}
 

--- a/src/main/java/rs117/hd/opengl/shader/Template.java
+++ b/src/main/java/rs117/hd/opengl/shader/Template.java
@@ -31,15 +31,21 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Stack;
 import java.util.function.Function;
 import lombok.extern.slf4j.Slf4j;
+import rs117.hd.utils.ResourcePath;
 
 @Slf4j
 public class Template
 {
-	private final List<Function<String, String>> resourceLoaders = new ArrayList<>();
+	enum IncludeType { GLSL, C, UNKNOWN }
 
-	private int includeCounter = 0;
+	private final List<Function<String, String>> resourceLoaders = new ArrayList<>();
+	private final Stack<Integer> includeStack = new Stack<>();
+
+	IncludeType includeType = IncludeType.UNKNOWN;
+	final ArrayList<String> includeList = new ArrayList<>();
 
 	public String process(String str)
 	{
@@ -51,25 +57,62 @@ public class Template
 			String trimmed = line.trim();
 			if (trimmed.startsWith("#include "))
 			{
-				String resource = trimmed.substring(9);
-				includeCounter++;
-				String contents = load(resource);
-				if (contents.trim().startsWith("#version "))
+				String currentFile = includeList.get(includeList.size() - 1);
+				int currentIndex = includeStack.peek();
+
+				String includeFile = trimmed.substring(9);
+				int includeIndex = includeList.size();
+				includeList.add(includeFile);
+				includeStack.push(includeIndex);
+				String includeContents = loadInternal(includeFile);
+				includeStack.pop();
+
+				switch (includeType)
 				{
-					sb.append(contents);
+					case GLSL:
+						if (includeContents.trim().startsWith("#version "))
+						{
+							// In GLSL, no preprocessor directive can precede #version, so handle included files
+							// starting with a #version directive differently.
+							sb.append(includeContents);
+						}
+						else
+						{
+							// In GLSL, the #line directive takes a line number and a source file index, which we map to
+							// an include-filename through tracking the list of includes.
+							// Source: https://www.khronos.org/opengl/wiki/Core_Language_(GLSL)#.23line_directive
+							sb
+								.append("#line 1 ") // Mark the first line of the included file
+								.append(includeIndex)
+								.append("\n")
+								.append(includeContents)
+								.append("#line ") // Return to the next line of the current file
+								.append(lineCount + 1)
+								.append(" ")
+								.append(currentIndex)
+								.append("\n");
+						}
+						break;
+					case C:
+						// In C, #line followed by a line number sets the line number for the current file, while
+						// #line followed by a line number and a string constant filename changes the line number and
+						// current filename being processed, so in our case we will only be using the latter.
+						// Source: https://gcc.gnu.org/onlinedocs/cpp/Line-Control.html
+						sb
+							.append("#line 1 \"") // Change to line 1 in the included file
+							.append(includeFile)
+							.append("\"\n")
+							.append(includeContents)
+							.append("#line ") // Return to the next line in the parent include
+							.append(lineCount + 1)
+							.append(" \"")
+							.append(currentFile)
+							.append("\"\n");
+						break;
+					default:
+						sb.append(includeContents);
+						break;
 				}
-				else
-				{
-					sb
-						.append("#line 1\n")
-						.append(contents)
-						.append("#line ")
-						.append(lineCount + 1)
-						.append(" ")
-						.append(includeCounter - 1)
-						.append("\n");
-				}
-				includeCounter--;
 			}
 			else
 			{
@@ -79,7 +122,7 @@ public class Template
 		return sb.toString();
 	}
 
-	public String load(String filename)
+	private String loadInternal(String filename)
 	{
 		for (Function<String, String> loader : resourceLoaders)
 		{
@@ -91,6 +134,30 @@ public class Template
 		}
 
 		return "";
+	}
+
+	public String load(String filename)
+	{
+		includeList.clear();
+		includeList.add(filename);
+		includeStack.add(0);
+
+		switch (ResourcePath.path(filename).getExtension().toLowerCase())
+		{
+			case "glsl":
+				includeType = IncludeType.GLSL;
+				break;
+			case "c":
+			case "h":
+			case "cl":
+				includeType = IncludeType.C;
+				break;
+			default:
+				includeType = IncludeType.UNKNOWN;
+				break;
+		}
+
+		return loadInternal(filename);
 	}
 
 	public Template add(Function<String, String> fn)


### PR DESCRIPTION
This adds include tracking to the `Template` class with basic support for GLSL and C, and a parser for Nvidia's GLSL compiler error messages. If the error format is unknown, it will print a list of shader file indices mapped to file names for hopefully somewhat easier debugging of GLSL errors.

Thanks to @keyosk for pointing out master was broken with OpenCL, and his initial fix in #53.