### PR TITLE
Preparation for water changes

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -38,8 +38,10 @@ import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
+import net.runelite.client.events.PluginChanged;
 import net.runelite.client.plugins.*;
 import net.runelite.client.plugins.entityhider.EntityHiderPlugin;
+import net.runelite.client.plugins.skybox.SkyboxPlugin;
 import net.runelite.client.ui.DrawManager;
 import net.runelite.client.util.OSType;
 import net.runelite.rlawt.AWTContext;
@@ -99,6 +101,7 @@ import static rs117.hd.utils.ResourcePath.path;
 	conflicts = "GPU"
 )
 @PluginDependency(EntityHiderPlugin.class)
+@PluginDependency(SkyboxPlugin.class)
 @Slf4j
 public class HdPlugin extends Plugin implements DrawCallbacks
 {
@@ -2185,6 +2188,13 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 		if (skyboxColorChanged) {
 			skyboxColorChanged = false;
 			environmentManager.updateSkyColor();
+		}
+	}
+
+	@Subscribe
+	public void onPluginChanged(PluginChanged event) {
+		if (event.getPlugin() instanceof SkyboxPlugin) {
+			skyboxColorChanged = true;
 		}
 	}
 

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -93,316 +93,15 @@ vec2 worldUvs(float scale) {
     return position.xz / 128. / scale;
 }
 
-void main() {
-    vec3 camPos = vec3(cameraX, cameraY, cameraZ);
-    vec3 downDir = normalize(vec3(0, -1.0, 0));
-    // View & light directions are from the fragment to the camera/light
-    vec3 viewDir = normalize(camPos - position);
-    vec3 lightDir = -lightDirection;
-
-    // material data
-    Material material1 = getMaterial(vMaterialData[0] >> MATERIAL_FLAG_BITS);
-    Material material2 = getMaterial(vMaterialData[1] >> MATERIAL_FLAG_BITS);
-    Material material3 = getMaterial(vMaterialData[2] >> MATERIAL_FLAG_BITS);
-
-    // water data
-    bool isTerrain = (vTerrainData[0] & 1) != 0; // 1 = 0b1
-    int waterDepth1 = vTerrainData[0] >> 8;
-    int waterDepth2 = vTerrainData[1] >> 8;
-    int waterDepth3 = vTerrainData[2] >> 8;
-    float waterDepth =
-        waterDepth1 * texBlend.x +
-        waterDepth2 * texBlend.y +
-        waterDepth3 * texBlend.z;
-    int waterTypeIndex = isTerrain ? vTerrainData[0] >> 3 & 0x1F : 0;
-    WaterType waterType = getWaterType(waterTypeIndex);
-
-    // set initial texture map ids
-    int colorMap1 = material1.colorMap;
-    int colorMap2 = material2.colorMap;
-    int colorMap3 = material3.colorMap;
-
-    // only use one flowMap map
-    int flowMap = material1.flowMap;
-
-    bool isUnderwater = waterDepth != 0;
-    bool isWater = waterTypeIndex > 0 && !isUnderwater;
-
-    if (isWater)
-    {
-        colorMap1 = waterType.normalMap; // wave normal map 1
-        colorMap2 = waterType.normalMap; // wave normal map 2
-        colorMap3 = waterType.foamMap; // foam diffuse map
-        flowMap = isUnderwater ? waterType.underwaterFlowMap : waterType.flowMap; // wave flow map
-    }
-
-    float alpha = 1;
-    vec4 fragColor = vColor[0] * texBlend.x + vColor[1] * texBlend.y + vColor[2] * texBlend.z;
-
-    // Source: https://www.geeks3d.com/20130122/normal-mapping-without-precomputed-tangent-space-vectors/
-    vec3 N = normalize(normals);
-    vec3 C1 = cross(vec3(0, 0, 1), N);
-    vec3 C2 = cross(vec3(0, 1, 0), N);
-    vec3 T = normalize(length(C1) > length(C2) ? C1 : C2);
-    vec3 B = normalize(cross(N, T));
-    mat3 TBN = mat3(T, B, N);
-
-    vec2 uv1 = getUvs(vUv[0], vMaterialData[0], position);
-    vec2 uv2 = getUvs(vUv[1], vMaterialData[1], position);
-    vec2 uv3 = getUvs(vUv[2], vMaterialData[2], position);
-    vec2 blendedUv = uv1 * texBlend.x + uv2 * texBlend.y + uv3 * texBlend.z;
-    uv1 = uv2 = uv3 = blendedUv;
-
-    // Scroll UVs
-    uv1 += material1.scrollDuration * elapsedTime;
-    uv2 += material2.scrollDuration * elapsedTime;
-    uv3 += material3.scrollDuration * elapsedTime;
-
-    // Scale from the center
-    uv1 = (uv1 - .5) / material1.textureScale + .5;
-    uv2 = (uv2 - .5) / material2.textureScale + .5;
-    uv3 = (uv3 - .5) / material3.textureScale + .5;
-
-    float selfShadowing = 0;
-    vec3 fragPos = position;
-    #if PARALLAX_MAPPING
-    mat3 invTBN = transpose(TBN);
-    vec3 tangentViewDir = invTBN * viewDir;
-    vec3 tangentLightDir = invTBN * lightDir;
-
-    vec2 fragDelta = vec2(0);
-
-    sampleDisplacementMap(material1, tangentViewDir, tangentLightDir, uv1, fragDelta, selfShadowing);
-    sampleDisplacementMap(material2, tangentViewDir, tangentLightDir, uv2, fragDelta, selfShadowing);
-    sampleDisplacementMap(material3, tangentViewDir, tangentLightDir, uv3, fragDelta, selfShadowing);
-
-    // Average
-    fragDelta /= 3;
-    selfShadowing /= 3;
-
-    fragPos += TBN * vec3(fragDelta, 0);
-    #endif
-
-    // water uvs
-    if (isWater)
-    {
-        uv1 = vec2(-worldUvs(5).x + animationFrame(31 * waterType.duration),
-        worldUvs(5).y + animationFrame(31 * waterType.duration));
-        uv2 = vec2(worldUvs(3).x - animationFrame(24 * waterType.duration),
-        worldUvs(3).y - animationFrame(24 * waterType.duration));
-    }
-
-    // get flowMap map
-    vec2 flowMapUv = uv1 - animationFrame(material1.flowMapDuration);
-    float flowMapStrength = material1.flowMapStrength;
-    if (isWater)
-    {
-        flowMapUv = worldUvs(15) + animationFrame(50 * waterType.duration);
-        flowMapStrength = 0.025;
-    }
-    if (isUnderwater)
-    {
-        flowMapUv = worldUvs(1.5) + animationFrame(10 * waterType.duration) * vec2(1, -1);
-        flowMapStrength = 0.075;
-    }
-
-    vec2 uvFlow = texture(textureArray, vec3(flowMapUv, flowMap)).xy;
-    uv1 += uvFlow * flowMapStrength;
-    uv2 += uvFlow * flowMapStrength;
-    uv3 += uvFlow * flowMapStrength;
-    if (isWater)
-    {
-        uv1 = vec2(worldUvs(2).y + animationFrame(20 * waterType.duration) + uvFlow.x * flowMapStrength,
-        worldUvs(2).x + animationFrame(20 * waterType.duration) + uvFlow.y * flowMapStrength);
-        uv1 = vec2(worldUvs(3).y - animationFrame(28 * waterType.duration) - uvFlow.x * flowMapStrength,
-        worldUvs(3).x + animationFrame(28 * waterType.duration) + uvFlow.y * flowMapStrength);
-    }
-
-    // get vertex colors
-    vec4 flatColor = vec4(0.5, 0.5, 0.5, 1.0);
-    vec4 baseColor1 = vColor[0];
-    vec4 baseColor2 = vColor[1];
-    vec4 baseColor3 = vColor[2];
-
-    // get diffuse textures
-    vec4 texColor1 = colorMap1 == -1 ? vec4(1) : texture(textureArray, vec3(uv1, colorMap1));
-    vec4 texColor2 = colorMap2 == -1 ? vec4(1) : texture(textureArray, vec3(uv2, colorMap2));
-    vec4 texColor3 = colorMap3 == -1 ? vec4(1) : texture(textureArray, vec3(uv3, colorMap3));
-
-    ivec3 isOverlay = isOverlay;
-    int overlayCount = isOverlay[0] + isOverlay[1] + isOverlay[2];
-    ivec3 isUnderlay = ivec3(1) - isOverlay;
-    int underlayCount = isUnderlay[0] + isUnderlay[1] + isUnderlay[2];
-
-    // calculate blend amounts for overlay and underlay vertices
-    vec3 underlayBlend = texBlend * isUnderlay;
-    vec3 overlayBlend = texBlend * isOverlay;
-
-    if (underlayCount == 0 || overlayCount == 0)
-    {
-        // if a tile has all overlay or underlay vertices,
-        // use the default blend
-
-        underlayBlend = texBlend;
-        overlayBlend = texBlend;
-    }
-    else
-    {
-        // if there's a mix of overlay and underlay vertices,
-        // calculate custom blends for each 'layer'
-
-        float underlayBlendMultiplier = 1.0 / (underlayBlend[0] + underlayBlend[1] + underlayBlend[2]);
-        // adjust back to 1.0 total
-        underlayBlend *= underlayBlendMultiplier;
-
-        float overlayBlendMultiplier = 1.0 / (overlayBlend[0] + overlayBlend[1] + overlayBlend[2]);
-        // adjust back to 1.0 total
-        overlayBlend *= overlayBlendMultiplier;
-    }
-
-
-    // get fragment colors by combining vertex colors and texture samples
-    vec4 texA = material1.overrideBaseColor ? texColor1 : vec4(texColor1.rgb * baseColor1.rgb, min(texColor1.a, baseColor1.a));
-    vec4 texB = material2.overrideBaseColor ? texColor2 : vec4(texColor2.rgb * baseColor2.rgb, min(texColor2.a, baseColor2.a));
-    vec4 texC = material3.overrideBaseColor ? texColor3 : vec4(texColor3.rgb * baseColor3.rgb, min(texColor3.a, baseColor3.a));
-
-    // combine fragment colors based on each blend, creating
-    // one color for each overlay/underlay 'layer'
-    vec4 underlayColor = texA * underlayBlend.x + texB * underlayBlend.y + texC * underlayBlend.z;
-    vec4 overlayColor = texA * overlayBlend.x + texB * overlayBlend.y + texC * overlayBlend.z;
-
-    float overlayMix = 0;
-
-    if (overlayCount == 0 || overlayCount == 3)
-    {
-        overlayMix = 0;
-    }
-    else
-    {
-        // custom blending logic for blending overlays into underlays
-        // in a style similar to 2008+ HD
-
-        // fragment UV
-        vec2 fragUv = blendedUv;
-        // standalone UV
-        // e.g. if there are 2 overlays and 1 underlay, the underlay is the standalone
-        vec2 uvA = vec2(-999);
-        // opposite UV A
-        vec2 uvB = vec2(-999);
-        // opposite UV B
-        vec2 uvC = vec2(-999);
-        bool inverted = false;
-
-        // assign standalone UV to uvA and others to uvB, uvC
-        for (int i = 0; i < 3; i++)
-        {
-            vec2 uv = vUv[0].xy;
-
-            if (i == 1)
-            {
-                uv = vUv[1].xy;
-            }
-            else if (i == 2)
-            {
-                uv = vUv[2].xy;
-            }
-
-            if ((isOverlay[i] == 1 && overlayCount == 1) || (isUnderlay[i] == 1 && underlayCount == 1))
-            {
-                // assign standalone vertex UV to uvA
-                uvA = uv;
-
-                if (overlayCount == 1)
-                {
-                    // we use this at the end of this logic to invert
-                    // the result if there's 1 overlay, 2 underlay
-                    // vs the default result from 1 underlay, 2 overlay
-                    inverted = true;
-                }
-            }
-            else
-            {
-                // assign opposite vertex UV to uvB or uvC
-                if (uvB == vec2(-999))
-                {
-                    uvB = uv;
-                }
-                else
-                {
-                    uvC = uv;
-                }
-            }
-        }
-
-        // point on side perpendicular to uvA
-        vec2 oppositePoint = uvB + pointToLine(uvB, uvC, uvA) * (uvC - uvB);
-
-        // calculate position of fragment's UV relative to
-        // line between uvA and oppositePoint
-        float result = pointToLine(uvA, oppositePoint, fragUv);
-
-        if (inverted)
-        {
-            result = 1 - result;
-        }
-
-        result = clamp(result, 0, 1);
-
-        float distance = distance(uvA, oppositePoint);
-
-        float cutoff = 0.5;
-
-        result = (result - (1.0 - cutoff)) * (1.0 / cutoff);
-        result = clamp(result, 0, 1);
-
-        float maxDistance = 2.5;
-        if (distance > maxDistance)
-        {
-            float multi = distance / maxDistance;
-            result = 1.0 - ((1.0 - result) * multi);
-            result = clamp(result, 0, 1);
-        }
-
-        overlayMix = result;
-    }
-
-    vec4 texColor = mix(underlayColor, overlayColor, overlayMix);
-    alpha = texColor.a;
-
-    // normals
-    vec3 normals = normals;
-
-    if (isWater)
-    {
-        vec3 n1 = -vec3((texColor1.x * 2 - 1) * waterType.normalStrength, texColor1.z, (texColor1.y * 2 - 1) * waterType.normalStrength);
-        vec3 n2 = -vec3((texColor2.x * 2 - 1) * waterType.normalStrength, texColor2.z, (texColor2.y * 2 - 1) * waterType.normalStrength);
-        normals = n1 + n2;
-    }
-    else
-    {
-        vec3 n1 = sampleNormalMap(material1, uv1, normals, TBN);
-        vec3 n2 = sampleNormalMap(material2, uv2, normals, TBN);
-        vec3 n3 = sampleNormalMap(material3, uv3, normals, TBN);
-        normals = (n1 + n2 + n3) / 3;
-    }
-    normals = normalize(normals);
-
-
-    float lightDotNormals = dot(normals, lightDir);
-    float downDotNormals = dot(downDir, normals);
-    float viewDotNormals = dot(viewDir, normals);
-
-
+float sampleShadowMap(vec3 fragPos, int waterTypeIndex, vec2 distortion, float lightDotNormals) {
     // sample shadow map
     float shadow = 0.0;
     if (shadowsEnabled == 1)
     {
         vec4 shadowPos = lightProjectionMatrix * vec4(fragPos, 1);
         vec3 projCoords = shadowPos.xyz / shadowPos.w * 0.5 + 0.5;
-        if (isWater || isUnderwater)
-        {
-            projCoords += vec3(uvFlow * 0.00075, 0.0);
-        }
+        projCoords.xy += distortion;
+
         float currentDepth = projCoords.z;
         float shadowMinBias = 0.0005f;
         float shadowBias = max(shadowMaxBias * (1.0 - lightDotNormals), shadowMinBias);
@@ -444,24 +143,440 @@ void main() {
         shadow = projCoords.z > 1.0 ? 0.0 : shadow;
     }
 
-    shadow = max(shadow, selfShadowing);
-    float inverseShadow = 1.0 - shadow;
+    return shadow;
+}
+
+void main() {
+    vec3 camPos = vec3(cameraX, cameraY, cameraZ);
+    vec3 downDir = normalize(vec3(0, -1.0, 0));
+    // View & light directions are from the fragment to the camera/light
+    vec3 viewDir = normalize(camPos - position);
+    vec3 lightDir = -lightDirection;
+
+    // material data
+    Material material1 = getMaterial(vMaterialData[0] >> MATERIAL_FLAG_BITS);
+    Material material2 = getMaterial(vMaterialData[1] >> MATERIAL_FLAG_BITS);
+    Material material3 = getMaterial(vMaterialData[2] >> MATERIAL_FLAG_BITS);
+
+    // water data
+    bool isTerrain = (vTerrainData[0] & 1) != 0; // 1 = 0b1
+    int waterDepth1 = vTerrainData[0] >> 8;
+    int waterDepth2 = vTerrainData[1] >> 8;
+    int waterDepth3 = vTerrainData[2] >> 8;
+    float waterDepth =
+        waterDepth1 * texBlend.x +
+        waterDepth2 * texBlend.y +
+        waterDepth3 * texBlend.z;
+    int waterTypeIndex = isTerrain ? vTerrainData[0] >> 3 & 0x1F : 0;
+    WaterType waterType = getWaterType(waterTypeIndex);
+
+    // set initial texture map ids
+    int colorMap1 = material1.colorMap;
+    int colorMap2 = material2.colorMap;
+    int colorMap3 = material3.colorMap;
+
+    // only use one flowMap map
+    int flowMap = material1.flowMap;
+
+    bool isUnderwater = waterDepth != 0;
+    bool isWater = waterTypeIndex > 0 && !isUnderwater;
+
+    vec4 fragColor = vColor[0] * texBlend.x + vColor[1] * texBlend.y + vColor[2] * texBlend.z;
+    vec4 outputColor = vec4(1);
+
+    if (isWater) {
+        vec2 baseUv = vUv[0].xy * texBlend.x + vUv[1].xy * texBlend.y + vUv[2].xy * texBlend.z;
+        vec2 uv2, uv3;
+        uv2 = uv3 = baseUv;
+
+        uv2 = vec2(
+            worldUvs(3).x - animationFrame(24 * waterType.duration),
+            worldUvs(3).y - animationFrame(24 * waterType.duration)
+        );
+
+        vec2 flowMapUv = worldUvs(15) + animationFrame(50 * waterType.duration);
+        float flowMapStrength = 0.025;
+
+        vec2 uvFlow = texture(textureArray, vec3(flowMapUv, waterType.flowMap)).xy;
+        uv2 += uvFlow * flowMapStrength;
+        uv3 += uvFlow * flowMapStrength;
+
+//        uv1 = vec2(
+//            worldUvs(2).y + animationFrame(20 * waterType.duration) + uvFlow.x * flowMapStrength,
+//            worldUvs(2).x + animationFrame(20 * waterType.duration) + uvFlow.y * flowMapStrength
+//        );
+        // TODO: this looks like a bug. Was probably intended to be uv2?
+        vec2 uv1 = vec2(
+            worldUvs(3).y - animationFrame(28 * waterType.duration) - uvFlow.x * flowMapStrength,
+            worldUvs(3).x + animationFrame(28 * waterType.duration) + uvFlow.y * flowMapStrength
+        );
+
+        // get diffuse textures
+        vec3 n1 = texture(textureArray, vec3(uv1, waterType.normalMap)).xyz;
+        vec3 n2 = texture(textureArray, vec3(uv2, waterType.normalMap)).xyz;
+        float foamMask = texture(textureArray, vec3(uv3, waterType.foamMap)).r;
+
+        // normals
+        vec3 normals = normals;
+        n1 = -vec3((n1.x * 2 - 1) * waterType.normalStrength, n1.z, (n1.y * 2 - 1) * waterType.normalStrength);
+        n2 = -vec3((n2.x * 2 - 1) * waterType.normalStrength, n2.z, (n2.y * 2 - 1) * waterType.normalStrength);
+        normals = n1 + n2;
+        normals = normalize(normals);
+
+        float lightDotNormals = dot(normals, lightDir);
+        float downDotNormals = dot(downDir, normals);
+        float viewDotNormals = dot(viewDir, normals);
+
+        vec2 distortion = uvFlow * .00075;
+        float shadow = sampleShadowMap(position, waterTypeIndex, distortion, lightDotNormals);
+        float inverseShadow = 1 - shadow;
+
+        vec3 vSpecularStrength = vec3(waterType.specularStrength);
+        vec3 vSpecularGloss = vec3(waterType.specularGloss);
+        float combinedSpecularStrength = waterType.specularStrength;
+
+        // calculate lighting
+
+        // ambient light
+        vec3 ambientLightOut = ambientColor * ambientStrength;
+
+        ambientLightOut *= (
+            (material1.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv1, material1.ambientOcclusionMap)).r) +
+            (material2.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv2, material2.ambientOcclusionMap)).r) +
+            (material3.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv3, material3.ambientOcclusionMap)).r)
+        ) / 3;
+
+        // directional light
+        vec3 dirLightColor = lightColor * lightStrength;
+
+        // apply shadows
+        dirLightColor *= inverseShadow;
+
+        vec3 lightColor = dirLightColor;
+        vec3 lightOut = max(lightDotNormals, 0.0) * lightColor;
+
+        // directional light specular
+        vec3 lightReflectDir = reflect(lightDirection, normals);
+        vec3 lightSpecularOut = specular(viewDir, lightReflectDir, vSpecularGloss, vSpecularStrength, lightColor, lightStrength).rgb;
+
+        // point lights
+        vec3 pointLightsOut = vec3(0);
+        vec3 pointLightsSpecularOut = vec3(0);
+        for (int i = 0; i < pointLightsCount; i++)
+        {
+            vec3 pointLightPos = vec3(PointLightArray[i].position.x, PointLightArray[i].position.z, PointLightArray[i].position.y);
+            float pointLightStrength = PointLightArray[i].strength;
+            vec3 pointLightColor = PointLightArray[i].color * pointLightStrength;
+            float pointLightSize = PointLightArray[i].size;
+            float distanceToLightSource = length(pointLightPos - position);
+            vec3 pointLightDir = normalize(pointLightPos - position);
+
+            if (distanceToLightSource <= pointLightSize)
+            {
+                float pointLightDotNormals = dot(normals, pointLightDir);
+                vec3 pointLightOut = pointLightColor * max(pointLightDotNormals, 0.0);
+
+                float attenuation = pow(clamp(1 - (distanceToLightSource / pointLightSize), 0.0, 1.0), 2.0);
+                pointLightOut *= attenuation;
+
+                pointLightsOut += pointLightOut;
+
+                vec3 pointLightReflectDir = reflect(-pointLightDir, normals);
+                vec4 spec = specular(viewDir, pointLightReflectDir, vSpecularGloss, vSpecularStrength, pointLightColor, pointLightStrength) * attenuation;
+                pointLightsSpecularOut += spec.rgb;
+            }
+        }
+
+
+        // sky light
+        vec3 skyLightColor = fogColor.rgb;
+        float skyLightStrength = 0.5;
+        float skyDotNormals = downDotNormals;
+        vec3 skyLightOut = max(skyDotNormals, 0.0) * skyLightColor * skyLightStrength;
+
+
+        // lightning
+        vec3 lightningColor = vec3(1.0, 1.0, 1.0);
+        float lightningStrength = lightningBrightness;
+        float lightningDotNormals = downDotNormals;
+        vec3 lightningOut = max(lightningDotNormals, 0.0) * lightningColor * lightningStrength;
+
+
+        // underglow
+        vec3 underglowOut = underglowColor * max(normals.y, 0) * underglowStrength;
+
+
+        // fresnel reflection
+        float baseOpacity = 0.4;
+        float fresnel = 1.0 - clamp(viewDotNormals, 0.0, 1.0);
+        float finalFresnel = clamp(mix(baseOpacity, 1.0, fresnel * 1.2), 0.0, 1.0);
+        vec3 surfaceColor = vec3(0);
+
+        // add sky gradient
+        if (finalFresnel < 0.5) {
+            surfaceColor = mix(waterColorDark, waterColorMid, finalFresnel * 2);
+        } else {
+            surfaceColor = mix(waterColorMid, waterColorLight, (finalFresnel - 0.5) * 2);
+        }
+
+        vec3 surfaceColorOut = surfaceColor * max(combinedSpecularStrength, 0.2);
+
+
+        // apply lighting
+        vec3 compositeLight = ambientLightOut + lightOut + lightSpecularOut + skyLightOut + lightningOut +
+        underglowOut + pointLightsOut + pointLightsSpecularOut + surfaceColorOut;
+
+        vec3 baseColor = waterType.surfaceColor * compositeLight;
+        baseColor = mix(baseColor, surfaceColor, waterType.fresnelAmount);
+        float shadowDarken = 0.15;
+        baseColor *= (1.0 - shadowDarken) + inverseShadow * shadowDarken;
+        float maxFoamAmount = 0.8;
+        float foamAmount = min(1.0 - fragColor.r, maxFoamAmount);
+        float foamDistance = 0.7;
+        vec3 foamColor = waterType.foamColor;
+        foamColor = foamColor * foamMask * compositeLight;
+        foamAmount = clamp(pow(1.0 - ((1.0 - foamAmount) / foamDistance), 3), 0.0, 1.0) * waterType.hasFoam;
+        foamAmount *= foamColor.r;
+        baseColor = mix(baseColor, foamColor, foamAmount);
+        vec3 specularComposite = mix(lightSpecularOut, vec3(0.0), foamAmount);
+        float flatFresnel = (1.0 - dot(viewDir, downDir)) * 1.0;
+        finalFresnel = max(finalFresnel, flatFresnel);
+        finalFresnel -= finalFresnel * shadow * 0.2;
+        baseColor += pointLightsSpecularOut + lightSpecularOut / 3;
+        outputColor.a = max(waterType.baseOpacity, max(foamAmount, max(finalFresnel, length(specularComposite / 3))));
+        outputColor.rgb = baseColor;
+    } else {
+        // Source: https://www.geeks3d.com/20130122/normal-mapping-without-precomputed-tangent-space-vectors/
+        vec3 N = normalize(normals);
+        vec3 C1 = cross(vec3(0, 0, 1), N);
+        vec3 C2 = cross(vec3(0, 1, 0), N);
+        vec3 T = normalize(length(C1) > length(C2) ? C1 : C2);
+        vec3 B = normalize(cross(N, T));
+        mat3 TBN = mat3(T, B, N);
+
+        // TODO: blended UV should probably be computed before getUvs
+        vec2 uv1 = getUvs(vUv[0], vMaterialData[0], position);
+        vec2 uv2 = getUvs(vUv[1], vMaterialData[1], position);
+        vec2 uv3 = getUvs(vUv[2], vMaterialData[2], position);
+        vec2 blendedUv = uv1 * texBlend.x + uv2 * texBlend.y + uv3 * texBlend.z;
+        uv1 = uv2 = uv3 = blendedUv;
+
+        // Scroll UVs
+        uv1 += material1.scrollDuration * elapsedTime;
+        uv2 += material2.scrollDuration * elapsedTime;
+        uv3 += material3.scrollDuration * elapsedTime;
+
+        // Scale from the center
+        uv1 = (uv1 - .5) / material1.textureScale + .5;
+        uv2 = (uv2 - .5) / material2.textureScale + .5;
+        uv3 = (uv3 - .5) / material3.textureScale + .5;
+
+        float selfShadowing = 0;
+        vec3 fragPos = position;
+        #if PARALLAX_MAPPING
+        mat3 invTBN = transpose(TBN);
+        vec3 tangentViewDir = invTBN * viewDir;
+        vec3 tangentLightDir = invTBN * lightDir;
+
+        vec2 fragDelta = vec2(0);
+
+        sampleDisplacementMap(material1, tangentViewDir, tangentLightDir, uv1, fragDelta, selfShadowing);
+        sampleDisplacementMap(material2, tangentViewDir, tangentLightDir, uv2, fragDelta, selfShadowing);
+        sampleDisplacementMap(material3, tangentViewDir, tangentLightDir, uv3, fragDelta, selfShadowing);
+
+        // Average
+        fragDelta /= 3;
+        selfShadowing /= 3;
+
+        fragPos += TBN * vec3(fragDelta, 0);
+        #endif
+
+        // get flowMap map
+        vec2 flowMapUv = uv1 - animationFrame(material1.flowMapDuration);
+        float flowMapStrength = material1.flowMapStrength;
+        if (isUnderwater)
+        {
+            flowMapUv = worldUvs(1.5) + animationFrame(10 * waterType.duration) * vec2(1, -1);
+            flowMapStrength = 0.075;
+        }
+
+        vec2 uvFlow = texture(textureArray, vec3(flowMapUv, flowMap)).xy;
+        uv1 += uvFlow * flowMapStrength;
+        uv2 += uvFlow * flowMapStrength;
+        uv3 += uvFlow * flowMapStrength;
+
+        // get vertex colors
+        vec4 flatColor = vec4(0.5, 0.5, 0.5, 1.0);
+        vec4 baseColor1 = vColor[0];
+        vec4 baseColor2 = vColor[1];
+        vec4 baseColor3 = vColor[2];
+
+        // get diffuse textures
+        vec4 texColor1 = colorMap1 == -1 ? vec4(1) : texture(textureArray, vec3(uv1, colorMap1));
+        vec4 texColor2 = colorMap2 == -1 ? vec4(1) : texture(textureArray, vec3(uv2, colorMap2));
+        vec4 texColor3 = colorMap3 == -1 ? vec4(1) : texture(textureArray, vec3(uv3, colorMap3));
+
+        ivec3 isOverlay = isOverlay;
+        int overlayCount = isOverlay[0] + isOverlay[1] + isOverlay[2];
+        ivec3 isUnderlay = ivec3(1) - isOverlay;
+        int underlayCount = isUnderlay[0] + isUnderlay[1] + isUnderlay[2];
+
+        // calculate blend amounts for overlay and underlay vertices
+        vec3 underlayBlend = texBlend * isUnderlay;
+        vec3 overlayBlend = texBlend * isOverlay;
+
+        if (underlayCount == 0 || overlayCount == 0)
+        {
+            // if a tile has all overlay or underlay vertices,
+            // use the default blend
+
+            underlayBlend = texBlend;
+            overlayBlend = texBlend;
+        }
+        else
+        {
+            // if there's a mix of overlay and underlay vertices,
+            // calculate custom blends for each 'layer'
+
+            float underlayBlendMultiplier = 1.0 / (underlayBlend[0] + underlayBlend[1] + underlayBlend[2]);
+            // adjust back to 1.0 total
+            underlayBlend *= underlayBlendMultiplier;
+
+            float overlayBlendMultiplier = 1.0 / (overlayBlend[0] + overlayBlend[1] + overlayBlend[2]);
+            // adjust back to 1.0 total
+            overlayBlend *= overlayBlendMultiplier;
+        }
+
+
+        // get fragment colors by combining vertex colors and texture samples
+        vec4 texA = material1.overrideBaseColor ? texColor1 : vec4(texColor1.rgb * baseColor1.rgb, min(texColor1.a, baseColor1.a));
+        vec4 texB = material2.overrideBaseColor ? texColor2 : vec4(texColor2.rgb * baseColor2.rgb, min(texColor2.a, baseColor2.a));
+        vec4 texC = material3.overrideBaseColor ? texColor3 : vec4(texColor3.rgb * baseColor3.rgb, min(texColor3.a, baseColor3.a));
+
+        // combine fragment colors based on each blend, creating
+        // one color for each overlay/underlay 'layer'
+        vec4 underlayColor = texA * underlayBlend.x + texB * underlayBlend.y + texC * underlayBlend.z;
+        vec4 overlayColor = texA * overlayBlend.x + texB * overlayBlend.y + texC * overlayBlend.z;
+
+        float overlayMix = 0;
+
+        if (overlayCount == 0 || overlayCount == 3)
+        {
+            overlayMix = 0;
+        }
+        else
+        {
+            // custom blending logic for blending overlays into underlays
+            // in a style similar to 2008+ HD
+
+            // fragment UV
+            vec2 fragUv = blendedUv;
+            // standalone UV
+            // e.g. if there are 2 overlays and 1 underlay, the underlay is the standalone
+            vec2 uvA = vec2(-999);
+            // opposite UV A
+            vec2 uvB = vec2(-999);
+            // opposite UV B
+            vec2 uvC = vec2(-999);
+            bool inverted = false;
+
+            // assign standalone UV to uvA and others to uvB, uvC
+            for (int i = 0; i < 3; i++)
+            {
+                vec2 uv = vUv[0].xy;
+
+                if (i == 1)
+                {
+                    uv = vUv[1].xy;
+                }
+                else if (i == 2)
+                {
+                    uv = vUv[2].xy;
+                }
+
+                if ((isOverlay[i] == 1 && overlayCount == 1) || (isUnderlay[i] == 1 && underlayCount == 1))
+                {
+                    // assign standalone vertex UV to uvA
+                    uvA = uv;
+
+                    if (overlayCount == 1)
+                    {
+                        // we use this at the end of this logic to invert
+                        // the result if there's 1 overlay, 2 underlay
+                        // vs the default result from 1 underlay, 2 overlay
+                        inverted = true;
+                    }
+                }
+                else
+                {
+                    // assign opposite vertex UV to uvB or uvC
+                    if (uvB == vec2(-999))
+                    {
+                        uvB = uv;
+                    }
+                    else
+                    {
+                        uvC = uv;
+                    }
+                }
+            }
+
+            // point on side perpendicular to uvA
+            vec2 oppositePoint = uvB + pointToLine(uvB, uvC, uvA) * (uvC - uvB);
+
+            // calculate position of fragment's UV relative to
+            // line between uvA and oppositePoint
+            float result = pointToLine(uvA, oppositePoint, fragUv);
+
+            if (inverted)
+            {
+                result = 1 - result;
+            }
+
+            result = clamp(result, 0, 1);
+
+            float distance = distance(uvA, oppositePoint);
+
+            float cutoff = 0.5;
+
+            result = (result - (1.0 - cutoff)) * (1.0 / cutoff);
+            result = clamp(result, 0, 1);
+
+            float maxDistance = 2.5;
+            if (distance > maxDistance)
+            {
+                float multi = distance / maxDistance;
+                result = 1.0 - ((1.0 - result) * multi);
+                result = clamp(result, 0, 1);
+            }
+
+            overlayMix = result;
+        }
+
+        outputColor = mix(underlayColor, overlayColor, overlayMix);
+
+        // normals
+        vec3 normals = normals;
+
+        vec3 n1 = sampleNormalMap(material1, uv1, normals, TBN);
+        vec3 n2 = sampleNormalMap(material2, uv2, normals, TBN);
+        vec3 n3 = sampleNormalMap(material3, uv3, normals, TBN);
+        normals = normalize((n1 + n2 + n3) / 3);
+
+        float lightDotNormals = dot(normals, lightDir);
+        float downDotNormals = dot(downDir, normals);
+        float viewDotNormals = dot(viewDir, normals);
+
+
+        float shadow = sampleShadowMap(fragPos, waterTypeIndex, vec2(0), lightDotNormals);
+        shadow = max(shadow, selfShadowing);
+        float inverseShadow = 1 - shadow;
 
 
 
-    // specular
-    vec3 vSpecularGloss, vSpecularStrength;
-    float combinedSpecularStrength;
-    if (isWater)
-    {
-        vSpecularStrength = vec3(waterType.specularStrength);
-        vSpecularGloss = vec3(waterType.specularGloss);
-        combinedSpecularStrength = waterType.specularStrength;
-    }
-    else
-    {
-        vSpecularGloss = vec3(material1.specularGloss, material2.specularGloss, material3.specularGloss);
-        vSpecularStrength = vec3(material1.specularStrength, material2.specularStrength, material3.specularStrength);
+        // specular
+        vec3 vSpecularGloss = vec3(material1.specularGloss, material2.specularGloss, material3.specularGloss);
+        vec3 vSpecularStrength = vec3(material1.specularStrength, material2.specularStrength, material3.specularStrength);
         vSpecularStrength *= vec3(
             material1.roughnessMap == -1 ? 1 : linearToSrgb(texture(textureArray, vec3(uv1, material1.roughnessMap)).r),
             material2.roughnessMap == -1 ? 1 : linearToSrgb(texture(textureArray, vec3(uv2, material2.roughnessMap)).r),
@@ -479,212 +594,174 @@ void main() {
                 clamp((1 - baseColor3.a) * 2, 0, 1)
             );
         }
-        combinedSpecularStrength = dot(vSpecularStrength, texBlend);
-    }
+        float combinedSpecularStrength = dot(vSpecularStrength, texBlend);
 
 
-    // calculate lighting
+        // calculate lighting
 
-    // ambient light
-    vec3 ambientLightOut = ambientColor * ambientStrength;
+        // ambient light
+        vec3 ambientLightOut = ambientColor * ambientStrength;
 
-    ambientLightOut *= (
-        (material1.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv1, material1.ambientOcclusionMap)).r) +
-        (material2.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv2, material2.ambientOcclusionMap)).r) +
-        (material3.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv3, material3.ambientOcclusionMap)).r)
-    ) / 3;
+        ambientLightOut *= (
+            (material1.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv1, material1.ambientOcclusionMap)).r) +
+            (material2.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv2, material2.ambientOcclusionMap)).r) +
+            (material3.ambientOcclusionMap == -1 ? 1 : texture(textureArray, vec3(uv3, material3.ambientOcclusionMap)).r)
+        ) / 3;
 
-    // directional light
-    vec3 dirLightColor = lightColor * lightStrength;
+        // directional light
+        vec3 dirLightColor = lightColor * lightStrength;
 
-    // underwater caustics based on directional light
-    if (underwaterCaustics && underwaterEnvironment) {
-        float scale = 12.8;
-        vec2 causticsUv = worldUvs(scale);
-
-        // height offset
-        causticsUv += lightDir.xy * position.y / (128 * scale);
-
-        const ivec2 direction = ivec2(1, -1);
-        const int driftSpeed = 231;
-        vec2 drift = animationFrame(231) * ivec2(1, -2);
-        vec2 flow1 = causticsUv + animationFrame(19) * direction + drift;
-        vec2 flow2 = causticsUv * 1.25 + animationFrame(37) * -direction + drift;
-
-        vec3 caustics = sampleCaustics(flow1, flow2) * 2;
-
-        vec3 causticsColor = underwaterCausticsColor * underwaterCausticsStrength;
-        dirLightColor += caustics * causticsColor * lightDotNormals * pow(lightStrength, 1.5);
-    }
-
-    // apply shadows
-    dirLightColor *= inverseShadow;
-
-    vec3 lightColor = dirLightColor;
-    vec3 lightOut = max(lightDotNormals, 0.0) * lightColor;
-
-    // directional light specular
-    vec3 lightReflectDir = reflect(lightDirection, normals);
-    vec3 lightSpecularOut = specular(viewDir, lightReflectDir, vSpecularGloss, vSpecularStrength, lightColor, lightStrength).rgb;
-
-    // point lights
-    vec3 pointLightsOut = vec3(0);
-    vec3 pointLightsSpecularOut = vec3(0);
-    for (int i = 0; i < pointLightsCount; i++)
-    {
-        vec3 pointLightPos = vec3(PointLightArray[i].position.x, PointLightArray[i].position.z, PointLightArray[i].position.y);
-        float pointLightStrength = PointLightArray[i].strength;
-        vec3 pointLightColor = PointLightArray[i].color * pointLightStrength;
-        float pointLightSize = PointLightArray[i].size;
-        float distanceToLightSource = length(pointLightPos - position);
-        vec3 pointLightDir = normalize(pointLightPos - position);
-
-        if (distanceToLightSource <= pointLightSize)
-        {
-            float pointLightDotNormals = dot(normals, pointLightDir);
-            vec3 pointLightOut = pointLightColor * max(pointLightDotNormals, 0.0);
-
-            float attenuation = pow(clamp(1 - (distanceToLightSource / pointLightSize), 0.0, 1.0), 2.0);
-            pointLightOut *= attenuation;
-
-            pointLightsOut += pointLightOut;
-
-            vec3 pointLightReflectDir = reflect(-pointLightDir, normals);
-            vec4 spec = specular(viewDir, pointLightReflectDir, vSpecularGloss, vSpecularStrength, pointLightColor, pointLightStrength) * attenuation;
-            pointLightsSpecularOut += spec.rgb;
-        }
-    }
-
-
-    // sky light
-    vec3 skyLightColor = fogColor.rgb;
-    float skyLightStrength = 0.5;
-    float skyDotNormals = downDotNormals;
-    vec3 skyLightOut = max(skyDotNormals, 0.0) * skyLightColor * skyLightStrength;
-
-
-    // lightning
-    vec3 lightningColor = vec3(1.0, 1.0, 1.0);
-    float lightningStrength = lightningBrightness;
-    float lightningDotNormals = downDotNormals;
-    vec3 lightningOut = max(lightningDotNormals, 0.0) * lightningColor * lightningStrength;
-
-
-    // underglow
-    vec3 underglowOut = underglowColor * max(normals.y, 0) * underglowStrength;
-
-
-    // fresnel reflection
-    float baseOpacity = 0.4;
-    float fresnel = 1.0 - clamp(viewDotNormals, 0.0, 1.0);
-    float finalFresnel = clamp(mix(baseOpacity, 1.0, fresnel * 1.2), 0.0, 1.0);
-    vec3 surfaceColor = vec3(0);
-    if (isWater)
-    {
-        // add sky gradient
-        if (finalFresnel < 0.5)
-        {
-            surfaceColor = mix(waterColorDark, waterColorMid, finalFresnel * 2);
-        }
-        else
-        {
-            surfaceColor = mix(waterColorMid, waterColorLight, (finalFresnel - 0.5) * 2);
-        }
-    }
-    vec3 surfaceColorOut = surfaceColor * max(combinedSpecularStrength, 0.2);
-
-
-    // apply lighting
-    vec3 compositeLight = ambientLightOut + lightOut + lightSpecularOut + skyLightOut + lightningOut +
-        underglowOut + pointLightsOut + pointLightsSpecularOut + surfaceColorOut;
-
-    vec3 compositeColor = texColor.rgb;
-
-    if (isWater)
-    {
-        vec3 baseColor = waterType.surfaceColor * compositeLight;
-        baseColor = mix(baseColor, surfaceColor, waterType.fresnelAmount);
-        float shadowDarken = 0.15;
-        baseColor *= (1.0 - shadowDarken) + inverseShadow * shadowDarken;
-        float maxFoamAmount = 0.8;
-        float foamAmount = min(1.0 - fragColor.r, maxFoamAmount);
-        float foamDistance = 0.7;
-        vec3 foamColor = waterType.foamColor;
-        foamColor = foamColor * texColor3.rgb * compositeLight;
-        foamAmount = clamp(pow(1.0 - ((1.0 - foamAmount) / foamDistance), 3), 0.0, 1.0) * waterType.hasFoam;
-        foamAmount *= foamColor.r;
-        baseColor = mix(baseColor, foamColor, foamAmount);
-        vec3 specularComposite = mix(lightSpecularOut, vec3(0.0), foamAmount);
-        float flatFresnel = (1.0 - dot(viewDir, downDir)) * 1.0;
-        finalFresnel = max(finalFresnel, flatFresnel);
-        finalFresnel -= finalFresnel * shadow * 0.2;
-        baseColor += pointLightsSpecularOut + lightSpecularOut / 3;
-        alpha = max(waterType.baseOpacity, max(foamAmount, max(finalFresnel, length(specularComposite / 3))));
-        compositeColor = baseColor;
-    }
-    else
-    {
-        float unlit = dot(texBlend, vec3(material1.unlit, material2.unlit, material3.unlit));
-        compositeColor *= mix(compositeLight, vec3(1), unlit);
-        compositeColor = linearToSrgb(compositeColor);
-    }
-
-
-    if (isUnderwater)
-    {
-        // underwater terrain
-        float lowestColorLevel = 500.0;
-        float midColorLevel = 150.0;
-        float depth = waterDepth; // e.g. 200
-        float surfaceLevel = position.y - waterDepth; // e.g. -1600
-
-        vec3 mixed = vec3(1);
-
-        if (depth < midColorLevel)
-        {
-            mixed = mix(compositeColor, compositeColor * waterType.depthColor, translateRange(0.0, midColorLevel, depth));
-        }
-        else if (depth < lowestColorLevel)
-        {
-            mixed = mix(compositeColor * waterType.depthColor, vec3(0.0), translateRange(midColorLevel, lowestColorLevel, depth));
-        }
-        else
-        {
-            mixed = vec3(0.0);
-        }
-        compositeColor = mixed;
-
-        // caustics
-        if (underwaterCaustics)
-        {
-            const float scale = 1.75;
-            const float maxCausticsDepth = 128 * 4;
-
+        // underwater caustics based on directional light
+        if (underwaterCaustics && underwaterEnvironment) {
+            float scale = 12.8;
             vec2 causticsUv = worldUvs(scale);
-
-            float depthMultiplier = (position.y - surfaceLevel - maxCausticsDepth) / -maxCausticsDepth;
-            depthMultiplier *= depthMultiplier;
 
             // height offset
             causticsUv += lightDir.xy * position.y / (128 * scale);
 
-            const ivec2 direction = ivec2(1, -2);
-            vec2 flow1 = causticsUv + animationFrame(17) * direction;
-            vec2 flow2 = causticsUv * 1.5 + animationFrame(23) * -direction;
-            vec3 caustics = sampleCaustics(flow1, flow2, .005);
+            const ivec2 direction = ivec2(1, -1);
+            const int driftSpeed = 231;
+            vec2 drift = animationFrame(231) * ivec2(1, -2);
+            vec2 flow1 = causticsUv + animationFrame(19) * direction + drift;
+            vec2 flow2 = causticsUv * 1.25 + animationFrame(37) * -direction + drift;
+
+            vec3 caustics = sampleCaustics(flow1, flow2) * 2;
 
             vec3 causticsColor = underwaterCausticsColor * underwaterCausticsStrength;
-            compositeColor *= 1 + caustics * causticsColor * depthMultiplier * lightDotNormals * lightStrength;
+            dirLightColor += caustics * causticsColor * lightDotNormals * pow(lightStrength, 1.5);
+        }
+
+        // apply shadows
+        dirLightColor *= inverseShadow;
+
+        vec3 lightColor = dirLightColor;
+        vec3 lightOut = max(lightDotNormals, 0.0) * lightColor;
+
+        // directional light specular
+        vec3 lightReflectDir = reflect(lightDirection, normals);
+        vec3 lightSpecularOut = specular(viewDir, lightReflectDir, vSpecularGloss, vSpecularStrength, lightColor, lightStrength).rgb;
+
+        // point lights
+        vec3 pointLightsOut = vec3(0);
+        vec3 pointLightsSpecularOut = vec3(0);
+        for (int i = 0; i < pointLightsCount; i++)
+        {
+            vec3 pointLightPos = vec3(PointLightArray[i].position.x, PointLightArray[i].position.z, PointLightArray[i].position.y);
+            float pointLightStrength = PointLightArray[i].strength;
+            vec3 pointLightColor = PointLightArray[i].color * pointLightStrength;
+            float pointLightSize = PointLightArray[i].size;
+            float distanceToLightSource = length(pointLightPos - position);
+            vec3 pointLightDir = normalize(pointLightPos - position);
+
+            if (distanceToLightSource <= pointLightSize)
+            {
+                float pointLightDotNormals = dot(normals, pointLightDir);
+                vec3 pointLightOut = pointLightColor * max(pointLightDotNormals, 0.0);
+
+                float attenuation = pow(clamp(1 - (distanceToLightSource / pointLightSize), 0.0, 1.0), 2.0);
+                pointLightOut *= attenuation;
+
+                pointLightsOut += pointLightOut;
+
+                vec3 pointLightReflectDir = reflect(-pointLightDir, normals);
+                vec4 spec = specular(viewDir, pointLightReflectDir, vSpecularGloss, vSpecularStrength, pointLightColor, pointLightStrength) * attenuation;
+                pointLightsSpecularOut += spec.rgb;
+            }
+        }
+
+
+        // sky light
+        vec3 skyLightColor = fogColor.rgb;
+        float skyLightStrength = 0.5;
+        float skyDotNormals = downDotNormals;
+        vec3 skyLightOut = max(skyDotNormals, 0.0) * skyLightColor * skyLightStrength;
+
+
+        // lightning
+        vec3 lightningColor = vec3(1.0, 1.0, 1.0);
+        float lightningStrength = lightningBrightness;
+        float lightningDotNormals = downDotNormals;
+        vec3 lightningOut = max(lightningDotNormals, 0.0) * lightningColor * lightningStrength;
+
+
+        // underglow
+        vec3 underglowOut = underglowColor * max(normals.y, 0) * underglowStrength;
+
+
+        // fresnel reflection
+        float baseOpacity = 0.4;
+        float fresnel = 1.0 - clamp(viewDotNormals, 0.0, 1.0);
+        float finalFresnel = clamp(mix(baseOpacity, 1.0, fresnel * 1.2), 0.0, 1.0);
+        vec3 surfaceColor = vec3(0);
+        vec3 surfaceColorOut = surfaceColor * max(combinedSpecularStrength, 0.2);
+
+
+        // apply lighting
+        vec3 compositeLight = ambientLightOut + lightOut + lightSpecularOut + skyLightOut + lightningOut +
+        underglowOut + pointLightsOut + pointLightsSpecularOut + surfaceColorOut;
+
+        float unlit = dot(texBlend, vec3(material1.unlit, material2.unlit, material3.unlit));
+        outputColor.rgb *= mix(compositeLight, vec3(1), unlit);
+        outputColor.rgb = linearToSrgb(outputColor.rgb);
+
+
+        if (isUnderwater)
+        {
+            // underwater terrain
+            float lowestColorLevel = 500.0;
+            float midColorLevel = 150.0;
+            float depth = waterDepth; // e.g. 200
+            float surfaceLevel = position.y - waterDepth; // e.g. -1600
+
+            vec3 mixed = vec3(1);
+
+            if (depth < midColorLevel)
+            {
+                mixed = mix(outputColor.rgb, outputColor.rgb * waterType.depthColor, translateRange(0.0, midColorLevel, depth));
+            }
+            else if (depth < lowestColorLevel)
+            {
+                mixed = mix(outputColor.rgb * waterType.depthColor, vec3(0.0), translateRange(midColorLevel, lowestColorLevel, depth));
+            }
+            else
+            {
+                mixed = vec3(0.0);
+            }
+            outputColor.rgb = mixed;
+
+            // caustics
+            if (underwaterCaustics)
+            {
+                const float scale = 1.75;
+                const float maxCausticsDepth = 128 * 4;
+
+                vec2 causticsUv = worldUvs(scale);
+
+                float depthMultiplier = (position.y - surfaceLevel - maxCausticsDepth) / -maxCausticsDepth;
+                depthMultiplier *= depthMultiplier;
+
+                // height offset
+                causticsUv += lightDir.xy * position.y / (128 * scale);
+
+                const ivec2 direction = ivec2(1, -2);
+                vec2 flow1 = causticsUv + animationFrame(17) * direction;
+                vec2 flow2 = causticsUv * 1.5 + animationFrame(23) * -direction;
+                vec3 caustics = sampleCaustics(flow1, flow2, .005);
+
+                vec3 causticsColor = underwaterCausticsColor * underwaterCausticsStrength;
+                outputColor.rgb *= 1 + caustics * causticsColor * depthMultiplier * lightDotNormals * lightStrength;
+            }
+        }
+
+        if (isWater && waterType.isFlat)
+        {
+            outputColor.a = 1.0f;
         }
     }
 
-    if (isWater && waterType.isFlat)
-    {
-        alpha = 1.0f;
-    }
 
 
-    vec3 hsv = rgbToHsv(compositeColor);
+    vec3 hsv = rgbToHsv(outputColor.rgb);
 
     // Apply saturation setting
     hsv.y *= saturation;
@@ -699,9 +776,9 @@ void main() {
         hsv.z = 0.5 - ((0.5 - hsv.z) * contrast);
     }
 
-    compositeColor = hsvToRgb(hsv);
+    outputColor.rgb = hsvToRgb(hsv);
 
-    compositeColor = colorBlindnessCompensation(compositeColor);
+    outputColor.rgb = colorBlindnessCompensation(outputColor.rgb);
 
     if (!isUnderwater)
     {
@@ -713,13 +790,13 @@ void main() {
         groundFog *= clamp(distance / closeFadeDistance, 0.0, 1.0);
         if (isWater)
         {
-            alpha = max(alpha, groundFog);
+            outputColor.a = max(outputColor.a, groundFog);
         }
-        compositeColor = mix(compositeColor, fogColor.rgb, groundFog);
+        outputColor.rgb = mix(outputColor.rgb, fogColor.rgb, groundFog);
     }
 
     // apply distance fog
-    compositeColor = mix(clamp(compositeColor, 0.0, 1.0), fogColor.rgb, fogAmount);
+    outputColor.rgb = mix(clamp(outputColor.rgb, 0.0, 1.0), fogColor.rgb, fogAmount);
 
-    FragColor = vec4(compositeColor, alpha);
+    FragColor = outputColor;
 }

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -782,11 +782,12 @@ void main() {
 
     outputColor.rgb = hsvToRgb(hsv);
 
+    outputColor.rgb = clamp(outputColor.rgb, 0, 1);
     outputColor.rgb = colorBlindnessCompensation(outputColor.rgb);
 
-    if (!isUnderwater)
-    {
-        // apply ground fog
+    // apply fog
+    if (!isUnderwater) {
+        // ground fog
         float distance = distance(position, camPos);
         float closeFadeDistance = 1500;
         float groundFog = 1.0 - clamp((position.y - groundFogStart) / (groundFogEnd - groundFogStart), 0.0, 1.0);
@@ -796,11 +797,11 @@ void main() {
         {
             outputColor.a = max(outputColor.a, groundFog);
         }
-        outputColor.rgb = mix(outputColor.rgb, fogColor.rgb, groundFog);
-    }
 
-    // apply distance fog
-    outputColor.rgb = mix(clamp(outputColor.rgb, 0.0, 1.0), fogColor.rgb, fogAmount);
+        // multiply the visibility of each fog
+        float combinedFog = 1 - (1 - fogAmount) * (1 - groundFog);
+        outputColor = mix(outputColor, fogColor, combinedFog);
+    }
 
     FragColor = outputColor;
 }


### PR DESCRIPTION
This primarily just shifts some code around in the fragment shader in preparation for reworking water rendering, but it also performs slightly better, and I've included a fix for this issue reported by Antwan, so I figured this might as well get merged already.
![image](https://user-images.githubusercontent.com/831317/200298707-7b3f62a7-5b74-4d5c-9a79-c3b30e11f7fc.png)

Below is a performance comparison between the master branch and the changes made in this PR, showing a roughly 6.5% improvement with lots of water in view.

master:
![image](https://user-images.githubusercontent.com/831317/200298126-81f29a66-f4f2-48fd-82cc-1c7a2c2b4b54.png)

this PR:
![image](https://user-images.githubusercontent.com/831317/200298143-2503994d-4bdf-4021-958a-816621a6c561.png)

I've also fixed how fog gets applied to water, so shadows on the water and such should now fade out the same as the rest of the scene when covered in fog.