### PR TITLE
Revert texture max brightness changes

### DIFF
--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -512,7 +512,7 @@ public class ModelPusher {
             color1H = color2H = color3H = 0;
             color1S = color2S = color3S = 0;
             color1L = color2L = color3L = 127;
-            maxBrightness1 = maxBrightness2 = maxBrightness3 = 127;
+            maxBrightness1 = maxBrightness2 = maxBrightness3 = 90;
         }
 
         if (tile != null && modelOverride.inheritTileColorType != InheritTileColorType.NONE) {


### PR DESCRIPTION
The brightness of textures was recently upped alongside color brightness without giving it too much extra thought, but this results in overly bright textures in some cases.

Here is what Ardougne rooftops look like currently:
![image](https://user-images.githubusercontent.com/831317/193977934-7d92c787-425f-4d70-9064-abb4260183c6.png)

Compared to what they looked like before:
![image](https://user-images.githubusercontent.com/831317/193977957-91160a17-05e1-443a-b911-a517eb734968.png)

I think it's safe to say the ideal end result is the bottom picture, but whether this PR is the best way to go about it is a different question. We should consider whether we want to change lighting strength for the overworld environment instead.

Note, this change doesn't affect infernal & fire capes.