### PR TITLE
Flip texture orientation to match vanilla UVs

### DIFF
--- a/src/main/java/rs117/hd/scene/SceneUploader.java
+++ b/src/main/java/rs117/hd/scene/SceneUploader.java
@@ -493,13 +493,13 @@ class SceneUploader
 			int packedMaterialDataNE = modelPusher.packMaterialData(neMaterial, neVertexIsOverlay, ModelOverride.NONE);
 
 			uvBuffer.ensureCapacity(24);
-			uvBuffer.put(1, 1, 0, packedMaterialDataNE);
-			uvBuffer.put(0, 1, 0, packedMaterialDataNW);
-			uvBuffer.put(1, 0, 0, packedMaterialDataSE);
+			uvBuffer.put(1, 0, 0, packedMaterialDataNE);
+			uvBuffer.put(0, 0, 0, packedMaterialDataNW);
+			uvBuffer.put(1, 1, 0, packedMaterialDataSE);
 
-			uvBuffer.put(0, 0, 0, packedMaterialDataSW);
-			uvBuffer.put(1, 0, 0, packedMaterialDataSE);
-			uvBuffer.put(0, 1, 0, packedMaterialDataNW);
+			uvBuffer.put(0, 1, 0, packedMaterialDataSW);
+			uvBuffer.put(1, 1, 0, packedMaterialDataSE);
+			uvBuffer.put(0, 0, 0, packedMaterialDataNW);
 
 			uvBufferLength += 6;
 		}
@@ -613,13 +613,13 @@ class SceneUploader
 			int packedMaterialDataNE = modelPusher.packMaterialData(neMaterial, false, ModelOverride.NONE);
 
 			uvBuffer.ensureCapacity(24);
-			uvBuffer.put(1, 1, 0, packedMaterialDataNE);
-			uvBuffer.put(0, 1, 0, packedMaterialDataNW);
-			uvBuffer.put(1, 0, 0, packedMaterialDataSE);
+			uvBuffer.put(1, 0, 0, packedMaterialDataNE);
+			uvBuffer.put(0, 0, 0, packedMaterialDataNW);
+			uvBuffer.put(1, 1, 0, packedMaterialDataSE);
 
-			uvBuffer.put(0, 0, 0, packedMaterialDataSW);
-			uvBuffer.put(1, 0, 0, packedMaterialDataSE);
-			uvBuffer.put(0, 1, 0, packedMaterialDataNW);
+			uvBuffer.put(0, 1, 0, packedMaterialDataSW);
+			uvBuffer.put(1, 1, 0, packedMaterialDataSE);
+			uvBuffer.put(0, 0, 0, packedMaterialDataNW);
 
 			uvBufferLength += 6;
 		}
@@ -830,9 +830,9 @@ class SceneUploader
 			int packedMaterialDataC = modelPusher.packMaterialData(materialC, vertexCIsOverlay, ModelOverride.NONE);
 
 			uvBuffer.ensureCapacity(12);
-			uvBuffer.put(localVertices[0][0] / 128f, localVertices[0][1] / 128f, 0, packedMaterialDataA);
-			uvBuffer.put(localVertices[1][0] / 128f, localVertices[1][1] / 128f, 0, packedMaterialDataB);
-			uvBuffer.put(localVertices[2][0] / 128f, localVertices[2][1] / 128f, 0, packedMaterialDataC);
+			uvBuffer.put(localVertices[0][0] / 128f, 1 - localVertices[0][1] / 128f, 0, packedMaterialDataA);
+			uvBuffer.put(localVertices[1][0] / 128f, 1 - localVertices[1][1] / 128f, 0, packedMaterialDataB);
+			uvBuffer.put(localVertices[2][0] / 128f, 1 - localVertices[2][1] / 128f, 0, packedMaterialDataC);
 
 			uvBufferLength += 3;
 		}
@@ -938,9 +938,9 @@ class SceneUploader
 				int packedMaterialDataC = modelPusher.packMaterialData(materialC, false, ModelOverride.NONE);
 
 				uvBuffer.ensureCapacity(12);
-				uvBuffer.put(localVertices[0][0] / 128f, localVertices[0][1] / 128f, 0, packedMaterialDataA);
-				uvBuffer.put(localVertices[1][0] / 128f, localVertices[1][1] / 128f, 0, packedMaterialDataB);
-				uvBuffer.put(localVertices[2][0] / 128f, localVertices[2][1] / 128f, 0, packedMaterialDataC);
+				uvBuffer.put(localVertices[0][0] / 128f, 1 - localVertices[0][1] / 128f, 0, packedMaterialDataA);
+				uvBuffer.put(localVertices[1][0] / 128f, 1 - localVertices[1][1] / 128f, 0, packedMaterialDataB);
+				uvBuffer.put(localVertices[2][0] / 128f, 1 - localVertices[2][1] / 128f, 0, packedMaterialDataC);
 
 				uvBufferLength += 3;
 			}

--- a/src/main/java/rs117/hd/scene/TextureManager.java
+++ b/src/main/java/rs117/hd/scene/TextureManager.java
@@ -173,10 +173,10 @@ public class TextureManager
 		double save = textureProvider.getBrightness();
 		textureProvider.setBrightness(1.0d);
 
-		pixelBuffer = BufferUtils.createIntBuffer(textureSize * textureSize);
-		vanillaImage = new BufferedImage(128, 128, BufferedImage.TYPE_INT_ARGB);
 		int[] vanillaPixels = new int[128 * 128];
+		pixelBuffer = BufferUtils.createIntBuffer(textureSize * textureSize);
 		scaledImage = new BufferedImage(textureSize, textureSize, BufferedImage.TYPE_INT_ARGB);
+		vanillaImage = new BufferedImage(128, 128, BufferedImage.TYPE_INT_ARGB);
 
 		int materialCount = Material.values().length;
 		materialOrdinalToTextureIndex = new int[materialCount];
@@ -303,8 +303,8 @@ public class TextureManager
 
 		// Reset
 		pixelBuffer = null;
-		vanillaImage = null;
 		scaledImage = null;
+		vanillaImage = null;
 		textureProvider.setBrightness(save);
 		glActiveTexture(TEXTURE_UNIT_UI);
 
@@ -332,18 +332,11 @@ public class TextureManager
 	{
 		// TODO: scale and transform on the GPU for better performance
 		AffineTransform t = new AffineTransform();
-		// Flip non-vanilla textures vertically
-		if (image != vanillaImage)
-		{
-			t.translate(0, scaledImage.getHeight());
-			t.scale(1, -1);
-		}
 		t.scale((double) textureSize / image.getWidth(), (double) textureSize / image.getHeight());
 		AffineTransformOp scaleOp = new AffineTransformOp(t, AffineTransformOp.TYPE_BICUBIC);
 		scaleOp.filter(image, scaledImage);
-		image = scaledImage;
 
-		int[] pixels = ((DataBufferInt) image.getRaster().getDataBuffer()).getData();
+		int[] pixels = ((DataBufferInt) scaledImage.getRaster().getDataBuffer()).getData();
 		pixelBuffer.put(pixels).flip();
 
 		// Go from TYPE_4BYTE_ABGR in the BufferedImage to RGBA

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -92,7 +92,8 @@ out vec4 FragColor;
 #include utils/displacement.glsl
 
 vec2 worldUvs(float scale) {
-    return IN.position.xz / 128. / scale;
+    vec2 uv = IN.position.xz / (128 * scale);
+    return vec2(uv.x, -uv.y);
 }
 
 float sampleShadowMap(vec3 fragPos, int waterTypeIndex, vec2 distortion, float lightDotNormals) {
@@ -152,29 +153,18 @@ vec4 sampleWater(int waterTypeIndex, vec3 viewDir) {
     WaterType waterType = getWaterType(waterTypeIndex);
 
     vec2 baseUv = vUv[0].xy * IN.texBlend.x + vUv[1].xy * IN.texBlend.y + vUv[2].xy * IN.texBlend.z;
-    vec2 uv2, uv3 = baseUv;
+    vec2 uv3 = baseUv;
 
-    uv2 = vec2(
-        worldUvs(3).x - animationFrame(24 * waterType.duration),
-        worldUvs(3).y - animationFrame(24 * waterType.duration)
-    );
+    vec2 uv2 = worldUvs(3) + vec2(-1, 1) * animationFrame(24 * waterType.duration);
+    vec2 uv1 = worldUvs(3).yx + animationFrame(28 * waterType.duration);
 
     vec2 flowMapUv = worldUvs(15) + animationFrame(50 * waterType.duration);
     float flowMapStrength = 0.025;
 
     vec2 uvFlow = texture(textureArray, vec3(flowMapUv, waterType.flowMap)).xy;
+    uv1 += uvFlow * flowMapStrength;
     uv2 += uvFlow * flowMapStrength;
     uv3 += uvFlow * flowMapStrength;
-
-//    uv1 = vec2(
-//        worldUvs(2).y + animationFrame(20 * waterType.duration) + uvFlow.x * flowMapStrength,
-//        worldUvs(2).x + animationFrame(20 * waterType.duration) + uvFlow.y * flowMapStrength
-//    );
-    // TODO: this looks like a bug. Was probably intended to be uv2?
-    vec2 uv1 = vec2(
-        worldUvs(3).y - animationFrame(28 * waterType.duration) - uvFlow.x * flowMapStrength,
-        worldUvs(3).x + animationFrame(28 * waterType.duration) + uvFlow.y * flowMapStrength
-    );
 
     // get diffuse textures
     vec3 n1 = texture(textureArray, vec3(uv1, waterType.normalMap)).xyz;
@@ -285,8 +275,6 @@ vec4 sampleWater(int waterTypeIndex, vec3 viewDir) {
 
     vec3 baseColor = waterType.surfaceColor * compositeLight;
     baseColor = mix(baseColor, surfaceColor, waterType.fresnelAmount);
-    float shadowDarken = 0.15;
-    baseColor *= (1.0 - shadowDarken) + inverseShadow * shadowDarken;
     float shoreLineMask = 1 - dot(IN.texBlend, vec3(vColor[0].x, vColor[1].x, vColor[2].x));
     float maxFoamAmount = 0.8;
     float foamAmount = min(shoreLineMask, maxFoamAmount);


### PR DESCRIPTION
Image replacements for OSRS picture frames will now be the right way up. For textures on tiles to remain aligned with north, UV coordinates had to be flipped on the Y-axis as well.

These changes also subtly affect the water surface, and the darker water surface shadowing has been removed. I could've fixed the water orientation again, but I think the new look is slightly better anyway.
Current master:
![master](https://user-images.githubusercontent.com/831317/208859781-043e2a82-5472-493b-8104-3fbf29cd77a4.png)
This branch:
![new branch](https://user-images.githubusercontent.com/831317/208859803-717f6ca1-8490-4701-a83d-e4a3e9dacc8e.png)
