### PR TITLE
Fix untextured Sophanem overlay

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -213,10 +213,10 @@ public enum Overlay {
 	OVERRIDE_SOPHANEM_CHURCH_FLOOR_FIX_2(26, Area.SOPHANEM_FLOORS, GroundMaterial.TILES_2X2_2_SEMIGLOSS, p -> p.blended(false)),
 	SOPHANEM_SUNTRAP(p -> p
 		.ids(1)
-		.groundMaterial(GroundMaterial.CLEAN_TILE)
+		.groundMaterial(GroundMaterial.MARBLE_2)
 		.area(Area.KHARID_DESERT_REGION)
 		.blended(false)
-		.shiftLightness(45)),
+		.shiftLightness(20)),
 	MAGE_TRAINING_ARENA_FLOOR(-122, Area.MAGE_TRAINING_ARENA, GroundMaterial.TILES_2X2_2_GLOSS, p -> p.blended(false)),
 	AL_KHARID_WELL_FIX(21, Area.AL_KHARID_WELL, GroundMaterial.DIRT, p -> p.blended(false)),
 	AL_KHARID_FLOOR_1(26, Area.AL_KHARID_BUILDINGS, GroundMaterial.TILES_2X2_2_SEMIGLOSS, p -> p

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -211,6 +211,12 @@ public enum Overlay {
 	// Al Kharid
 	OVERRIDE_SOPHANEM_CHURCH_FLOOR_FIX_1(21, Area.SOPHANEM_FLOORS, GroundMaterial.TILES_2X2_2_SEMIGLOSS, p -> p.blended(false)),
 	OVERRIDE_SOPHANEM_CHURCH_FLOOR_FIX_2(26, Area.SOPHANEM_FLOORS, GroundMaterial.TILES_2X2_2_SEMIGLOSS, p -> p.blended(false)),
+	SOPHANEM_SUNTRAP(p -> p
+		.ids(1)
+		.groundMaterial(GroundMaterial.CLEAN_TILE)
+		.area(Area.KHARID_DESERT_REGION)
+		.blended(false)
+		.shiftLightness(45)),
 	MAGE_TRAINING_ARENA_FLOOR(-122, Area.MAGE_TRAINING_ARENA, GroundMaterial.TILES_2X2_2_GLOSS, p -> p.blended(false)),
 	AL_KHARID_WELL_FIX(21, Area.AL_KHARID_WELL, GroundMaterial.DIRT, p -> p.blended(false)),
 	AL_KHARID_FLOOR_1(26, Area.AL_KHARID_BUILDINGS, GroundMaterial.TILES_2X2_2_SEMIGLOSS, p -> p

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -216,7 +216,7 @@ public enum Overlay {
 		.groundMaterial(GroundMaterial.MARBLE_2)
 		.area(Area.KHARID_DESERT_REGION)
 		.blended(false)
-		.shiftLightness(20)),
+		.shiftLightness(10)),
 	MAGE_TRAINING_ARENA_FLOOR(-122, Area.MAGE_TRAINING_ARENA, GroundMaterial.TILES_2X2_2_GLOSS, p -> p.blended(false)),
 	AL_KHARID_WELL_FIX(21, Area.AL_KHARID_WELL, GroundMaterial.DIRT, p -> p.blended(false)),
 	AL_KHARID_FLOOR_1(26, Area.AL_KHARID_BUILDINGS, GroundMaterial.TILES_2X2_2_SEMIGLOSS, p -> p


### PR DESCRIPTION
Overlay is originally untextured so it's just oddly bright sand, this PR sets it to a tile; I attempted to use blending but i couldn't get anything that looked half decent so i opted to go without.

![image](https://github.com/117HD/RLHD/assets/11658143/b2c36c7b-7522-4e24-924e-f533f72ab6e2)
![image](https://github.com/117HD/RLHD/assets/11658143/9c32587a-dfa6-4cf0-bea7-5a85a8888ab8)
