### PR TITLE
Wizard Tower Changed Roof 

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Area.java
+++ b/src/main/java/rs117/hd/data/environments/Area.java
@@ -311,6 +311,7 @@ public enum Area
 		new AABB(3118,3166),
 		new AABB(3115,3166)
 	),
+	WIZARD_TOWER_ROOF(new AABB(3101, 3167, 3116, 3153)),
 
 	// Misthalin Mystery
 	MISTHALIN_MYSTERY_MANOR(1600, 4863, 1727, 4779),

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -803,7 +803,7 @@ public enum Overlay {
 		.replaceWithIf(WINTER_JAGGED_STONE_TILE, plugin -> plugin.configWinterTheme)
 		.ids(-85, -77, 11)
 	),
-	WIZARD_TOWER_ROOF(GroundMaterial.GRUNGE_2, p -> p
+	WIZARD_TOWER_ROOF(GroundMaterial.MARBLE_1_GLOSS, p -> p.blended(false)
 		.area(Area.WIZARD_TOWER_ROOF)
 		.ids(33).replaceWithIf(STRANGLEWOOD_SNOW,plugin -> plugin.configWinterTheme)
 	),

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -807,9 +807,11 @@ public enum Overlay {
 		.replaceWithIf(WINTER_JAGGED_STONE_TILE, plugin -> plugin.configWinterTheme)
 		.ids(-85, -77, 11)
 	),
-	WIZARD_TOWER_ROOF(GroundMaterial.MARBLE_1_GLOSS, p -> p.blended(false)
+	WIZARD_TOWER_ROOF(GroundMaterial.MARBLE_1_GLOSS, p -> p
+		.ids(33)
+		.blended(false)
 		.area(Area.WIZARD_TOWER_ROOF)
-		.ids(33).replaceWithIf(SNOW_2,plugin -> plugin.configWinterTheme)
+		.replaceWithIf(SNOW_2, plugin -> plugin.configWinterTheme)
 	),
 	OVERLAY_SWAMP_WATER(WaterType.SWAMP_WATER, p -> p.ids(-100, 7)),
 	OVERLAY_WOOD_PLANKS(GroundMaterial.WOOD_PLANKS_1, p -> p.ids(5, 35)),

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -56,6 +56,10 @@ public enum Overlay {
 		.ids()
 		.groundMaterial(GroundMaterial.WINTER_JAGGED_STONE_TILE_LIGHT_2)
 	),
+	SNOW_2(p -> p
+		.ids()
+		.groundMaterial(GroundMaterial.SNOW_2)
+	),
 	WINTER_EAST_ARDOUGNE_CASTLE_PATH_FIX(10, Area.EAST_ARDOUGNE_CASTLE_PATH_FIX, GroundMaterial.VARROCK_PATHS, p -> p
 		.replaceWithIf(WINTER_JAGGED_STONE_TILE_LIGHT, plugin -> plugin.configWinterTheme)
 		.shiftLightness(3)
@@ -805,7 +809,7 @@ public enum Overlay {
 	),
 	WIZARD_TOWER_ROOF(GroundMaterial.MARBLE_1_GLOSS, p -> p.blended(false)
 		.area(Area.WIZARD_TOWER_ROOF)
-		.ids(33).replaceWithIf(STRANGLEWOOD_SNOW,plugin -> plugin.configWinterTheme)
+		.ids(33).replaceWithIf(SNOW_2,plugin -> plugin.configWinterTheme)
 	),
 	OVERLAY_SWAMP_WATER(WaterType.SWAMP_WATER, p -> p.ids(-100, 7)),
 	OVERLAY_WOOD_PLANKS(GroundMaterial.WOOD_PLANKS_1, p -> p.ids(5, 35)),

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -803,6 +803,10 @@ public enum Overlay {
 		.replaceWithIf(WINTER_JAGGED_STONE_TILE, plugin -> plugin.configWinterTheme)
 		.ids(-85, -77, 11)
 	),
+	WIZARD_TOWER_ROOF(GroundMaterial.GRUNGE_2, p -> p
+		.area(Area.WIZARD_TOWER_ROOF)
+		.ids(33).replaceWithIf(STRANGLEWOOD_SNOW,plugin -> plugin.configWinterTheme)
+	),
 	OVERLAY_SWAMP_WATER(WaterType.SWAMP_WATER, p -> p.ids(-100, 7)),
 	OVERLAY_WOOD_PLANKS(GroundMaterial.WOOD_PLANKS_1, p -> p.ids(5, 35)),
 	OVERLAY_CLEAN_WOOD_PLANKS(GroundMaterial.CLEAN_WOOD_FLOOR, p -> p.ids(52).shiftLightness(-4)),


### PR DESCRIPTION
Changed roof from being snow all the time to 


MARBLE_1_GLOSS

Before:
![image](https://github.com/117HD/RLHD/assets/72366279/596b234c-0c71-4fb0-b5f5-5eaa9ea878ab)
After:
![image](https://github.com/117HD/RLHD/assets/72366279/39deb81e-966a-46e3-a242-4e65304c43cf)

It seems like they (Jagex) used overlay 33 so the roof was bright, as they did in the fally party room this just makes the roof use marble like we did for party room