### PR TITLE
Use interface blocks for the main shader inputs and outputs

### DIFF
--- a/src/main/resources/rs117/hd/geom.glsl
+++ b/src/main/resources/rs117/hd/geom.glsl
@@ -34,7 +34,6 @@ layout(triangle_strip, max_vertices = 3) out;
 
 #include utils/polyfills.glsl
 #include utils/constants.glsl
-#include utils/structs.glsl
 #include utils/misc.glsl
 
 uniform mat4 projectionMatrix;
@@ -48,7 +47,10 @@ in VertexData {
     float fogAmount;
 } IN[3];
 
-flat out Vertex[3] vertices;
+flat out vec4 vColor[3];
+flat out vec3 vUv[3];
+flat out int vMaterialData[3];
+flat out int vTerrainData[3];
 
 out FragmentData {
     float fogAmount;
@@ -69,12 +71,10 @@ void main() {
     vec3 N = normalize(cross(T, B));
 
     for (int i = 0; i < 3; i++) {
-        vertices[i] = Vertex(
-            IN[i].color,
-            IN[i].uv.xyz,
-            int(IN[i].uv.w),
-            int(IN[i].normal.w)
-        );
+        vColor[i] = IN[i].color;
+        vUv[i] = IN[i].uv.xyz;
+        vMaterialData[i] = int(IN[i].uv.w);
+        vTerrainData[i] = int(IN[i].normal.w);
     }
 
     for (int i = 0; i < 3; i++) {

--- a/src/main/resources/rs117/hd/geom.glsl
+++ b/src/main/resources/rs117/hd/geom.glsl
@@ -47,14 +47,19 @@ in VertexData {
     float fogAmount;
 } IN[3];
 
-flat out vec4 vColor[3];
-flat out vec3 vUv[3];
-flat out int vMaterialData[3];
-flat out int vTerrainData[3];
-out float fogAmount;
-out vec3 normals;
-out vec3 position;
-out vec3 texBlend;
+out PrimitiveData {
+    flat vec4 vColor;
+    flat vec3 vUv;
+    flat int vMaterialData;
+    flat int vTerrainData;
+} PRIM[3];
+
+out FragmentData {
+    float fogAmount;
+    vec3 normals;
+    vec3 position;
+    vec3 texBlend;
+} OUT;
 
 void main() {
     int materialData = int(IN[0].uv.w);
@@ -66,24 +71,24 @@ void main() {
         vec3 T = normalize(vec3(IN[0].pos - IN[1].pos));
         vec3 B = normalize(vec3(IN[0].pos - IN[2].pos));
         vec3 N = normalize(cross(T, B));
-        normals = N;
+        OUT.normals = N;
     }
 
     for (int i = 0; i < 3; i++) {
-        vColor[i] = IN[i].color;
-        vUv[i] = IN[i].uv.xyz;
-        vMaterialData[i] = int(IN[i].uv.w);
-        vTerrainData[i] = int(IN[i].normal.w);
+        PRIM[i].vColor = IN[i].color;
+        PRIM[i].vUv = IN[i].uv.xyz;
+        PRIM[i].vMaterialData = int(IN[i].uv.w);
+        PRIM[i].vTerrainData = int(IN[i].normal.w);
     }
 
     for (int i = 0; i < 3; i++) {
-        texBlend = vec3(0);
-        texBlend[i] = 1;
-        fogAmount = IN[i].fogAmount;
-        gl_Position = projectionMatrix * vec4(IN[i].pos, 1.f);
-        position = IN[i].pos;
+        OUT.texBlend = vec3(0);
+        OUT.texBlend[i] = 1;
+        OUT.fogAmount = IN[i].fogAmount;
+        OUT.position = IN[i].pos;
         if (!flatNormals)
-            normals = normalize(IN[i].normal.xyz);
+            OUT.normals = normalize(IN[i].normal.xyz);
+        gl_Position = projectionMatrix * vec4(IN[i].pos, 1.f);
         EmitVertex();
     }
 

--- a/src/main/resources/rs117/hd/utils/misc.glsl
+++ b/src/main/resources/rs117/hd/utils/misc.glsl
@@ -83,7 +83,7 @@ vec2 getUvs(vec3 uvw, int materialData, vec3 position) {
         vec3 C1 = cross(vec3(0, 0, 1), N);
         vec3 C2 = cross(vec3(0, 1, 0), N);
         vec3 T = normalize(length(C1) > length(C2) ? C1 : C2);
-        vec3 B = normalize(cross(N, T));
+        vec3 B = cross(N, T);
         mat3 TBN = mat3(T, B, N);
 
         return fract((TBN * position).xy / 128.f / scale);

--- a/src/main/resources/rs117/hd/utils/specular.glsl
+++ b/src/main/resources/rs117/hd/utils/specular.glsl
@@ -30,6 +30,6 @@ vec4 specular(vec3 viewDir, vec3 reflectDir, vec3 specularGloss, vec3 specularSt
     vec3 specY = vec3(pow(vDotR, specularGloss.y) * lightColor * specularStrength.y);
     vec3 specZ = vec3(pow(vDotR, specularGloss.z) * lightColor * specularStrength.z);
     float specAmount = clamp(vDotR * lightStrength, 0.0, 1.0);
-    vec4 combined = vec4(specX * texBlend.x + specY * texBlend.y + specZ * texBlend.z, specAmount);
+    vec4 combined = vec4(specX * IN.texBlend.x + specY * IN.texBlend.y + specZ * IN.texBlend.z, specAmount);
     return vDotR > 0.0 ? combined : vec4(0.0);
 }

--- a/src/main/resources/rs117/hd/utils/structs.glsl
+++ b/src/main/resources/rs117/hd/utils/structs.glsl
@@ -1,6 +1,0 @@
-struct Vertex {
-    vec4 color;
-    vec3 uv;
-    int materialData;
-    int terrainData;
-};

--- a/src/main/resources/rs117/hd/utils/structs.glsl
+++ b/src/main/resources/rs117/hd/utils/structs.glsl
@@ -1,0 +1,6 @@
+struct Vertex {
+    vec4 color;
+    vec3 uv;
+    int materialData;
+    int terrainData;
+};


### PR DESCRIPTION
This does give off the following warning on my end, but I think it's wrongly interpreting the block as a struct:
```
GLSL 4.50: Member declarators may contain precision qualifiers, but use of any other qualifier results in a compile-time error. (You may put the qualifier on the whole struct.)
```

This was confirmed to work with [this GPU on Windows](https://opengl.gpuinfo.org/displayreport.php?id=7720) and my GTX 970 on Linux, so I think it should be fine to merge.