### PR TITLE
Anisotropic Filtering

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -2281,6 +2281,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 					recompilePrograms();
 				});
 				break;
+			case "anisotropicFilteringLevel":
+				textureManager.freeTextures();
+				break;
 			case "uiScalingMode":
 			case "colorBlindMode":
 			case "parallaxMappingMode":


### PR DESCRIPTION
Anisotropic filtering was not being updated live due to the textures needed to be reloaded, you can now set it without restart the plugin to see the effects 