### PR TITLE
Enable hotswapping through plugin test

### DIFF
--- a/src/test/java/rs117/hd/HdPluginTest.java
+++ b/src/test/java/rs117/hd/HdPluginTest.java
@@ -4,9 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.client.RuneLite;
 import net.runelite.client.RuneLiteProperties;
 import net.runelite.client.externalplugins.ExternalPluginManager;
+import rs117.hd.utils.ResourcePath;
 
 import java.io.InputStream;
 import java.util.Properties;
+
+import static rs117.hd.utils.ResourcePath.path;
 
 @SuppressWarnings("unchecked")
 @Slf4j
@@ -14,6 +17,7 @@ public class HdPluginTest
 {
 	public static void main(String[] args) throws Exception
 	{
+		ResourcePath.RESOURCE_PATH = path("src/main/resources");
 		useLatestPluginHub();
 		ExternalPluginManager.loadBuiltin(HdPlugin.class);
 		RuneLite.main(args);


### PR DESCRIPTION
This disables hotswapping based purely on a file system check, as this check would also be true when the plugin is used while developing other RuneLite plugins. Additionally, this adds an environment variable to optionally enable hotswapping in release mode, which can be helpful with tracking down shader bugs or other issues that are hard to reproduce locally. This largely makes the other environment variables obsolete, so we could potentially go through and remove those.