### PR TITLE
Update HdPlugin.java

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -2565,8 +2565,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	 */
 	public int[] getCameraFocalPoint()
 	{
-		int camX = client.getOculusOrbFocalPointX();
-		int camY = client.getOculusOrbFocalPointY();
+		boolean oculusActive = client.getOculusOrbState() == 1;
+		int camX = oculusActive ? client.getOculusOrbFocalPointX() : client.getCameraX();
+		int camY = oculusActive ? client.getOculusOrbFocalPointY() : client.getCameraY();
 		// approximate the Z position of the point the camera is aimed at.
 		// the difference in height between the camera at lowest and highest pitch
 		int camPitch = client.getCameraPitch();


### PR DESCRIPTION
Changed getCameraFocalPoint to use getCameraX and getCameraY when you are not in a orb of oculus state, while this does not seem to make any visual changes, according to the comments  '* @return The camera target's x, y, z coordinates' it should be the current camera X and Y, and [getOculusOrbFocalPointX,getOculusOrbFocalPointY] Use Different variables this has been the same since the plugin as first uploaded  