### PR TITLE
Fix area related crashing on load

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Area.java
+++ b/src/main/java/rs117/hd/data/environments/Area.java
@@ -1303,8 +1303,8 @@ public enum Area
 	),
 
 	OVERWORLD(700, 2300, 4200, 4095),
-	ALL(0, 0, Integer.MAX_VALUE, Integer.MAX_VALUE),
-	NONE(0, 0, 0, 0),
+	ALL(2, 1001, 5000, 13000),
+	NONE(1, 1000, 1, 1000),
 	;
 
 	public final AABB[] aabbs;


### PR DESCRIPTION
Currently on when attempting to load the HD plugin you are greeted with an error:
```
    java.lang.IllegalArgumentException: Your definition for the area ALL has an incorrect AABB: AABB{min=(0,0), max=(2147483647,2147483647)}
    at rs117.hd.utils.DeveloperTools.activate(DeveloperTools.java:47)
    at rs117.hd.HdPlugin.lambda$startUp$2(HdPlugin.java:537)
    at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
    at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
    at net.runelite.client.callback.Hooks.tick(Hooks.java:213)
    at client.if(client.java:45284)
    at client.ax(client.java)
    at aj.d(aj.java:377)
    at aj.run(aj.java:356)
    at java.base/java.lang.Thread.run(Thread.java:829)
```

Fixing this error generates the next error:


```
    java.lang.IllegalArgumentException: Your definition for the area NONE has an incorrect AABB: AABB{min=(0,0), max=(0,0)}
    at rs117.hd.utils.DeveloperTools.activate(DeveloperTools.java:47)
    at rs117.hd.HdPlugin.lambda$startUp$2(HdPlugin.java:537)
    at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
    at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
    at net.runelite.client.callback.Hooks.tick(Hooks.java:213)
    at client.if(client.java:45284)
    at client.ax(client.java)
    at aj.d(aj.java:377)
    at aj.run(aj.java:356)
    at java.base/java.lang.Thread.run(Thread.java:829)
```

values in the PR were found by testing each value one at a time until the crash was toggled by changing one digit
Why they are those values i couldn't tell you.