### PR TITLE
Add option to return old max brightness behaviour

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -87,6 +87,7 @@ import java.util.Map;
 
 import static org.jocl.CL.*;
 import static org.lwjgl.opengl.GL43C.*;
+import static rs117.hd.HdPluginConfig.KEY_REDUCE_OVER_EXPOSURE;
 import static rs117.hd.HdPluginConfig.KEY_WINTER_THEME;
 import static rs117.hd.utils.ResourcePath.path;
 
@@ -380,6 +381,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	public boolean configExpandShadowDraw = false;
 	public boolean configHdInfernalTexture = true;
 	public boolean configWinterTheme = true;
+	public boolean configReduceOverExposure = false;
 	public int configMaxDynamicLights;
 
 	public int[] camTarget = new int[3];
@@ -417,6 +419,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		configExpandShadowDraw = config.expandShadowDraw();
 		configHdInfernalTexture = config.hdInfernalTexture();
 		configWinterTheme = config.winterTheme();
+		configReduceOverExposure = config.reduceOverExposure();
 		configMaxDynamicLights = config.maxDynamicLights().getValue();
 
 		clientThread.invoke(() ->
@@ -2249,11 +2252,13 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			case "groundTextures":
 			case "objectTextures":
 			case "tzhaarHD":
+			case KEY_REDUCE_OVER_EXPOSURE:
 				configGroundBlending = config.groundBlending();
 				configGroundTextures = config.groundTextures();
 				configModelTextures = config.objectTextures();
 				configTzhaarHD = config.tzhaarHD();
 				configWinterTheme = config.winterTheme();
+				configReduceOverExposure = config.reduceOverExposure();
 				clientThread.invoke(() -> {
 					modelPusher.clearModelCache();
 					reloadScene();

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -545,6 +545,19 @@ public interface HdPluginConfig extends Config
 		return false;
 	}
 
+	String KEY_REDUCE_OVER_EXPOSURE = "reduceOverExposure";
+	@ConfigItem(
+		keyName = KEY_REDUCE_OVER_EXPOSURE,
+		name = "Reduce over-exposure",
+		description = "Previously, HD attempted to reduce over-exposure by lowering the maximum face color brightness.\n" +
+			"This turned most white-looking things into a dull grey. This option returns that old behaviour.",
+		position = 304,
+		section = miscellaneousSettings
+	)
+	default boolean reduceOverExposure() {
+		return false;
+	}
+
 	/*====== Experimental settings ======*/
 
 	@ConfigSection(

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -504,9 +504,14 @@ public class ModelPusher {
         }), 0);
         color3L = (int) HDUtils.lerp(color3L, lightenC, dotC);
 
-        int maxBrightness1 = (int) HDUtils.lerp(127, 55, (float) Math.pow((float) color1S / 0x7, .05));
-        int maxBrightness2 = (int) HDUtils.lerp(127, 55, (float) Math.pow((float) color2S / 0x7, .05));
-        int maxBrightness3 = (int) HDUtils.lerp(127, 55, (float) Math.pow((float) color3S / 0x7, .05));
+        int maxBrightness1 = 55;
+        int maxBrightness2 = 55;
+        int maxBrightness3 = 55;
+        if (!hdPlugin.configReduceOverExposure) {
+            maxBrightness1 = (int) HDUtils.lerp(127, maxBrightness1, (float) Math.pow((float) color1S / 0x7, .05));
+            maxBrightness2 = (int) HDUtils.lerp(127, maxBrightness2, (float) Math.pow((float) color2S / 0x7, .05));
+            maxBrightness3 = (int) HDUtils.lerp(127, maxBrightness3, (float) Math.pow((float) color3S / 0x7, .05));
+        }
         if (faceTextures != null && faceTextures[face] != -1) {
             // Without overriding the color for textured faces, vanilla shading remains pretty noticeable even after
             // the approximate reversal above. Ardougne rooftops is a good example, where vanilla shading results in a


### PR DESCRIPTION
New behaviour:
![image](https://user-images.githubusercontent.com/831317/194710686-f9f9934b-ea6c-4ea5-ac72-50a7a63d01a7.png)
Old behaviour (i.e. with `Reduce over-exposure` enabled):
![image](https://user-images.githubusercontent.com/831317/194710695-74c86456-4156-453f-a4be-0a85bcbe5119.png)
