### PR TITLE
Fix gaps between tiles

### DIFF
--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -254,10 +254,12 @@ void main() {
             float underlayBlendMultiplier = 1.0 / (underlayBlend[0] + underlayBlend[1] + underlayBlend[2]);
             // adjust back to 1.0 total
             underlayBlend *= underlayBlendMultiplier;
+            underlayBlend = clamp(underlayBlend, 0, 1);
 
             float overlayBlendMultiplier = 1.0 / (overlayBlend[0] + overlayBlend[1] + overlayBlend[2]);
             // adjust back to 1.0 total
             overlayBlend *= overlayBlendMultiplier;
+            overlayBlend = clamp(overlayBlend, 0, 1);
         }
 
 


### PR DESCRIPTION
**Fixes #203 Gaps Between Tiles**

Reproduction of the bug
https://youtu.be/9yWim7J3lhg
https://youtu.be/TW__HG7uT6M

The bug fixed
https://youtu.be/i0UvfFOwXfg

It seems the Terrain tile UV's range needs to be corrected. Clamping the blend factors of overlay and underlay seems to address this issue.