### PR TITLE
Fix model cache allocation

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -87,8 +87,7 @@ import java.util.Map;
 
 import static org.jocl.CL.*;
 import static org.lwjgl.opengl.GL43C.*;
-import static rs117.hd.HdPluginConfig.KEY_REDUCE_OVER_EXPOSURE;
-import static rs117.hd.HdPluginConfig.KEY_WINTER_THEME;
+import static rs117.hd.HdPluginConfig.*;
 import static rs117.hd.utils.ResourcePath.path;
 
 @PluginDescriptor(
@@ -2300,6 +2299,13 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 				log.debug("Rebuilding sync mode");
 				clientThread.invoke(this::setupSyncMode);
 				break;
+			case KEY_ENABLE_MODEL_CACHING:
+			case KEY_MODEL_CACHE_SIZE:
+				clientThread.invoke(() -> {
+					modelPusher.shutDown();
+					modelPusher.startUp();
+				});
+				break;
 		}
 	}
 
@@ -2484,7 +2490,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			TempModelInfo tempModelInfo = tempModelInfoMap.get(batchHash);
 			if (!config.enableModelBatching() || tempModelInfo == null || tempModelInfo.getFaceCount() != model.getFaceCount()) {
 				ModelOverride modelOverride = modelOverrideManager.getOverride(hash);
-				final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer, 0, 0, 0, modelOverride, ObjectType.NONE, !config.enableModelCaching());
+				final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer,
+					0, 0, 0, modelOverride, ObjectType.NONE, true);
 				final int faceCount = lengths[0] / 3;
 				final int actualTempUvOffset = lengths[1] > 0 ? tempUvOffset : -1;
 

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -552,9 +552,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 				clientThread.invokeLater(this::displayUpdateMessage);
 			}
-			catch (Throwable e)
+			catch (Throwable err)
 			{
-				log.error("Error starting HD plugin", e);
+				log.error("Error while starting 117HD", err);
 				stopPlugin();
 			}
 			return true;
@@ -637,7 +637,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			}
 			catch (PluginInstantiationException ex)
 			{
-				log.error("error stopping plugin", ex);
+				log.error("Error while stopping 117HD", ex);
 			}
 		});
 

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -40,8 +40,7 @@ public interface HdPluginConfig extends Config
 	@ConfigSection(
 		name = "General",
 		description = "General settings",
-		position = 0,
-		closedByDefault = false
+		position = 0
 	)
 	String generalSettings = "generalSettings";
 
@@ -123,11 +122,11 @@ public interface HdPluginConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "vsyncMode",
-			name = "VSync Mode",
-			description = "Method to synchronize frame rate with refresh rate",
-			position = 6,
-			section = generalSettings
+		keyName = "vsyncMode",
+		name = "VSync Mode",
+		description = "Method to synchronize frame rate with refresh rate",
+		position = 6,
+		section = generalSettings
 	)
 	default SyncMode syncMode()
 	{
@@ -135,15 +134,15 @@ public interface HdPluginConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "fpsTarget",
-			name = "FPS Target",
-			description = "Target FPS when unlock FPS is enabled and Vsync mode is OFF",
-			position = 7,
-			section = generalSettings
+		keyName = "fpsTarget",
+		name = "FPS Target",
+		description = "Target FPS when unlock FPS is enabled and Vsync mode is OFF",
+		position = 7,
+		section = generalSettings
 	)
 	@Range(
-			min = 0,
-			max = 999
+		min = 0,
+		max = 999
 	)
 	default int fpsTarget()
 	{
@@ -231,8 +230,7 @@ public interface HdPluginConfig extends Config
 	@ConfigSection(
 		name = "Lighting",
 		description = "Lighting settings",
-		position = 100,
-		closedByDefault = false
+		position = 100
 	)
 	String lightingSettings = "lightingSettings";
 
@@ -564,10 +562,10 @@ public interface HdPluginConfig extends Config
 	/*====== Experimental settings ======*/
 
 	@ConfigSection(
-			name = "Experimental",
-			description = "Experimental features - if you're experiencing issues you should consider disabling these",
-			position = 400,
-			closedByDefault = true
+		name = "Experimental",
+		description = "Experimental features - if you're experiencing issues you should consider disabling these",
+		position = 400,
+		closedByDefault = true
 	)
 	String experimentalSettings = "experimentalSettings";
 
@@ -583,39 +581,39 @@ public interface HdPluginConfig extends Config
 
 	String KEY_ENABLE_MODEL_CACHING = "enableModelCaching";
 	@ConfigItem(
-			keyName = KEY_ENABLE_MODEL_CACHING,
-			name = "Enable model caching",
-			description = "Model caching improves performance by saving and reusing model data from older frames.<br>" +
-				"May cause instability or graphical bugs.",
-			position = 402,
-			section = experimentalSettings
+		keyName = KEY_ENABLE_MODEL_CACHING,
+		name = "Enable model caching",
+		description = "Model caching improves performance by saving and reusing model data from older frames.<br>" +
+			"May cause instability or graphical bugs.",
+		position = 402,
+		section = experimentalSettings
 	)
 	default boolean enableModelCaching() { return false; }
 
 	String KEY_MODEL_CACHE_SIZE = "modelCacheSizeMiB";
 	@Range(
-			min = 256,
-			max = 16384
+		min = 256,
+		max = 16384
 	)
 	@ConfigItem(
-			keyName = KEY_MODEL_CACHE_SIZE,
-			name = "Model cache size (MiB)",
-			description = "Size of the model cache in mebibytes (slightly more than megabytes).<br>" +
-				"Minimum=256 MiB, maximum=16384 MiB",
-			position = 403,
-			section = experimentalSettings
+		keyName = KEY_MODEL_CACHE_SIZE,
+		name = "Model cache size (MiB)",
+		description = "Size of the model cache in mebibytes (slightly more than megabytes).<br>" +
+			"Minimum=256 MiB, maximum=16384 MiB",
+		position = 403,
+		section = experimentalSettings
 	)
 	default int modelCacheSizeMiB() {
 		return 2048;
 	}
 
 	@ConfigItem(
-			keyName = "loadingClearCache",
-			name = "Clear cache when loading",
-			description = "Clear the model cache whenever the game loads a new scene.<br>" +
-				"This should generally only be used if the cache size is lower than 512 MiB.",
-			position = 404,
-			section = experimentalSettings
+		keyName = "loadingClearCache",
+		name = "Clear cache when loading",
+		description = "Clear the model cache whenever the game loads a new scene.<br>" +
+			"This should generally only be used if the cache size is lower than 512 MiB.",
+		position = 404,
+		section = experimentalSettings
 	)
 	default boolean loadingClearCache() {
 		return false;

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -91,7 +91,10 @@ public interface HdPluginConfig extends Config
 	@ConfigItem(
 		keyName = "anisotropicFilteringLevel",
 		name = "Anisotropic Filtering",
-		description = "Configures the anisotropic filtering level from 0 to 16x.",
+		description = "Configures whether mipmapping and anisotropic filtering should be used.<br>" +
+			"At zero, mipmapping is disabled and textures look the most pixelated.<br>" +
+			"At 1 through 16, mipmapping is enabled, and textures look more blurry and smoothed out.<br>" +
+			"The higher you go beyond 1, the less blurry textures will look, up to a certain extent.",
 		position = 4,
 		section = generalSettings
 	)

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -569,31 +569,36 @@ public interface HdPluginConfig extends Config
 	String experimentalSettings = "experimentalSettings";
 
 	@ConfigItem(
-			keyName = "enableModelCaching",
+		keyName = "enableModelBatching",
+		name = "Enable model batching",
+		description = "Model batching improves performance by reusing identical models within the same frame.<br>" +
+			"May cause instability and graphical bugs.",
+		position = 401,
+		section = experimentalSettings
+	)
+	default boolean enableModelBatching() { return false; }
+
+	String KEY_ENABLE_MODEL_CACHING = "enableModelCaching";
+	@ConfigItem(
+			keyName = KEY_ENABLE_MODEL_CACHING,
 			name = "Enable model caching",
-			description = "Model caching improves performance with increased memory usage. May cause instability or graphical bugs.",
-			position = 401,
+			description = "Model caching improves performance by saving and reusing model data from older frames.<br>" +
+				"May cause instability or graphical bugs.",
+			position = 402,
 			section = experimentalSettings
 	)
 	default boolean enableModelCaching() { return false; }
 
-	@ConfigItem(
-			keyName = "enableModelBatching",
-			name = "Enable model batching",
-			description = "Model batching generally improves performance but may cause instability and graphical bugs.",
-			position = 402,
-			section = experimentalSettings
-	)
-	default boolean enableModelBatching() { return false; }
-
+	String KEY_MODEL_CACHE_SIZE = "modelCacheSizeMiB";
 	@Range(
 			min = 256,
 			max = 16384
 	)
 	@ConfigItem(
-			keyName = "modelCacheSizeMiB",
+			keyName = KEY_MODEL_CACHE_SIZE,
 			name = "Model cache size (MiB)",
-			description = "Size of the model cache in mebibytes. Plugin must be restarted to apply changes. Min=256 Max=16384",
+			description = "Size of the model cache in mebibytes (slightly more than megabytes).<br>" +
+				"Minimum=256 MiB, maximum=16384 MiB",
 			position = 403,
 			section = experimentalSettings
 	)
@@ -604,7 +609,8 @@ public interface HdPluginConfig extends Config
 	@ConfigItem(
 			keyName = "loadingClearCache",
 			name = "Clear cache when loading",
-			description = "Clear the model cache whenever the game shows the \"loading please wait...\" message. This may improve performance when memory allocated to the cache is small.",
+			description = "Clear the model cache whenever the game loads a new scene.<br>" +
+				"This should generally only be used if the cache size is lower than 512 MiB.",
 			position = 404,
 			section = experimentalSettings
 	)

--- a/src/main/java/rs117/hd/model/BufferPool.java
+++ b/src/main/java/rs117/hd/model/BufferPool.java
@@ -21,7 +21,9 @@ public class BufferPool {
         try {
             // Try allocating the whole size as a single chunk
             allocateChunk(byteCapacity);
-        } catch (OutOfMemoryError err) {
+        } catch (Throwable err) {
+            // Largely unnecessary, but free the above allocation in case it failed while initializing buffer addresses
+            freeAllocations();
             log.warn("Unable to allocate {} bytes as a single chunk", byteCapacity, err);
 
             try {
@@ -32,7 +34,7 @@ public class BufferPool {
                     allocateChunk(chunkSize);
                     bytesRemaining -= chunkSize;
                 }
-            } catch (OutOfMemoryError err2) {
+            } catch (Throwable err2) {
                 log.error("Unable to allocate {} bytes in chunks of 1 GiB", byteCapacity, err2);
                 freeAllocations();
                 throw err2;

--- a/src/main/java/rs117/hd/model/BufferPool.java
+++ b/src/main/java/rs117/hd/model/BufferPool.java
@@ -51,7 +51,7 @@ public class BufferPool {
         allocationHandles.add(handle);
 
         for (long cursor = 0; chunkSize - cursor >= BUFFER_SIZE; cursor += BUFFER_SIZE) {
-            bufferAddressStack.push(cursor);
+            bufferAddressStack.push(handle + cursor);
         }
     }
 

--- a/src/main/java/rs117/hd/model/BufferPool.java
+++ b/src/main/java/rs117/hd/model/BufferPool.java
@@ -35,8 +35,8 @@ public class BufferPool {
                     bytesRemaining -= chunkSize;
                 }
             } catch (Throwable err2) {
-                log.error("Unable to allocate {} bytes in chunks of 1 GiB", byteCapacity, err2);
                 freeAllocations();
+                log.error("Unable to allocate {} bytes in chunks of 1 GiB", byteCapacity, err2);
                 throw err2;
             }
         }

--- a/src/main/java/rs117/hd/model/BufferPool.java
+++ b/src/main/java/rs117/hd/model/BufferPool.java
@@ -14,20 +14,21 @@ public class BufferPool {
     private final Stack<Long> bufferAddressStack;
     private final long byteCapacity;
     private boolean allocated;
-    private final HdPlugin hdPlugin;
+    private final HdPlugin plugin;
 
-    public BufferPool(long byteCapacity, HdPlugin hdPlugin) {
+    public BufferPool(long byteCapacity, HdPlugin plugin) {
         this.bufferAddressStack = new Stack<>();
         this.byteCapacity = byteCapacity;
         this.allocated = false;
-        this.hdPlugin = hdPlugin;
+        this.plugin = plugin;
+        allocate();
     }
 
     public boolean isEmpty() {
         return this.bufferAddressStack.isEmpty();
     }
 
-    public void allocate() {
+    private void allocate() {
         if (this.allocated) {
             return;
         }
@@ -43,8 +44,9 @@ public class BufferPool {
                 bytesRemaining -= allocationSize;
             }
         } catch (OutOfMemoryError oom) {
-            log.error("out of memory during initialization -- shutting down");
-            hdPlugin.stopPlugin();
+            log.error("Out of memory during initialization -- shutting down HD");
+            free();
+            plugin.stopPlugin();
         }
 
         this.allocated = true;

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -4,6 +4,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.kit.KitType;
+import net.runelite.client.callback.ClientThread;
 import rs117.hd.HdPlugin;
 import rs117.hd.HdPluginConfig;
 import rs117.hd.data.materials.Material;
@@ -42,6 +43,9 @@ public class ModelPusher {
     private Client client;
 
     @Inject
+    private ClientThread clientThread;
+
+    @Inject
     private ProceduralGenerator proceduralGenerator;
 
     @Inject
@@ -63,8 +67,8 @@ public class ModelPusher {
                 modelCache = new ModelCache(config.modelCacheSizeMiB());
             } catch (Throwable err) {
                 log.error("Error while initializing model cache. Stopping the plugin...", err);
-                plugin.stopPlugin();
                 // Allow the model pusher to be used until the plugin has cleanly shut down
+                clientThread.invokeLater(plugin::stopPlugin);
             }
         }
     }

--- a/src/main/java/rs117/hd/scene/SceneUploader.java
+++ b/src/main/java/rs117/hd/scene/SceneUploader.java
@@ -136,7 +136,8 @@ class SceneUploader
 		}
 		model.setSceneId(sceneId);
 
-		final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer, tileX, tileY, tileZ, modelOverride, objectType, true);
+		final int[] lengths = modelPusher.pushModel(hash, model, vertexBuffer, uvBuffer, normalBuffer,
+			tileX, tileY, tileZ, modelOverride, objectType, false);
 
 		offset += lengths[0];
 		uvOffset += lengths[1];


### PR DESCRIPTION
Apparently, memory is allocated for the model cache regardless of whether caching is enabled or not... :sweat_smile: This fixes that issue, and also makes model caching options apply when changed. Some config descriptions have also been updated.