### PR TITLE
Use RuneLite's Gson instance as a base

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -26,7 +26,9 @@
 package rs117.hd;
 
 import com.google.common.primitives.Ints;
+import com.google.gson.Gson;
 import com.google.inject.Provides;
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
@@ -169,6 +171,11 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	@Inject
 	private DeveloperTools developerTools;
 	private ComputeMode computeMode = ComputeMode.OPENGL;
+
+	@Inject
+	private Gson rlGson;
+	@Getter
+	private Gson gson;
 
 	private Canvas canvas;
 	private AWTContext awtContext;
@@ -406,6 +413,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	@Override
 	protected void startUp()
 	{
+		gson = rlGson.newBuilder().setLenient().create();
+
 		configGroundTextures = config.groundTextures();
 		configGroundBlending = config.groundBlending();
 		configModelTextures = config.objectTextures();

--- a/src/main/java/rs117/hd/scene/LightManager.java
+++ b/src/main/java/rs117/hd/scene/LightManager.java
@@ -75,7 +75,7 @@ public class LightManager
 	private Client client;
 
 	@Inject
-	private HdPlugin hdPlugin;
+	private HdPlugin plugin;
 
 	@Inject
 	private EntityHiderPlugin entityHiderPlugin;
@@ -121,7 +121,7 @@ public class LightManager
 		{
 			Light[] lights;
 			try {
-				lights = path.loadJson(Light[].class);
+				lights = path.loadJson(plugin.getGson(), Light[].class);
 			} catch (IOException ex) {
 				log.error("Failed to load lights", ex);
 				return;
@@ -184,9 +184,9 @@ public class LightManager
 			loadSceneLights();
 		}
 
-		int camX = hdPlugin.camTarget[0];
-		int camY = hdPlugin.camTarget[1];
-		int camZ = hdPlugin.camTarget[2];
+		int camX = plugin.camTarget[0];
+		int camY = plugin.camTarget[1];
+		int camZ = plugin.camTarget[2];
 
 		Iterator<SceneLight> lightIterator = sceneLights.iterator();
 
@@ -419,7 +419,7 @@ public class LightManager
 			}
 		}
 
-		return hdPlugin.configNpcLights;
+		return plugin.configNpcLights;
 	}
 
 	public boolean projectileLightVisible()
@@ -433,7 +433,7 @@ public class LightManager
 			}
 		}
 
-		return hdPlugin.configProjectileLights;
+		return plugin.configProjectileLights;
 	}
 
 	public void reset()

--- a/src/main/java/rs117/hd/scene/ModelOverrideManager.java
+++ b/src/main/java/rs117/hd/scene/ModelOverrideManager.java
@@ -41,7 +41,7 @@ public class ModelOverrideManager {
             modelsToHide.clear();
 
             try {
-                ModelOverride[] entries = path.loadJson(ModelOverride[].class);
+                ModelOverride[] entries = path.loadJson(plugin.getGson(), ModelOverride[].class);
                 if (entries == null)
                     throw new IOException("Empty or invalid: " + path);
                 for (ModelOverride entry : entries) {

--- a/src/main/java/rs117/hd/utils/ResourcePath.java
+++ b/src/main/java/rs117/hd/utils/ResourcePath.java
@@ -60,7 +60,6 @@ import java.util.stream.Collectors;
 public class ResourcePath {
     public static ResourcePath RESOURCE_PATH = Env.getPathOrDefault("RLHD_RESOURCE_PATH", (ResourcePath) null);
 
-    private static final Gson GSON = new GsonBuilder().setLenient().create();
     private static final FileWatcher.UnregisterCallback NOOP = () -> {};
 
     @Nullable
@@ -293,9 +292,9 @@ public class ResourcePath {
         }
     }
 
-    public <T> T loadJson(Class<T> type) throws IOException {
+    public <T> T loadJson(Gson gson, Class<T> type) throws IOException {
         try (BufferedReader reader = toReader()) {
-            return GSON.fromJson(reader, type);
+            return gson.fromJson(reader, type);
         }
     }
 

--- a/src/test/java/rs117/hd/lighting/ReformatLightsJson.java
+++ b/src/test/java/rs117/hd/lighting/ReformatLightsJson.java
@@ -61,7 +61,8 @@ public class ReformatLightsJson
 			System.out.println("Loading current lights from JSON...");
 			// Load all lights from current lights.json
 			GsonUtils.THROW_WHEN_PARSING_FAILS = true;
-			Light[] currentLights = configPath.loadJson(Light[].class);
+			Gson gson = new GsonBuilder().setLenient().create();
+			Light[] currentLights = configPath.loadJson(gson, Light[].class);
 			Collections.addAll(uniqueLights, currentLights);
 			System.out.println("Loaded " + currentLights.length + " lights");
 		}


### PR DESCRIPTION
After https://github.com/runelite/plugin-hub/commit/78630b8, we can't create our own Gson instance statically in `ResourcePath`, so instead it's created in `HdPlugin` using RuneLite's Gson instance as a base. The reasoning behind creating it once in `HdPlugin` instead of everywhere on demand is that we probably want all of our configs to support commenting out portions for ease of development, plus we could add our own custom type adapters in one place if we want to at some point.