### PR TITLE
lower specularity on gravel to fix issues in Yanille

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Material.java
+++ b/src/main/java/rs117/hd/data/materials/Material.java
@@ -228,7 +228,7 @@ public enum Material
 	GRAVEL_N,
 	GRAVEL(p -> p
 		.setNormalMap(GRAVEL_N)
-		.setSpecular(0.6f,130)),
+		.setSpecular(0.4f,130)),
 
 	DIRT_SHINY_1(DIRT_1, p -> p
 		.setSpecular(1.1f, 380)),


### PR DESCRIPTION
A discord user reported in january there was over shiny gravel in yanille. lowered the specularity to resolve.
![image](https://user-images.githubusercontent.com/11658143/221363993-cd4af2a1-de36-47f7-8d1c-3386f5208658.png)
