### PR TITLE
Make over-exposure workaround optional

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -87,6 +87,7 @@ import java.util.Map;
 
 import static org.jocl.CL.*;
 import static org.lwjgl.opengl.GL43C.*;
+import static rs117.hd.HdPluginConfig.KEY_REDUCE_OVER_EXPOSURE;
 import static rs117.hd.HdPluginConfig.KEY_WINTER_THEME;
 import static rs117.hd.utils.ResourcePath.path;
 
@@ -380,6 +381,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	public boolean configExpandShadowDraw = false;
 	public boolean configHdInfernalTexture = true;
 	public boolean configWinterTheme = true;
+	public boolean configReduceOverExposure = false;
 	public int configMaxDynamicLights;
 
 	public int[] camTarget = new int[3];
@@ -417,6 +419,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		configExpandShadowDraw = config.expandShadowDraw();
 		configHdInfernalTexture = config.hdInfernalTexture();
 		configWinterTheme = config.winterTheme();
+		configReduceOverExposure = config.reduceOverExposure();
 		configMaxDynamicLights = config.maxDynamicLights().getValue();
 
 		clientThread.invoke(() ->
@@ -2241,19 +2244,22 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				});
 				break;
 			case "textureResolution":
+			case "hdInfernalTexture":
+				configHdInfernalTexture = config.hdInfernalTexture();
+				textureManager.freeTextures();
 			case "groundBlending":
 			case "groundTextures":
 			case "objectTextures":
 			case "tzhaarHD":
 			case KEY_WINTER_THEME:
-			case "hdInfernalTexture":
+			case KEY_REDUCE_OVER_EXPOSURE:
 				configGroundBlending = config.groundBlending();
 				configGroundTextures = config.groundTextures();
 				configObjectTextures = config.objectTextures();
 				configTzhaarHD = config.tzhaarHD();
 				configWinterTheme = config.winterTheme();
-				configHdInfernalTexture = config.hdInfernalTexture();
-				textureManager.freeTextures();
+				configReduceOverExposure = config.reduceOverExposure();
+				modelPusher.clearModelCache();
 				reloadScene();
 				break;
 			case "projectileLights":

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -35,8 +35,6 @@ import rs117.hd.config.*;
 @ConfigGroup("hd")
 public interface HdPluginConfig extends Config
 {
-	String KEY_WINTER_THEME = "winterTheme0";
-
 	/*====== General settings ======*/
 
 	@ConfigSection(
@@ -534,6 +532,7 @@ public interface HdPluginConfig extends Config
 		return true;
 	}
 
+	String KEY_WINTER_THEME = "winterTheme0";
 	@ConfigItem(
 		keyName = KEY_WINTER_THEME,
 		name = "Winter theme",
@@ -545,6 +544,21 @@ public interface HdPluginConfig extends Config
 	{
 		return false;
 	}
+
+	String KEY_REDUCE_OVER_EXPOSURE = "reduceOverExposure";
+	@ConfigItem(
+		keyName = KEY_REDUCE_OVER_EXPOSURE,
+		name = "Reduce over-exposure",
+		description = "Previously, HD attempted to reduce over-exposure by lowering the maximum face color brightness.\n" +
+			"This turned most white-looking things into a dull grey. This option returns that old behaviour.",
+		position = 304,
+		section = miscellaneousSettings
+	)
+	default boolean reduceOverExposure() {
+		return false;
+	}
+
+	/*====== Experimental settings ======*/
 
 	@ConfigSection(
 			name = "Experimental",

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -608,9 +608,11 @@ public class ModelPusher {
             packedAlphaPriority = tzHaarRecolored[3][0];
         }
 
-        color1L = Ints.constrainToRange(color1L, 0, maxBrightness);
-        color2L = Ints.constrainToRange(color2L, 0, maxBrightness);
-        color3L = Ints.constrainToRange(color3L, 0, maxBrightness);
+        if (hdPlugin.configReduceOverExposure) {
+            color1L = HDUtils.clamp(color1L, 0, maxBrightness);
+            color2L = HDUtils.clamp(color2L, 0, maxBrightness);
+            color3L = HDUtils.clamp(color3L, 0, maxBrightness);
+        }
 
         color1 = (color1H << 3 | color1S) << 7 | color1L;
         color2 = (color2H << 3 | color2S) << 7 | color2L;

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -132,6 +132,14 @@ public class HDUtils
 		return out;
 	}
 
+	public static int clamp(int value, int min, int max) {
+		return Math.min(max, Math.max(min, value));
+	}
+
+	public static float clamp(float value, float min, float max) {
+		return Math.min(max, Math.max(min, value));
+	}
+
 	public static int vertexHash(int[] vPos)
 	{
 		// simple custom hashing function for vertex position data

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -69,9 +69,9 @@ uniform float contrast;
 uniform int pointLightsCount; // number of lights in current frame
 
 in float fogAmount;
-in vec4 vColor1;
-in vec4 vColor2;
-in vec4 vColor3;
+flat in vec4 vColor1;
+flat in vec4 vColor2;
+flat in vec4 vColor3;
 flat in vec2 vUv1;
 flat in vec2 vUv2;
 flat in vec2 vUv3;

--- a/src/main/resources/rs117/hd/geom.glsl
+++ b/src/main/resources/rs117/hd/geom.glsl
@@ -44,9 +44,9 @@ in vec4 vUv[];
 in float vFogAmount[];
 
 out float fogAmount;
-out vec4 vColor1;
-out vec4 vColor2;
-out vec4 vColor3;
+flat out vec4 vColor1;
+flat out vec4 vColor2;
+flat out vec4 vColor3;
 flat out vec2 vUv1;
 flat out vec2 vUv2;
 flat out vec2 vUv3;


### PR DESCRIPTION
This removes the maximum brightness cap that 117 added at one point, presumably to avoid over-exposure after lighting. Reverting this makes colors more true to vanilla, and it's most noticeable on pure white faces, which the brightness cap turned into a dull grey.

Before:
![image](https://user-images.githubusercontent.com/831317/192154369-00d1e97e-a300-4eec-8771-7a1f651b4a46.png)

After:
![image](https://user-images.githubusercontent.com/831317/192154375-7fae5a27-e324-410b-becb-2456b3934734.png)

When combined with the changes from #70, you get the following, which is how the entrance looks in vanilla.
![image](https://user-images.githubusercontent.com/831317/192154462-718608a9-706a-47b3-8b5c-5f6b0f43185f.png)
