### PR TITLE
Remove shading from GotR entrance

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -2475,7 +2475,13 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 			TempModelInfo tempModelInfo = tempModelInfoMap.get(batchHash);
 			if (!config.enableModelBatching() || tempModelInfo == null || tempModelInfo.getFaceCount() != model.getFaceCount()) {
-				final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer, 0, 0, 0, ObjectProperties.NONE, ObjectType.NONE, !config.enableModelCaching());
+				int modelType = ModelUtils.getModelType(hash);
+				ObjectProperties objectProperties = ObjectProperties.NONE;
+				if (modelType == ModelUtils.TYPE_OBJECT) {
+					objectProperties = objectManager.getObjectProperties(ModelUtils.getIdOrIndex(hash));
+				}
+
+				final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer, 0, 0, 0, objectProperties, ObjectType.NONE, !config.enableModelCaching());
 				final int faceCount = lengths[0] / 3;
 				final int actualTempUvOffset = lengths[1] > 0 ? tempUvOffset : -1;
 

--- a/src/main/java/rs117/hd/data/materials/Material.java
+++ b/src/main/java/rs117/hd/data/materials/Material.java
@@ -44,7 +44,8 @@ public enum Material
 	// Default
 	NONE,
 
-	// Special textures
+	// Special materials
+	UNLIT(NONE, p -> p.setUnlit(true)),
 	TRANSPARENT,
 	LAVA_FLOW_MAP,
 	WATER_FLOW_MAP,

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -477,39 +477,42 @@ public class ModelPusher {
         int color3S = color3 >> 7 & 0x7;
         int color3L = color3 & 0x7F;
 
-        // reduce the effect of the baked shading by approximately inverting the process by which
-        // the shading is added initially.
-        int lightenA = (int) (Math.max((color1L - ignoreLowLightness), 0) * lightnessMultiplier) + baseLighten;
-        float dotA = Math.max(dotNormal3Lights(new float[]{
+        int maxBrightness = 55;
+        boolean isLit = objectProperties == null || objectProperties.material == null || !objectProperties.material.unlit;
+        if (isLit) {
+            // reduce the effect of the baked shading by approximately inverting the process by which
+            // the shading is added initially.
+            int lightenA = (int) (Math.max((color1L - ignoreLowLightness), 0) * lightnessMultiplier) + baseLighten;
+            float dotA = Math.max(dotNormal3Lights(new float[]{
                 xVertexNormals[triA],
                 yVertexNormals[triA],
                 zVertexNormals[triA],
-        }), 0);
-        color1L = (int) HDUtils.lerp(color1L, lightenA, dotA);
+            }), 0);
+            color1L = (int) HDUtils.lerp(color1L, lightenA, dotA);
 
-        int lightenB = (int) (Math.max((color2L - ignoreLowLightness), 0) * lightnessMultiplier) + baseLighten;
-        float dotB = Math.max(dotNormal3Lights(new float[]{
+            int lightenB = (int) (Math.max((color2L - ignoreLowLightness), 0) * lightnessMultiplier) + baseLighten;
+            float dotB = Math.max(dotNormal3Lights(new float[]{
                 xVertexNormals[triB],
                 yVertexNormals[triB],
                 zVertexNormals[triB],
-        }), 0);
-        color2L = (int) HDUtils.lerp(color2L, lightenB, dotB);
+            }), 0);
+            color2L = (int) HDUtils.lerp(color2L, lightenB, dotB);
 
-        int lightenC = (int) (Math.max((color3L - ignoreLowLightness), 0) * lightnessMultiplier) + baseLighten;
-        float dotC = Math.max(dotNormal3Lights(new float[]{
+            int lightenC = (int) (Math.max((color3L - ignoreLowLightness), 0) * lightnessMultiplier) + baseLighten;
+            float dotC = Math.max(dotNormal3Lights(new float[]{
                 xVertexNormals[triC],
                 yVertexNormals[triC],
                 zVertexNormals[triC],
-        }), 0);
-        color3L = (int) HDUtils.lerp(color3L, lightenC, dotC);
+            }), 0);
+            color3L = (int) HDUtils.lerp(color3L, lightenC, dotC);
 
-        int maxBrightness = 55;
-        if (faceTextures != null && faceTextures[face] != -1) {
-            maxBrightness = 90;
-            // set textured faces to pure white as they are harder to remove shadows from for some reason
-            color1H = color2H = color3H = 0;
-            color1S = color2S = color3S = 0;
-            color1L = color2L = color3L = 127;
+            if (faceTextures != null && faceTextures[face] != -1) {
+                maxBrightness = 90;
+                // set textured faces to pure white as they are harder to remove shadows from for some reason
+                color1H = color2H = color3H = 0;
+                color1S = color2S = color3S = 0;
+                color1L = color2L = color3L = 127;
+            }
         }
 
         if (tile != null && objectProperties != null && objectProperties.inheritTileColorType != InheritTileColorType.NONE) {

--- a/src/main/resources/rs117/hd/scene/object_properties.json
+++ b/src/main/resources/rs117/hd/scene/object_properties.json
@@ -1419,5 +1419,13 @@
       3709,
       3950
     ]
+  },
+  {
+    "description": "Guardians of the Rift entrance",
+    "objectIds": [
+      "BARRIER_43700",
+      "BARRIER_43849"
+    ],
+    "material": "UNLIT"
   }
 ]


### PR DESCRIPTION
- Add support for ObjectProperties on dynamic models.
- Add unlit material.
- Stop trying to remove vanilla shading from unlit faces.
- Set the material for each of the GotR entrance variants to the unlit material.

Before:
![image](https://user-images.githubusercontent.com/831317/192154664-45f82cdf-1db0-40fe-b2da-4ab9eeea6cd9.png)

After:
![image](https://user-images.githubusercontent.com/831317/192154673-67d40a95-eb8c-4580-940b-3e2ff920249e.png)

When combined with the changes from #69, you get the following result:
![image](https://user-images.githubusercontent.com/831317/192154736-0e8b1d32-3981-4f84-b822-dc60285f5ea5.png)
