### PR TITLE
Fix delayed scene reloading

### DIFF
--- a/src/main/java/rs117/hd/scene/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/scene/EnvironmentManager.java
@@ -167,7 +167,9 @@ public class EnvironmentManager
 				{
 					if (environment == Environment.PLAYER_OWNED_HOUSE || environment == Environment.PLAYER_OWNED_HOUSE_SNOWY) {
 						hdPlugin.setInHouse(true);
-						hdPlugin.setNextSceneReload(System.currentTimeMillis() + 2500);
+
+						// POH takes 1 game tick to enter, then 2 game ticks to load per floor
+						hdPlugin.reloadSceneAfter(7);
 					} else {
 						hdPlugin.setInHouse(false);
 					}

--- a/src/main/java/rs117/hd/scene/EnvironmentManager.java
+++ b/src/main/java/rs117/hd/scene/EnvironmentManager.java
@@ -169,7 +169,7 @@ public class EnvironmentManager
 						hdPlugin.setInHouse(true);
 
 						// POH takes 1 game tick to enter, then 2 game ticks to load per floor
-						hdPlugin.reloadSceneAfter(7);
+						hdPlugin.reloadSceneIn(7);
 					} else {
 						hdPlugin.setInHouse(false);
 					}

--- a/src/main/java/rs117/hd/scene/ModelOverrideManager.java
+++ b/src/main/java/rs117/hd/scene/ModelOverrideManager.java
@@ -7,11 +7,7 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.coords.WorldPoint;
 import rs117.hd.HdPlugin;
-import rs117.hd.data.materials.Material;
-import rs117.hd.data.materials.UvType;
-import rs117.hd.scene.model_overrides.InheritTileColorType;
 import rs117.hd.scene.model_overrides.ModelOverride;
-import rs117.hd.scene.model_overrides.TzHaarRecolorType;
 import rs117.hd.utils.AABB;
 import rs117.hd.utils.Env;
 import rs117.hd.utils.ModelHash;
@@ -55,7 +51,7 @@ public class ModelOverrideManager {
                         addEntry(ModelHash.packUuid(objectId, ModelHash.TYPE_OBJECT), entry);
                 }
                 if (client.getGameState() == GameState.LOGGED_IN)
-                    plugin.reloadScene();
+                    plugin.reloadSceneNextGameTick();
                 log.debug("Loaded {} model overrides", modelOverrides.size());
             } catch (IOException ex) {
                 log.error("Failed to load model overrides:", ex);


### PR DESCRIPTION
This fixes lag in The Gauntlet resulting from the scene being reloaded too early, and this makes the delayed POH reload more precise. The POH reload delay is however tuned for loading a POH with 3 floors that is not already loaded, so it may delay the scene reload too much for smaller POHs or POH instances that persist.