### PR TITLE
Fix hiding of baked lighting from static models

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -2279,6 +2279,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				break;
 			case "hideBakedEffects":
 				modelPusher.clearModelCache();
+				reloadScene();
 				break;
 		}
 	}
@@ -2393,7 +2394,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			return;
 		}
 
-		if (objectManager.shouldHide(ModelUtils.getID(hash), ModelUtils.getWorldLocation(client, x, z))) {
+		if (objectManager.shouldHide(ModelUtils.getIdOrIndex(hash), ModelUtils.getWorldLocation(client, x, z))) {
 			return;
 		}
 
@@ -2468,7 +2469,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 			TempModelInfo tempModelInfo = tempModelInfoMap.get(batchHash);
 			if (!config.enableModelBatching() || tempModelInfo == null || tempModelInfo.getFaceCount() != model.getFaceCount()) {
-				final int[] lengths = modelPusher.pushModel(renderable, model, vertexBuffer, uvBuffer, normalBuffer, 0, 0, 0, ObjectProperties.NONE, ObjectType.NONE, !config.enableModelCaching());
+				final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer, 0, 0, 0, ObjectProperties.NONE, ObjectType.NONE, !config.enableModelCaching());
 				final int faceCount = lengths[0] / 3;
 				final int actualTempUvOffset = lengths[1] > 0 ? tempUvOffset : -1;
 

--- a/src/main/java/rs117/hd/scene/SceneUploader.java
+++ b/src/main/java/rs117/hd/scene/SceneUploader.java
@@ -105,7 +105,7 @@ class SceneUploader
 		log.debug("Scene upload time: {}", stopwatch);
 	}
 
-	private void uploadModel(Model model, GpuIntBuffer vertexBuffer, GpuFloatBuffer uvBuffer, GpuFloatBuffer normalBuffer, int tileZ, int tileX, int tileY, ObjectProperties objectProperties, ObjectType objectType)
+	private void uploadModel(long hash, Model model, GpuIntBuffer vertexBuffer, GpuFloatBuffer uvBuffer, GpuFloatBuffer normalBuffer, int tileZ, int tileX, int tileY, ObjectProperties objectProperties, ObjectType objectType)
 	{
 		if (model.getSceneId() == sceneId)
 		{
@@ -133,7 +133,7 @@ class SceneUploader
 		}
 		model.setSceneId(sceneId);
 
-		final int[] lengths = modelPusher.pushModel(null, model, vertexBuffer, uvBuffer, normalBuffer, tileX, tileY, tileZ, objectProperties, objectType, true);
+		final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer, tileX, tileY, tileZ, objectProperties, objectType, true);
 
 		offset += lengths[0];
 		uvOffset += lengths[1];
@@ -208,16 +208,16 @@ class SceneUploader
 			if (renderable1 instanceof Model)
 			{
 				Model model = (Model) renderable1;
-				uploadModel(model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX, tileY,
-					objectProperties, ObjectType.WALL_OBJECT);
+				uploadModel(wallObject.getHash(), model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX,
+					tileY, objectProperties, ObjectType.WALL_OBJECT);
 			}
 
 			Renderable renderable2 = wallObject.getRenderable2();
 			if (renderable2 instanceof Model)
 			{
 				Model model = (Model) renderable2;
-				uploadModel(model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX, tileY,
-					objectProperties, ObjectType.WALL_OBJECT);
+				uploadModel(wallObject.getHash(), model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX,
+					tileY, objectProperties, ObjectType.WALL_OBJECT);
 			}
 		}
 
@@ -230,8 +230,8 @@ class SceneUploader
 			if (renderable instanceof Model)
 			{
 				Model model = (Model) renderable;
-				uploadModel(model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX, tileY,
-					objectProperties, ObjectType.GROUND_OBJECT);
+				uploadModel(groundObject.getHash(), model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX,
+					tileY, objectProperties, ObjectType.GROUND_OBJECT);
 			}
 		}
 
@@ -244,16 +244,16 @@ class SceneUploader
 			if (renderable instanceof Model)
 			{
 				Model model = (Model) renderable;
-				uploadModel(model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX, tileY,
-					objectProperties, ObjectType.DECORATIVE_OBJECT);
+				uploadModel(decorativeObject.getHash(), model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX,
+					tileY, objectProperties, ObjectType.DECORATIVE_OBJECT);
 			}
 
 			Renderable renderable2 = decorativeObject.getRenderable2();
 			if (renderable2 instanceof Model)
 			{
 				Model model = (Model) renderable2;
-				uploadModel(model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX, tileY,
-					objectProperties, ObjectType.DECORATIVE_OBJECT);
+				uploadModel(decorativeObject.getHash(), model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX,
+					tileY, objectProperties, ObjectType.DECORATIVE_OBJECT);
 			}
 		}
 
@@ -271,8 +271,8 @@ class SceneUploader
 			if (renderable instanceof Model)
 			{
 				Model model = (Model) gameObject.getRenderable();
-				uploadModel(model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX, tileY,
-					objectProperties, ObjectType.GAME_OBJECT);
+				uploadModel(gameObject.getHash(), model, vertexBuffer, uvBuffer, normalBuffer, tileZ, tileX,
+					tileY, objectProperties, ObjectType.GAME_OBJECT);
 			}
 		}
 	}

--- a/src/main/java/rs117/hd/utils/ModelUtils.java
+++ b/src/main/java/rs117/hd/utils/ModelUtils.java
@@ -3,14 +3,12 @@ package rs117.hd.utils;
 import net.runelite.api.Client;
 import net.runelite.api.coords.WorldPoint;
 
-enum ModelType {
-    PLAYER,
-    NPC,
-    OBJECT,
-    GROUND_ITEM
-}
-
 public class ModelUtils {
+    public static final int TYPE_PLAYER = 0;
+    public static final int TYPE_NPC = 1;
+    public static final int TYPE_OBJECT = 2;
+    public static final int TYPE_GROUND_ITEM = 3;
+
     public static WorldPoint getWorldLocation(Client client, int x, int z) {
         int lx = x + client.getCameraX2();
         int lz = z + client.getCameraZ2();
@@ -22,7 +20,7 @@ public class ModelUtils {
      * Npc's it's the npc index
      * Players it's the player index
      */
-    public static int getID(long hash) {
+    public static int getIdOrIndex(long hash) {
         return (int) (hash >>> 17 & 0xffffffffL);
     }
 
@@ -36,9 +34,5 @@ public class ModelUtils {
 
     public static int getModelType(long hash) {
         return (int) ((hash >> 14) & 3);
-    }
-
-    public static ModelType getType(long hash) {
-        return ModelType.values()[getModelType(hash)];
     }
 }


### PR DESCRIPTION
Instead of passing around Renderable instances, pass the more generic hash which can be quickly decoded into an ID and type in the ModelPusher. This will also work for GameObjects uploaded by SceneUploader, which are not themselves Renderable instances.