### PR TITLE
Add user-facing error popups for known issues

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -34,6 +34,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.events.*;
 import net.runelite.api.hooks.DrawCallbacks;
+import net.runelite.client.RuneLite;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
@@ -44,6 +45,7 @@ import net.runelite.client.plugins.entityhider.EntityHiderPlugin;
 import net.runelite.client.plugins.skybox.SkyboxPlugin;
 import net.runelite.client.ui.ClientUI;
 import net.runelite.client.ui.DrawManager;
+import net.runelite.client.util.LinkBrowser;
 import net.runelite.client.util.OSType;
 import net.runelite.rlawt.AWTContext;
 import org.jocl.CL;
@@ -106,7 +108,8 @@ import static rs117.hd.utils.ResourcePath.path;
 @Slf4j
 public class HdPlugin extends Plugin implements DrawCallbacks
 {
-	private static final String ENV_SHADER_PATH = "RLHD_SHADER_PATH";
+	public static final String DISCORD_URL = "https://discord.gg/U4p6ChjgSE";
+	public static final String RUNELITE_URL = "https://runelite.net";
 
 	public static final int TEXTURE_UNIT_UI = GL_TEXTURE0; // default state
 	public static final int TEXTURE_UNIT_GAME = GL_TEXTURE1;
@@ -122,6 +125,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	public static final int UV_SIZE = 4; // 4 floats per vertex
 	public static final int NORMAL_SIZE = 4; // 4 floats per vertex
 
+	private static final String ENV_SHADER_PATH = "RLHD_SHADER_PATH";
 	private static final int[] eightIntWrite = new int[8];
 
 	@Inject
@@ -451,24 +455,46 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 
 				GL.createCapabilities();
 
-				log.info("Using device: {}", glGetString(GL_RENDERER));
+				String glRenderer = glGetString(GL_RENDERER);
+				String arch = System.getProperty("sun.arch.data.model", "Unknown");
+				if (glRenderer == null)
+				{
+					glRenderer = "Unknown";
+				}
+				log.info("Using device: {}", glRenderer);
 				log.info("Using driver: {}", glGetString(GL_VERSION));
-				log.info("Client is {}-bit", System.getProperty("sun.arch.data.model"));
+				log.info("Client is {}-bit", arch);
 
 				GLCapabilities caps = GL.getCapabilities();
-				if (computeMode == ComputeMode.OPENGL)
+
+				boolean isGenericGpu = glRenderer.equals("GDI Generic");
+				boolean isUnsupportedGpu = isGenericGpu || (computeMode == ComputeMode.OPENGL ? !caps.OpenGL43 : !caps.OpenGL31);
+				if (isUnsupportedGpu)
 				{
-					if (!caps.OpenGL43)
-					{
-						throw new RuntimeException("OpenGL 4.3 is required but not available");
-					}
-				}
-				else
-				{
-					if (!caps.OpenGL31)
-					{
-						throw new RuntimeException("OpenGL 3.1 is required but not available");
-					}
+					log.error("The GPU is lacking OpenGL {} support. Stopping the plugin...",
+						computeMode == ComputeMode.OPENGL ? "4.3" : "3.1");
+					PopupUtils.displayPopupMessage(client, "117HD Error",
+						(isGenericGpu ?
+							"117HD was unable to access your GPU." :
+							"Your GPU is currently not supported by 117HD.<br><br>GPU name: " + glRenderer
+						) +
+						"<br><br>" +
+						"If your system actually has a supported GPU, try the following steps:<br>" +
+						(!arch.equals("32") ? "" :
+							"&nbsp;• Install the 64-bit version of RuneLite from " +
+								"<a href=\"" + HdPlugin.RUNELITE_URL + "\">the official website</a>.<br>"
+						) +
+						"&nbsp;• If you're on a desktop PC, make sure your monitor is plugged into the graphics card<br>" +
+						"&nbsp;&nbsp;&nbsp;&nbsp;instead of the motherboard's display output.<br>" +
+						"&nbsp;• Reinstall the drivers for your graphics card and restart your system.<br>" +
+						"<br>" +
+						"If you're still seeing this error after following the steps above, please join our " +
+							"<a href=\"" + HdPlugin.DISCORD_URL + "\">Discord</a><br>" +
+						"server, and drag and drop your client log file into one of our support channels.",
+						new String[] { "Open log folder", "Ok, let me try that..." },
+						i -> { if (i == 0) LinkBrowser.open(RuneLite.LOGS_DIR.toString()); });
+					stopPlugin();
+					return true;
 				}
 
 				lwjglInitted = true;

--- a/src/main/java/rs117/hd/model/BufferPool.java
+++ b/src/main/java/rs117/hd/model/BufferPool.java
@@ -36,7 +36,7 @@ public class BufferPool {
                 }
             } catch (Throwable err2) {
                 freeAllocations();
-                log.error("Unable to allocate {} bytes in chunks of 1 GiB", byteCapacity, err2);
+                log.error("Unable to allocate {} bytes in chunks of up to 1 GiB each", byteCapacity, err2);
                 throw err2;
             }
         }

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -4,7 +4,9 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.api.kit.KitType;
+import net.runelite.client.RuneLite;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.util.LinkBrowser;
 import rs117.hd.HdPlugin;
 import rs117.hd.HdPluginConfig;
 import rs117.hd.data.materials.Material;
@@ -17,6 +19,7 @@ import rs117.hd.scene.model_overrides.TzHaarRecolorType;
 import rs117.hd.scene.ProceduralGenerator;
 import rs117.hd.utils.HDUtils;
 import rs117.hd.utils.ModelHash;
+import rs117.hd.utils.PopupUtils;
 import rs117.hd.utils.buffer.GpuFloatBuffer;
 import rs117.hd.utils.buffer.GpuIntBuffer;
 
@@ -63,10 +66,45 @@ public class ModelPusher {
 
     public void startUp() {
         if (config.enableModelCaching()) {
+            final int size = config.modelCacheSizeMiB();
             try {
-                modelCache = new ModelCache(config.modelCacheSizeMiB());
+                modelCache = new ModelCache(size);
             } catch (Throwable err) {
                 log.error("Error while initializing model cache. Stopping the plugin...", err);
+
+                if (err instanceof OutOfMemoryError) {
+                    String arch = System.getProperty("sun.arch.data.model", "Unknown");
+                    PopupUtils.displayPopupMessage(client, "117HD Error",
+                        "117HD ran out of memory while trying to allocate the model cache.<br><br>" +
+                        (arch.equals("32") ?
+                            (
+                                "You are currently using the 32-bit RuneLite launcher, which heavily restricts<br>" +
+                                "the amount of memory RuneLite is allowed to use.<br>" +
+                                "Please install the 64-bit launcher from " +
+                                "<a href=\"" + HdPlugin.RUNELITE_URL + "\">RuneLite's website</a> and try again.<br>"
+                            ) : (
+                                (size <= 2048 ? "" :
+                                    "Your cache size of " + size + " MiB is " + (
+                                        size >= 4096 ?
+                                            "very large. We would recommend reducing it.<br>" :
+                                            "bigger than the default size. Try reducing it.<br>"
+                                    )
+                                ) +
+                                "Normally, a cache size above 2048 MiB is unnecessary, and the game should<br>" +
+                                "run acceptably even at 1024 MiB. If you end up having to reduce the size far<br>" +
+                                "below 512 MiB, you may be better off disabling the model cache entirely.<br>"
+                            )
+                        ) +
+                        "<br>" +
+                        "You can also try closing some other programs on your PC to free up memory.<br>" +
+                        "<br>" +
+                        "If you need further assistance, please join our " +
+                            "<a href=\"" + HdPlugin.DISCORD_URL + "\">Discord</a> server, and<br>" +
+                        "drag and drop your client log file into one of our support channels.",
+                        new String[] { "Open log folder", "Ok, let me try that..." },
+                        i -> { if (i == 0) LinkBrowser.open(RuneLite.LOGS_DIR.toString()); });
+                }
+
                 // Allow the model pusher to be used until the plugin has cleanly shut down
                 clientThread.invokeLater(plugin::stopPlugin);
             }


### PR DESCRIPTION
I could use some help making these look prettier, but it's a start at least.

<details>
<summary>Outdated screenshots</summary>

Here's the message when `GDI Generic` is detected (typically a driver issue or monitor plugged into the wrong port without an iGPU in the system):
![image](https://user-images.githubusercontent.com/831317/216465358-c26253bd-a6ea-4ecd-a67d-ceed84025bb8.png)

A similar error is shown for unsupported GPUs:
![image](https://user-images.githubusercontent.com/831317/216466398-e42f32e4-0027-4498-bb49-898e34395927.png)
It will also suggest installing the 64-bit launcher if they're currently using 32-bit.

And finally some messages for model cache allocation issues:
![image](https://user-images.githubusercontent.com/831317/216466585-df00a05e-5aa1-4fb2-8940-fbc5ea0c7ca0.png)
![image](https://user-images.githubusercontent.com/831317/216465483-6decf1b0-e03d-489e-a343-f8f6f5676982.png)
</details>