### PR TITLE
Add option to remove vanilla shading if old behaviour is desired

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -87,7 +87,7 @@ import java.util.Map;
 
 import static org.jocl.CL.*;
 import static org.lwjgl.opengl.GL43C.*;
-import static rs117.hd.HdPluginConfig.KEY_REDUCE_OVER_EXPOSURE;
+import static rs117.hd.HdPluginConfig.KEY_REMOVE_VANILLA_SHADING;
 import static rs117.hd.HdPluginConfig.KEY_WINTER_THEME;
 import static rs117.hd.utils.ResourcePath.path;
 
@@ -381,7 +381,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	public boolean configExpandShadowDraw = false;
 	public boolean configHdInfernalTexture = true;
 	public boolean configWinterTheme = true;
-	public boolean configReduceOverExposure = false;
+	public boolean configRemoveVanillaShading = false;
 	public int configMaxDynamicLights;
 
 	public int[] camTarget = new int[3];
@@ -419,7 +419,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		configExpandShadowDraw = config.expandShadowDraw();
 		configHdInfernalTexture = config.hdInfernalTexture();
 		configWinterTheme = config.winterTheme();
-		configReduceOverExposure = config.reduceOverExposure();
+		configRemoveVanillaShading = config.removeVanillaShading();
 		configMaxDynamicLights = config.maxDynamicLights().getValue();
 
 		clientThread.invoke(() ->
@@ -2252,13 +2252,13 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			case "objectTextures":
 			case "tzhaarHD":
 			case KEY_WINTER_THEME:
-			case KEY_REDUCE_OVER_EXPOSURE:
+			case KEY_REMOVE_VANILLA_SHADING:
 				configGroundBlending = config.groundBlending();
 				configGroundTextures = config.groundTextures();
 				configObjectTextures = config.objectTextures();
 				configTzhaarHD = config.tzhaarHD();
 				configWinterTheme = config.winterTheme();
-				configReduceOverExposure = config.reduceOverExposure();
+				configRemoveVanillaShading = config.removeVanillaShading();
 				modelPusher.clearModelCache();
 				reloadScene();
 				break;

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -545,16 +545,18 @@ public interface HdPluginConfig extends Config
 		return false;
 	}
 
-	String KEY_REDUCE_OVER_EXPOSURE = "reduceOverExposure";
+	String KEY_REMOVE_VANILLA_SHADING = "removeVanillaShading";
 	@ConfigItem(
-		keyName = KEY_REDUCE_OVER_EXPOSURE,
-		name = "Reduce over-exposure",
-		description = "Previously, HD attempted to reduce over-exposure by lowering the maximum face color brightness.\n" +
-			"This turned most white-looking things into a dull grey. This option returns that old behaviour.",
+		keyName = KEY_REMOVE_VANILLA_SHADING,
+		name = "Remove vanilla shading",
+		description =
+			"Previously, HD attempted to remove vanilla shading by approximately increasing the brightness of colors<br> " +
+			"by the same amount as the base game would darken them. This worked alright for the most part, but it<br> " +
+			"resulted in white colors appearing more like dull greys. Enabling this option brings back that old behaviour.",
 		position = 304,
 		section = miscellaneousSettings
 	)
-	default boolean reduceOverExposure() {
+	default boolean removeVanillaShading() {
 		return false;
 	}
 

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -1,6 +1,5 @@
 package rs117.hd.model;
 
-import com.google.common.primitives.Ints;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.kit.KitType;
@@ -478,8 +477,7 @@ public class ModelPusher {
         int color3L = color3 & 0x7F;
 
         int maxBrightness = 55;
-        boolean isLit = objectProperties == null || objectProperties.material == null || !objectProperties.material.unlit;
-        if (isLit) {
+        if (hdPlugin.configRemoveVanillaShading) {
             // reduce the effect of the baked shading by approximately inverting the process by which
             // the shading is added initially.
             int lightenA = (int) (Math.max((color1L - ignoreLowLightness), 0) * lightnessMultiplier) + baseLighten;
@@ -611,7 +609,7 @@ public class ModelPusher {
             packedAlphaPriority = tzHaarRecolored[3][0];
         }
 
-        if (hdPlugin.configReduceOverExposure) {
+        if (hdPlugin.configRemoveVanillaShading) {
             color1L = HDUtils.clamp(color1L, 0, maxBrightness);
             color2L = HDUtils.clamp(color2L, 0, maxBrightness);
             color3L = HDUtils.clamp(color3L, 0, maxBrightness);


### PR DESCRIPTION
This replaces the config option introduced by #69 with an option to remove vanilla shading, which can be enabled if the old behaviour of HD is desired. This means that HD will by default use vanilla shading with HD lighting on top. This all in all looks better imo.

Current vs. new:
![image](https://user-images.githubusercontent.com/831317/192355827-926a7659-9d80-4e5f-998f-4c45319434b2.png)
![image](https://user-images.githubusercontent.com/831317/192355841-0624613b-2d2a-4a19-b041-18f02993c768.png)

Current vs. new:
![image](https://user-images.githubusercontent.com/831317/192357360-740bc72b-f65d-4eba-9304-8c63588f37ab.png)
![image](https://user-images.githubusercontent.com/831317/192357380-45199576-bc5b-4c49-a11b-6c7424cbd6bd.png)

An unfortunate result of this is that capes will again get darker (except firecape & infernal), thanks to vanilla shading making them overly dark. We can potentially fix this in the future by loading unshaded models from the cache, but for now I think it's an acceptable tradeoff.