### PR TITLE
Dirt specularity correction

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Material.java
+++ b/src/main/java/rs117/hd/data/materials/Material.java
@@ -306,12 +306,12 @@ public enum Material {
 	DIRT_1_N,
 	DIRT_1(p -> p
 		.setNormalMap(DIRT_1_N)
-		.setSpecular(0.5f, 35)),
+		.setSpecular(0.25f, 18)),
 	DIRT_1_VERT(DIRT_1, p -> p.setNormalMap(null)),
 	DIRT_2_N,
 	DIRT_2(p -> p
 		.setNormalMap(DIRT_2_N)
-		.setSpecular(0.4f, 30)),
+		.setSpecular(0.25f, 18)),
 	DIRT_2_VERT(DIRT_2, p -> p.setNormalMap(null)),
 	GRAVEL_N,
 	GRAVEL(p -> p


### PR DESCRIPTION
Corrects an issue better seen in motion where dirt is over bright from too much specularity and gloss.

![image](https://github.com/117HD/RLHD/assets/11658143/8c00f4ca-37dd-4baf-9502-91ce08b43cd3)
![image](https://github.com/117HD/RLHD/assets/11658143/f124f792-06c9-4e68-bf52-ef82d024b71d)
