### PR TITLE
Fine grained saturation and contrast

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1950,8 +1950,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 			glUniform1f(uniLightningBrightness, environmentManager.lightningBrightness);
 			glUniform1i(uniPointLightsCount, Math.min(configMaxDynamicLights, lightManager.visibleLightsCount));
 
-			glUniform1f(uniSaturation, config.saturation().getAmount());
-			glUniform1f(uniContrast, config.contrast().getAmount());
+			glUniform1f(uniSaturation, config.saturation() / 100f);
+			glUniform1f(uniContrast, config.contrast() / 100f);
 			glUniform1i(uniUnderwaterEnvironment, environmentManager.isUnderwater() ? 1 : 0);
 			glUniform1i(uniUnderwaterCaustics, config.underwaterCaustics() ? 1 : 0);
 			glUniform3fv(uniUnderwaterCausticsColor, environmentManager.currentUnderwaterCausticsColor);
@@ -2268,7 +2268,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks
 	@Subscribe
 	public void onConfigChanged(ConfigChanged event)
 	{
-		if (!event.getGroup().equals("hd"))
+		if (!event.getGroup().equals(CONFIG_GROUP))
 		{
 			return;
 		}

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -29,12 +29,15 @@ import net.runelite.client.config.*;
 
 import static rs117.hd.HdPlugin.MAX_DISTANCE;
 import static rs117.hd.HdPlugin.MAX_FOG_DEPTH;
+import static rs117.hd.HdPluginConfig.CONFIG_GROUP;
 
 import rs117.hd.config.*;
 
-@ConfigGroup("hd")
+@ConfigGroup(CONFIG_GROUP)
 public interface HdPluginConfig extends Config
 {
+	String CONFIG_GROUP = "hd";
+
 	/*====== General settings ======*/
 
 	@ConfigSection(
@@ -203,25 +206,41 @@ public interface HdPluginConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "saturation",
+		keyName = "fSaturation",
 		name = "Saturation",
-		description = "Controls the saturation of the final rendered image.",
+		description = "Controls the saturation of the final rendered image.<br>" +
+			"Intended to be kept between 0% and 120%.",
 		position = 11,
 		section = generalSettings
 	)
-	default Saturation saturation()
+	@Units(Units.PERCENT)
+	@Range(min = -500, max = 500)
+	default int saturation()
+	{
+		return (int) (oldSaturationDropdown().getAmount() * 100);
+	}
+	@ConfigItem(keyName = "saturation", hidden = true, name = "", description = "")
+	default Saturation oldSaturationDropdown()
 	{
 		return Saturation.DEFAULT;
 	}
 
 	@ConfigItem(
-		keyName = "contrast",
+		keyName = "fContrast",
 		name = "Contrast",
-		description = "Controls the contrast of the final rendered image.",
+		description = "Controls the contrast of the final rendered image.<br>" +
+			"Intended to be kept between 90% and 110%.",
 		position = 12,
 		section = generalSettings
 	)
-	default Contrast contrast()
+	@Units(Units.PERCENT)
+	@Range(min = -500, max = 500)
+	default int contrast()
+	{
+		return (int) (oldContrastDropdown().getAmount() * 100);
+	}
+	@ConfigItem(keyName = "contrast", hidden = true, name = "", description = "")
+	default Contrast oldContrastDropdown()
 	{
 		return Contrast.DEFAULT;
 	}

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -252,7 +252,8 @@ public interface HdPluginConfig extends Config
 	@ConfigItem(
 		keyName = "brightness2",
 		name = "Brightness",
-		description = "Controls the brightness of environmental lighting.",
+		description = "Controls the brightness of environmental lighting.<br>" +
+			"A brightness value of 20 is recommended.",
 		position = 13,
 		section = generalSettings
 	)


### PR DESCRIPTION
This turns our saturation and contrast dropdowns into percentage number fields. I've left them with *quite* relaxed ranges, and included mentions of intended use in their tooltips instead of forcing some more sensible limits.

Requested by [`PleaseRephrase&Clarify
#8471` on Discord](https://discord.com/channels/886733267284398130/886739055994343495/1092756573878759485) and in this PR on the old repo: https://github.com/RS117/RLHD/pull/138

Please let me know if you think we should set some more sensible limits. Some examples of what you can do with these limits:
![image](https://user-images.githubusercontent.com/831317/232359549-ce23d34b-7b3f-4592-80a8-ce66f5d06a8f.png)
![image](https://user-images.githubusercontent.com/831317/232359586-ccb37903-3d5e-480b-bdd3-c64223c2d5a9.png)
![image](https://user-images.githubusercontent.com/831317/232359594-322a1d08-3257-4579-805d-b83445c9045c.png)
![image](https://user-images.githubusercontent.com/831317/232359554-98a567aa-dfbd-4785-ae1e-3c9f88ce35b3.png)
![image](https://user-images.githubusercontent.com/831317/232359571-d3dc0dd3-db1d-4cf3-8d2c-837c0f1b0641.png)
