### PR TITLE
Reduce unnecessary color conversions

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -400,9 +400,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 	public boolean configShadowsEnabled;
 	public boolean configExpandShadowDraw;
 	public boolean configUseFasterModelHashing;
-	public boolean configRetainVanillaShading;
-	public boolean configUndoVanillaShadingInCompute;
-	public boolean configUndoVanillaShadingOnCpu;
+	public boolean configUndoVanillaShading;
 	public boolean configPreserveVanillaNormals;
 	public ShadowMode configShadowMode;
 	public SeasonalTheme configSeasonalTheme;
@@ -753,7 +751,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 			.define("SHADOW_MODE", configShadowMode)
 			.define("SHADOW_TRANSPARENCY", config.enableShadowTransparency())
 			.define("VANILLA_COLOR_BANDING", config.vanillaColorBanding())
-			.define("UNDO_VANILLA_SHADING", configUndoVanillaShadingInCompute)
+			.define("UNDO_VANILLA_SHADING", configUndoVanillaShading)
 			.define("LEGACY_GREY_COLORS", configLegacyGreyColors)
 			.define("DISABLE_DIRECTIONAL_SHADING", config.shadingMode() != ShadingMode.DEFAULT)
 			.define("FLAT_SHADING", config.flatShading())
@@ -2114,7 +2112,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 		glUseProgram(glUiProgram);
 		glUniform2i(uniTexSourceDimensions, canvasWidth, canvasHeight);
 		glUniform1f(uniUiColorBlindnessIntensity, config.colorBlindnessIntensity() / 100f);
-		glUniform4fv(uniUiAlphaOverlay, ColorUtils.unpackARGB(overlayColor));
+		glUniform4fv(uniUiAlphaOverlay, ColorUtils.srgba(overlayColor));
 
 		if (client.isStretchedEnabled()) {
 			Dimension dim = client.getStretchedDimensions();
@@ -2390,18 +2388,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 		configMaxDynamicLights = config.maxDynamicLights().getValue();
 		configExpandShadowDraw = config.expandShadowDraw();
 		configUseFasterModelHashing = config.fasterModelHashing();
-		configUndoVanillaShadingInCompute = config.undoVanillaShadingInCompute();
+		configUndoVanillaShading = config.shadingMode() != ShadingMode.VANILLA;
 		configPreserveVanillaNormals = config.preserveVanillaNormals();
 		configSeasonalTheme = config.seasonalTheme();
-		configRetainVanillaShading = config.shadingMode() == ShadingMode.VANILLA;
-		if (configRetainVanillaShading) {
-			// Disable shading reversal entirely
-			configUndoVanillaShadingOnCpu = false;
-			configUndoVanillaShadingInCompute = false;
-		} else {
-			// Do shading reversal on CPU if it's not being done in compute
-			configUndoVanillaShadingOnCpu = !configUndoVanillaShadingInCompute;
-		}
 	}
 
 	@Subscribe
@@ -2482,7 +2471,6 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 							reuploadScene = true;
 							break;
 						case KEY_LEGACY_GREY_COLORS:
-						case KEY_UNDO_VANILLA_SHADING_IN_COMPUTE:
 						case KEY_PRESERVE_VANILLA_NORMALS:
 						case KEY_SHADING_MODE:
 						case KEY_FLAT_SHADING:

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -816,17 +816,6 @@ public interface HdPluginConfig extends Config
 		return true;
 	}
 
-	String KEY_UNDO_VANILLA_SHADING_IN_COMPUTE = "experimentalUndoVanillaShadingInCompute";
-	@ConfigItem(
-		keyName = KEY_UNDO_VANILLA_SHADING_IN_COMPUTE,
-		name = "Undo vanilla shading in compute",
-		description = "Should increase performance at the expense of potential graphical issues.",
-		section = experimentalSettings
-	)
-	default boolean undoVanillaShadingInCompute() {
-		return true;
-	}
-
 	String KEY_PRESERVE_VANILLA_NORMALS = "experimentalPreserveVanillaNormals";
 	@ConfigItem(
 		keyName = KEY_PRESERVE_VANILLA_NORMALS,

--- a/src/main/java/rs117/hd/data/WaterType.java
+++ b/src/main/java/rs117/hd/data/WaterType.java
@@ -30,8 +30,8 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import rs117.hd.data.materials.Material;
 
-import static rs117.hd.utils.ColorUtils.linearToSrgb;
 import static rs117.hd.utils.ColorUtils.rgb;
+import static rs117.hd.utils.ColorUtils.srgb;
 
 public enum WaterType
 {
@@ -44,9 +44,9 @@ public enum WaterType
 		.normalStrength(.05f)
 		.baseOpacity(.8f)
 		.fresnelAmount(.3f)
-		.surfaceColor(linearToSrgb(rgb(23, 33, 20)))
-		.foamColor(linearToSrgb(rgb(115, 120, 101)))
-		.depthColor(linearToSrgb(rgb(41, 82, 26)))
+		.surfaceColor(srgb(23, 33, 20))
+		.foamColor(srgb(115, 120, 101))
+		.depthColor(srgb(41, 82, 26))
 		.causticsStrength(0)
 		.duration(1.2f)),
 	SWAMP_WATER_FLAT(SWAMP_WATER, true),
@@ -56,9 +56,9 @@ public enum WaterType
 		.normalStrength(.05f)
 		.baseOpacity(.9f)
 		.fresnelAmount(.3f)
-		.surfaceColor(linearToSrgb(rgb(22, 23, 13)))
-		.foamColor(linearToSrgb(rgb(106, 108, 100)))
-		.depthColor(linearToSrgb(rgb(50, 52, 46)))
+		.surfaceColor(srgb(22, 23, 13))
+		.foamColor(srgb(106, 108, 100))
+		.depthColor(srgb(50, 52, 46))
 		.causticsStrength(0)
 		.duration(1.6f)),
 	BLACK_TAR_FLAT(b -> b
@@ -79,9 +79,9 @@ public enum WaterType
 		.normalStrength(.05f)
 		.baseOpacity(.8f)
 		.fresnelAmount(.3f)
-		.surfaceColor(linearToSrgb(rgb(38, 0, 0)))
-		.foamColor(linearToSrgb(rgb(117, 63, 45)))
-		.depthColor(linearToSrgb(rgb(50, 26, 22)))
+		.surfaceColor(srgb(38, 0, 0))
+		.foamColor(srgb(117, 63, 45))
+		.depthColor(srgb(50, 26, 22))
 		.causticsStrength(0)
 		.duration(2)),
 	ICE(b -> b
@@ -90,8 +90,8 @@ public enum WaterType
 		.normalStrength(.04f)
 		.baseOpacity(.85f)
 		.fresnelAmount(1)
-		.foamColor(linearToSrgb(rgb(150, 150, 150)))
-		.depthColor(linearToSrgb(rgb(0, 117, 142)))
+		.foamColor(srgb(150, 150, 150))
+		.depthColor(srgb(0, 117, 142))
 		.causticsStrength(.4f)
 		.duration(0)
 		.normalMap(Material.WATER_NORMAL_MAP_2)),
@@ -102,9 +102,9 @@ public enum WaterType
 		.normalStrength(.05f)
 		.baseOpacity(.7f)
 		.fresnelAmount(.3f)
-		.surfaceColor(linearToSrgb(rgb(35, 10, 0)))
-		.foamColor(linearToSrgb(rgb(106, 108, 24)))
-		.depthColor(linearToSrgb(rgb(65, 23, 0)))
+		.surfaceColor(srgb(35, 10, 0))
+		.foamColor(srgb(106, 108, 24))
+		.depthColor(srgb(65, 23, 0))
 		.causticsStrength(0)
 		.duration(2.7f)),
 	SCAR_SLUDGE(b -> b
@@ -113,9 +113,9 @@ public enum WaterType
 		.normalStrength(.05f)
 		.baseOpacity(.85f)
 		.fresnelAmount(.3f)
-		.surfaceColor(linearToSrgb(rgb(0x26, 0x26, 0x23)))
-		.foamColor(linearToSrgb(rgb(0x69, 0x77, 0x5e)))
-		.depthColor(linearToSrgb(rgb(0x69, 0x77, 0x5e)))
+		.surfaceColor(srgb(0x26, 0x26, 0x23))
+		.foamColor(srgb(0x69, 0x77, 0x5e))
+		.depthColor(srgb(0x69, 0x77, 0x5e))
 		.causticsStrength(0)
 		.duration(1.2f)),
 	PLAIN_WATER(b -> b
@@ -151,8 +151,8 @@ public enum WaterType
 		private float fresnelAmount = 1;
 		private Material normalMap = Material.WATER_NORMAL_MAP_1;
 		private float[] surfaceColor = { 1, 1, 1 };
-		private float[] foamColor = linearToSrgb(rgb(176, 164, 146));
-		private float[] depthColor = linearToSrgb(rgb(0, 117, 142));
+		private float[] foamColor = srgb(176, 164, 146);
+		private float[] depthColor = srgb(0, 117, 142);
 		private float causticsStrength = 1;
 		private boolean hasFoam = true;
 		private float duration = 1;

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -1110,19 +1110,19 @@ public enum Overlay {
 		return match;
 	}
 
-	public int[] modifyColor(int[] colorHSL) {
-		colorHSL[0] = hue >= 0 ? hue : colorHSL[0];
-		colorHSL[0] += shiftHue;
-		colorHSL[0] = HDUtils.clamp(colorHSL[0], 0, 63);
+	public int modifyColor(int jagexHsl) {
+		int h = hue != -1 ? hue : jagexHsl >> 10 & 0x3F;
+		h += shiftHue;
+		h = HDUtils.clamp(h, 0, 0x3F);
 
-		colorHSL[1] = saturation >= 0 ? saturation : colorHSL[1];
-		colorHSL[1] += shiftSaturation;
-		colorHSL[1] = HDUtils.clamp(colorHSL[1], 0, 7);
+		int s = saturation != -1 ? saturation : jagexHsl >> 7 & 7;
+		s += shiftSaturation;
+		s = HDUtils.clamp(s, 0, 7);
 
-		colorHSL[2] = lightness >= 0 ? lightness : colorHSL[2];
-		colorHSL[2] += shiftLightness;
-		colorHSL[2] = HDUtils.clamp(colorHSL[2], 0, 127);
+		int l = lightness != -1 ? lightness : jagexHsl & 0x7F;
+		l += shiftLightness;
+		l = HDUtils.clamp(l, 0, 0x7F);
 
-		return colorHSL;
+		return h << 10 | s << 7 | l;
 	}
 }

--- a/src/main/java/rs117/hd/data/materials/Underlay.java
+++ b/src/main/java/rs117/hd/data/materials/Underlay.java
@@ -745,19 +745,19 @@ public enum Underlay {
 		return match;
 	}
 
-	public int[] modifyColor(int[] colorHSL) {
-		colorHSL[0] = hue >= 0 ? hue : colorHSL[0];
-		colorHSL[0] += shiftHue;
-		colorHSL[0] = HDUtils.clamp(colorHSL[0], 0, 63);
+	public int modifyColor(int jagexHsl) {
+		int h = hue != -1 ? hue : jagexHsl >> 10 & 0x3F;
+		h += shiftHue;
+		h = HDUtils.clamp(h, 0, 0x3F);
 
-		colorHSL[1] = saturation >= 0 ? saturation : colorHSL[1];
-		colorHSL[1] += shiftSaturation;
-		colorHSL[1] = HDUtils.clamp(colorHSL[1], 0, 7);
+		int s = saturation != -1 ? saturation : jagexHsl >> 7 & 7;
+		s += shiftSaturation;
+		s = HDUtils.clamp(s, 0, 7);
 
-		colorHSL[2] = lightness >= 0 ? lightness : colorHSL[2];
-		colorHSL[2] += shiftLightness;
-		colorHSL[2] = HDUtils.clamp(colorHSL[2], 0, 127);
+		int l = lightness != -1 ? lightness : jagexHsl & 0x7F;
+		l += shiftLightness;
+		l = HDUtils.clamp(l, 0, 0x7F);
 
-		return colorHSL;
+		return h << 10 | s << 7 | l;
 	}
 }

--- a/src/main/java/rs117/hd/model/ModelPusher.java
+++ b/src/main/java/rs117/hd/model/ModelPusher.java
@@ -36,7 +36,6 @@ import rs117.hd.utils.ModelHash;
 import rs117.hd.utils.PopupUtils;
 
 import static rs117.hd.HdPlugin.MAX_FACE_COUNT;
-import static rs117.hd.utils.HDUtils.LIGHT_DIR_MODEL;
 
 /**
  * Pushes models
@@ -67,23 +66,8 @@ public class ModelPusher {
 
 	public static final int DATUM_PER_FACE = 12;
 	public static final int MAX_MATERIAL_COUNT = (1 << 12) - 1;
-	// subtracts the X lowest lightness levels from the formula.
-	// helps keep darker colors appropriately dark
-	private static final int IGNORE_LOW_LIGHTNESS = 3;
-	// multiplier applied to vertex' lightness value.
-	// results in greater lightening of lighter colors
-	private static final float LIGHTNESS_MULTIPLIER = 3f;
-	// the minimum amount by which each color will be lightened
-	private static final int BASE_LIGHTEN = 10;
 
 	private static final int[] ZEROED_INTS = new int[12];
-
-	private static final int[] MAX_BRIGHTNESS_LOOKUP_TABLE = new int[8];
-
-	static {
-		for (int i = 0; i < 8; i++)
-			MAX_BRIGHTNESS_LOOKUP_TABLE[i] = (int) (127 - 72 * Math.pow(i / 7f, .05));
-	}
 
 	private ModelCache modelCache;
 
@@ -516,16 +500,6 @@ public class ModelPusher {
 		if (color3 == -1)
 			color2 = color3 = color1;
 
-		int color1H = color1 >> 10 & 0x3F;
-		int color1S = color1 >> 7 & 0x7;
-		int color1L = color1 & 0x7F;
-		int color2H = color2 >> 10 & 0x3F;
-		int color2S = color2 >> 7 & 0x7;
-		int color2L = color2 & 0x7F;
-		int color3H = color3 >> 10 & 0x3F;
-		int color3S = color3 >> 7 & 0x7;
-		int color3L = color3 & 0x7F;
-
 		int packedAlphaPriorityFlags = 0;
 		if (faceTransparencies != null && !isTextured)
 			packedAlphaPriorityFlags |= (faceTransparencies[face] & 0xFF) << 24;
@@ -536,90 +510,11 @@ public class ModelPusher {
 			// Without overriding the color for textured faces, vanilla shading remains pretty noticeable even after
 			// the approximate reversal above. Ardougne rooftops is a good example, where vanilla shading results in a
 			// weird-looking tint. The brightness clamp afterward is required to reduce the over-exposure introduced.
-			if (!plugin.configRetainVanillaShading) {
-				color1H = color2H = color3H = 0;
-				color1S = color2S = color3S = 0;
-				color1L = color2L = color3L = 90;
-				
-				// Let the shader know vanilla shading reversal should be skipped for this face
-				packedAlphaPriorityFlags |= 1 << 20;
-			}
+			color1 = color2 = color3 = 90;
+
+			// Let the shader know vanilla shading reversal should be skipped for this face
+			packedAlphaPriorityFlags |= 1 << 20;
 		} else {
-			if (plugin.configUndoVanillaShadingOnCpu) {
-				// Approximately invert vanilla shading by brightening vertices that were likely darkened by vanilla based on
-				// vertex normals. This process is error-prone, as not all models are lit by vanilla with the same light
-				// direction, and some models even have baked lighting built into the model itself. In some cases, increasing
-				// brightness in this way leads to overly bright colors, so we are forced to cap brightness at a relatively
-				// low value for it to look acceptable in most cases.
-				float[] L = LIGHT_DIR_MODEL;
-				float color1Adjust = BASE_LIGHTEN - color1L +
-									 (color1L < IGNORE_LOW_LIGHTNESS ? 0 : (color1L - IGNORE_LOW_LIGHTNESS) * LIGHTNESS_MULTIPLIER);
-				float color2Adjust = BASE_LIGHTEN - color2L +
-									 (color2L < IGNORE_LOW_LIGHTNESS ? 0 : (color2L - IGNORE_LOW_LIGHTNESS) * LIGHTNESS_MULTIPLIER);
-				float color3Adjust = BASE_LIGHTEN - color3L +
-									 (color3L < IGNORE_LOW_LIGHTNESS ? 0 : (color3L - IGNORE_LOW_LIGHTNESS) * LIGHTNESS_MULTIPLIER);
-
-				float nx, ny, nz, lightDotNormal;
-				final int[] xVertexNormals = model.getVertexNormalsX();
-				final int[] yVertexNormals = model.getVertexNormalsY();
-				final int[] zVertexNormals = model.getVertexNormalsZ();
-				if (
-					modelOverride.flatNormals ||
-					xVertexNormals == null ||
-					yVertexNormals == null ||
-					zVertexNormals == null ||
-					!plugin.configPreserveVanillaNormals && model.getFaceColors3()[face] == -1
-				) {
-					float ax = xVertices[triA];
-					float ay = yVertices[triA];
-					float az = zVertices[triA];
-					float tx = ax - xVertices[triB];
-					float ty = ay - yVertices[triB];
-					float tz = az - zVertices[triB];
-					float bx = ax - xVertices[triC];
-					float by = ay - yVertices[triC];
-					float bz = az - zVertices[triC];
-					nx = ty * bz - tz * by;
-					ny = tz * bx - tx * bz;
-					nz = tx * by - ty * bx;
-
-					lightDotNormal = nx * L[0] + ny * L[1] + nz * L[2];
-					if (lightDotNormal > 0) {
-						lightDotNormal /= (float) Math.sqrt(nx * nx + ny * ny + nz * nz);
-						color1L += (int) (lightDotNormal * color1Adjust);
-						color2L += (int) (lightDotNormal * color2Adjust);
-						color3L += (int) (lightDotNormal * color3Adjust);
-					}
-				} else {
-					nx = xVertexNormals[triA];
-					ny = yVertexNormals[triA];
-					nz = zVertexNormals[triA];
-					lightDotNormal = nx * L[0] + ny * L[1] + nz * L[2];
-					if (lightDotNormal > 0) {
-						lightDotNormal /= (float) Math.sqrt(nx * nx + ny * ny + nz * nz);
-						color1L += (int) (lightDotNormal * color1Adjust);
-					}
-
-					nx = xVertexNormals[triB];
-					ny = yVertexNormals[triB];
-					nz = zVertexNormals[triB];
-					lightDotNormal = nx * L[0] + ny * L[1] + nz * L[2];
-					if (lightDotNormal > 0) {
-						lightDotNormal /= (float) Math.sqrt(nx * nx + ny * ny + nz * nz);
-						color2L += (int) (lightDotNormal * color2Adjust);
-					}
-
-					nx = xVertexNormals[triC];
-					ny = yVertexNormals[triC];
-					nz = zVertexNormals[triC];
-					lightDotNormal = nx * L[0] + ny * L[1] + nz * L[2];
-					if (lightDotNormal > 0) {
-						lightDotNormal /= (float) Math.sqrt(nx * nx + ny * ny + nz * nz);
-						color3L += (int) (lightDotNormal * color3Adjust);
-					}
-				}
-			}
-
 			final int overrideAmount = model.getOverrideAmount() & 0xFF;
 			if (overrideAmount > 0) {
 				// HSL override is not applied to flat shade faces or to textured faces
@@ -628,21 +523,21 @@ public class ModelPusher {
 				final byte overrideLum = model.getOverrideLuminance();
 
 				if (overrideHue != -1) {
-					color1H += overrideAmount * (overrideHue - color1H) >> 7;
-					color2H += overrideAmount * (overrideHue - color2H) >> 7;
-					color3H += overrideAmount * (overrideHue - color3H) >> 7;
+					color1 += overrideAmount * (overrideHue - (color1 >> 10 & 0x3F)) >> 7 << 10;
+					color2 += overrideAmount * (overrideHue - (color2 >> 10 & 0x3F)) >> 7 << 10;
+					color3 += overrideAmount * (overrideHue - (color3 >> 10 & 0x3F)) >> 7 << 10;
 				}
 
 				if (overrideSat != -1) {
-					color1S += overrideAmount * (overrideSat - color1S) >> 7;
-					color2S += overrideAmount * (overrideSat - color2S) >> 7;
-					color3S += overrideAmount * (overrideSat - color3S) >> 7;
+					color1 += overrideAmount * (overrideSat - (color1 >> 7 & 7)) >> 7 << 7;
+					color2 += overrideAmount * (overrideSat - (color2 >> 7 & 7)) >> 7 << 7;
+					color3 += overrideAmount * (overrideSat - (color3 >> 7 & 7)) >> 7 << 7;
 				}
 
 				if (overrideLum != -1) {
-					color1L += overrideAmount * (overrideLum - color1L) >> 7;
-					color2L += overrideAmount * (overrideLum - color2L) >> 7;
-					color3L += overrideAmount * (overrideLum - color3L) >> 7;
+					color1 += overrideAmount * (overrideLum - (color1 & 0x7F)) >> 7;
+					color2 += overrideAmount * (overrideLum - (color2 & 0x7F)) >> 7;
+					color3 += overrideAmount * (overrideLum - (color3 & 0x7F)) >> 7;
 				}
 			}
 
@@ -653,42 +548,33 @@ public class ModelPusher {
 					SceneTilePaint tilePaint = tile.getSceneTilePaint();
 
 					if (tilePaint != null || tileModel != null) {
-						int[] tileColorHSL;
-
 						// No point in inheriting tilepaint color if the ground tile does not have a color, for example above a cave wall
-						if (tilePaint != null && tilePaint.getTexture() == -1 && tilePaint.getRBG() != 0
-							&& tilePaint.getNeColor() != 12345678) {
-							// pull any corner color as either one should be OK
-							tileColorHSL = HDUtils.colorIntToHSL(tilePaint.getNeColor());
+						if (
+							tilePaint != null &&
+							tilePaint.getTexture() == -1 &&
+							tilePaint.getRBG() != 0 &&
+							tilePaint.getNeColor() != 12345678
+						) {
 
-							// average saturation and lightness
-							tileColorHSL[1] =
+							// Since tile colors are guaranteed to have the same hue and saturation per face,
+							// we can blend without converting from HSL to RGB
+							int averageColor =
 								(
-									tileColorHSL[1] +
-									HDUtils.colorIntToHSL(tilePaint.getSeColor())[1] +
-									HDUtils.colorIntToHSL(tilePaint.getNwColor())[1] +
-									HDUtils.colorIntToHSL(tilePaint.getNeColor())[1]
-								) / 4;
-
-							tileColorHSL[2] =
-								(
-									tileColorHSL[2] +
-									HDUtils.colorIntToHSL(tilePaint.getSeColor())[2] +
-									HDUtils.colorIntToHSL(tilePaint.getNwColor())[2] +
-									HDUtils.colorIntToHSL(tilePaint.getNeColor())[2]
+									tilePaint.getSwColor() +
+									tilePaint.getNwColor() +
+									tilePaint.getNeColor() +
+									tilePaint.getSeColor()
 								) / 4;
 
 							Overlay overlay = Overlay.getOverlay(scene, tile, plugin);
 							if (overlay != Overlay.NONE) {
-								overlay.modifyColor(tileColorHSL);
+								averageColor = overlay.modifyColor(averageColor);
 							} else {
 								Underlay underlay = Underlay.getUnderlay(scene, tile, plugin);
-								underlay.modifyColor(tileColorHSL);
+								averageColor = underlay.modifyColor(averageColor);
 							}
 
-							color1H = color2H = color3H = tileColorHSL[0];
-							color1S = color2S = color3S = tileColorHSL[1];
-							color1L = color2L = color3L = tileColorHSL[2];
+							color1 = color2 = color3 = averageColor;
 
 							// Let the shader know vanilla shading reversal should be skipped for this face
 							packedAlphaPriorityFlags |= 1 << 20;
@@ -717,14 +603,9 @@ public class ModelPusher {
 							if (faceColorIndex != -1) {
 								int color = tileModel.getTriangleColorA()[faceColorIndex];
 								if (color != 12345678) {
-									tileColorHSL = HDUtils.colorIntToHSL(color);
-
 									Underlay underlay = Underlay.getUnderlay(scene, tile, plugin);
-									underlay.modifyColor(tileColorHSL);
-
-									color1H = color2H = color3H = tileColorHSL[0];
-									color1S = color2S = color3S = tileColorHSL[1];
-									color1L = color2L = color3L = tileColorHSL[2];
+									color = underlay.modifyColor(color);
+									color1 = color2 = color3 = color;
 
 									// Let the shader know vanilla shading reversal should be skipped for this face
 									packedAlphaPriorityFlags |= 1 << 20;
@@ -735,52 +616,27 @@ public class ModelPusher {
 				}
 
 				if (plugin.configTzhaarHD && modelOverride.tzHaarRecolorType != TzHaarRecolorType.NONE) {
-					int[][] tzHaarRecolored = ProceduralGenerator.recolorTzHaar(
+					int[] tzHaarRecolored = ProceduralGenerator.recolorTzHaar(
 						modelOverride,
 						model,
 						face,
 						packedAlphaPriorityFlags,
 						objectType,
-						color1S,
-						color1L,
-						color2S,
-						color2L,
-						color3S,
-						color3L
+						color1,
+						color2,
+						color3
 					);
-					color1H = tzHaarRecolored[0][0];
-					color1S = tzHaarRecolored[0][1];
-					color1L = tzHaarRecolored[0][2];
-					color2H = tzHaarRecolored[1][0];
-					color2S = tzHaarRecolored[1][1];
-					color2L = tzHaarRecolored[1][2];
-					color3H = tzHaarRecolored[2][0];
-					color3S = tzHaarRecolored[2][1];
-					color3L = tzHaarRecolored[2][2];
-					packedAlphaPriorityFlags = tzHaarRecolored[3][0];
+					color1 = tzHaarRecolored[0];
+					color2 = tzHaarRecolored[1];
+					color3 = tzHaarRecolored[2];
+					packedAlphaPriorityFlags = tzHaarRecolored[3];
 				}
-			}
-
-			if (plugin.configUndoVanillaShadingOnCpu) {
-				int maxBrightness1 = 55;
-				int maxBrightness2 = 55;
-				int maxBrightness3 = 55;
-				if (!plugin.configLegacyGreyColors) {
-					maxBrightness1 = MAX_BRIGHTNESS_LOOKUP_TABLE[color1S];
-					maxBrightness2 = MAX_BRIGHTNESS_LOOKUP_TABLE[color2S];
-					maxBrightness3 = MAX_BRIGHTNESS_LOOKUP_TABLE[color3S];
-				}
-
-				// Clamp brightness as detailed above
-				color1L = color1L > maxBrightness1 ? maxBrightness1 : color1L;
-				color2L = color2L > maxBrightness2 ? maxBrightness2 : color2L;
-				color3L = color3L > maxBrightness3 ? maxBrightness3 : color3L;
 			}
 		}
 
-		color1 = packedAlphaPriorityFlags | color1H << 10 | color1S << 7 | color1L;
-		color2 = packedAlphaPriorityFlags | color2H << 10 | color2S << 7 | color2L;
-		color3 = packedAlphaPriorityFlags | color3H << 10 | color3S << 7 | color3L;
+		color1 |= packedAlphaPriorityFlags;
+		color2 |= packedAlphaPriorityFlags;
+		color3 |= packedAlphaPriorityFlags;
 
 		int[] data = sceneContext.modelFaceVertices;
 		data[0] = xVertices[triA];

--- a/src/main/java/rs117/hd/opengl/compute/OpenCLManager.java
+++ b/src/main/java/rs117/hd/opengl/compute/OpenCLManager.java
@@ -319,7 +319,7 @@ public class OpenCLManager {
 	public void initPrograms() throws ShaderException, IOException {
 		try (var stack = MemoryStack.stackPush()) {
 			var template = new Template()
-				.define("UNDO_VANILLA_SHADING", plugin.configUndoVanillaShadingInCompute)
+				.define("UNDO_VANILLA_SHADING", plugin.configUndoVanillaShading)
 				.define("LEGACY_GREY_COLORS", plugin.configLegacyGreyColors)
 				.addIncludePath(OpenCLManager.class);
 			passthroughProgram = compileProgram(stack, template.load("comp_unordered.cl"));

--- a/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
+++ b/src/main/java/rs117/hd/overlays/TileInfoOverlay.java
@@ -496,7 +496,6 @@ public class TileInfoOverlay extends net.runelite.client.ui.overlay.Overlay {
 	private static String hslString(int color) {
 		if (color == 12345678)
 			return "HIDDEN";
-		int[] hsl = HDUtils.colorIntToHSL(color);
-		return color + " (" + hsl[0] + ", " + hsl[1] + ", " + hsl[2] + ")";
+		return color + " (" + (color >> 10 & 0x3F) + ", " + (color >> 7 & 7) + ", " + (color & 0x7F) + ")";
 	}
 }

--- a/src/main/java/rs117/hd/scene/ProceduralGenerator.java
+++ b/src/main/java/rs117/hd/scene/ProceduralGenerator.java
@@ -39,9 +39,14 @@ import rs117.hd.data.materials.Underlay;
 import rs117.hd.scene.model_overrides.ModelOverride;
 import rs117.hd.scene.model_overrides.ObjectType;
 import rs117.hd.scene.model_overrides.TzHaarRecolorType;
-import rs117.hd.utils.HDUtils;
 
 import static net.runelite.api.Constants.*;
+import static rs117.hd.utils.HDUtils.add;
+import static rs117.hd.utils.HDUtils.calculateSurfaceNormals;
+import static rs117.hd.utils.HDUtils.clamp;
+import static rs117.hd.utils.HDUtils.dotLightDirectionTile;
+import static rs117.hd.utils.HDUtils.lerp;
+import static rs117.hd.utils.HDUtils.vertexHash;
 
 @Slf4j
 @Singleton
@@ -258,7 +263,7 @@ public class ProceduralGenerator {
 			// Near-solid-black tiles that are used in some places under wall objects
 			boolean lowPriorityColor = vertexColors[vertex] <= 2;
 
-			int[] colorHSL = HDUtils.colorIntToHSL(vertexColors[vertex]);
+			int color = vertexColors[vertex];
 
 			float lightenMultiplier = 1.5f;
 			int lightenBase = 15;
@@ -269,12 +274,23 @@ public class ProceduralGenerator {
 
 			float[] vNormals = sceneContext.vertexTerrainNormals.getOrDefault(vertexHashes[vertex], new float[] { 0, 0, 0 });
 
-			float dot = HDUtils.dotLightDirectionTile(vNormals[0], vNormals[1], vNormals[2]);
-			int lighten = (int) (Math.max((colorHSL[2] - lightenAdd), 0) * lightenMultiplier) + lightenBase;
-			colorHSL[2] = (int) HDUtils.lerp(colorHSL[2], lighten, Math.max(dot, 0));
-			int darken = (int) (Math.max((colorHSL[2] - darkenAdd), 0) * darkenMultiplier) + darkenBase;
-			colorHSL[2] = (int) HDUtils.lerp(colorHSL[2], darken, Math.abs(Math.min(dot, 0)));
-			colorHSL[2] *= 1.25f;
+			float dot = dotLightDirectionTile(vNormals[0], vNormals[1], vNormals[2]);
+			int lightness = color & 0x7F;
+			lightness = (int) lerp(
+				lightness,
+				(int) (
+					Math.max((lightness - lightenAdd), 0) * lightenMultiplier
+				) + lightenBase,
+				Math.max(dot, 0)
+			);
+			lightness = (int) (
+				1.25f * lerp(
+					lightness,
+					(int) (Math.max((lightness - darkenAdd), 0) * darkenMultiplier) + darkenBase,
+					Math.abs(Math.min(dot, 0))
+				)
+			);
+			color = color & ~0x7F | clamp(lightness, 0, 0x7F);
 
 			boolean isOverlay = false;
 			Material material = Material.DIRT_1;
@@ -282,17 +298,18 @@ public class ProceduralGenerator {
 			if (overlay != Overlay.NONE) {
 				material = overlay.groundMaterial.getRandomMaterial(worldPos[2], worldPos[0], worldPos[1]);
 				isOverlay = !overlay.blendedAsUnderlay;
-				overlay.modifyColor(colorHSL);
+				color = overlay.modifyColor(color);
 			} else if (vertexUnderlays[vertex] != Underlay.NONE) {
 				Underlay underlay = vertexUnderlays[vertex];
 				material = underlay.groundMaterial.getRandomMaterial(worldPos[2], worldPos[0], worldPos[1]);
 				isOverlay = underlay.blendedAsOverlay;
-				underlay.modifyColor(colorHSL);
+				color = underlay.modifyColor(color);
 			}
 
 			final int maxBrightness = 55; // reduces overexposure
-			colorHSL[2] = HDUtils.clamp(colorHSL[2], 0, maxBrightness);
-			vertexColors[vertex] = HDUtils.colorHSLToInt(colorHSL);
+			if (lightness > maxBrightness)
+				color = color & ~0x7F | maxBrightness;
+			vertexColors[vertex] = color;
 
 			// mark the vertex as either an overlay or underlay.
 			// this is used to determine how to blend between vertex colors
@@ -597,9 +614,9 @@ public class ProceduralGenerator {
 					// limit range of variation
 					float minOffset = 0.25f;
 					float maxOffset = 0.75f;
-					noiseOffset = HDUtils.lerp(minOffset, maxOffset, noiseOffset);
+					noiseOffset = lerp(minOffset, maxOffset, noiseOffset);
 					// apply offset to vertex height range
-					int heightOffset = (int) HDUtils.lerp(minRange, maxRange, noiseOffset);
+					int heightOffset = (int) lerp(minRange, maxRange, noiseOffset);
 					underwaterDepths[z][x][y] = heightOffset;
 				}
 			}
@@ -671,13 +688,13 @@ public class ProceduralGenerator {
 									int localVertexY = vertices[vertex][1] - (tileY * Perspective.LOCAL_TILE_SIZE);
 									float lerpX = (float) localVertexX / (float) Perspective.LOCAL_TILE_SIZE;
 									float lerpY = (float) localVertexY / (float) Perspective.LOCAL_TILE_SIZE;
-									float northHeightOffset = HDUtils.lerp(
+									float northHeightOffset = lerp(
 										underwaterDepths[z][x][y + 1],
 										underwaterDepths[z][x + 1][y + 1],
 										lerpX
 									);
-									float southHeightOffset = HDUtils.lerp(underwaterDepths[z][x][y], underwaterDepths[z][x + 1][y], lerpX);
-									int heightOffset = (int) HDUtils.lerp(southHeightOffset, northHeightOffset, lerpY);
+									float southHeightOffset = lerp(underwaterDepths[z][x][y], underwaterDepths[z][x + 1][y], lerpX);
+									int heightOffset = (int) lerp(southHeightOffset, northHeightOffset, lerpY);
 
 									if (!sceneContext.vertexIsLand.containsKey(vertexKeys[vertex])) {
 										sceneContext.vertexUnderwaterDepth.put(vertexKeys[vertex], heightOffset);
@@ -776,7 +793,7 @@ public class ProceduralGenerator {
 				vertexHeights[2] += sceneContext.vertexUnderwaterDepth.getOrDefault(faceVertexKeys[face][2], 0);
 			}
 
-			float[] vertexNormals = HDUtils.calculateSurfaceNormals(
+			float[] vertexNormals = calculateSurfaceNormals(
 				new float[] {
 					faceVertices[face][0][0],
 					faceVertices[face][0][1],
@@ -798,7 +815,7 @@ public class ProceduralGenerator {
 			{
 				int vertexKey = faceVertexKeys[face][vertex];
 				// accumulate normals to hashmap
-				sceneContext.vertexTerrainNormals.merge(vertexKey, vertexNormals, (a, b) -> HDUtils.add(a, a, b));
+				sceneContext.vertexTerrainNormals.merge(vertexKey, vertexNormals, (a, b) -> add(a, a, b));
 			}
 		}
 	}
@@ -1006,7 +1023,7 @@ public class ProceduralGenerator {
 		int[] vertexHashes = new int[tileVertices.length];
 
 		for (int vertex = 0; vertex < tileVertices.length; ++vertex)
-			vertexHashes[vertex] = HDUtils.vertexHash(tileVertices[vertex]);
+			vertexHashes[vertex] = vertexHash(tileVertices[vertex]);
 
 		return vertexHashes;
 	}
@@ -1017,12 +1034,12 @@ public class ProceduralGenerator {
 		int[] vertexHashes = new int[faceVertices.length];
 
 		for (int vertex = 0; vertex < faceVertices.length; ++vertex)
-			vertexHashes[vertex] = HDUtils.vertexHash(faceVertices[vertex]);
+			vertexHashes[vertex] = vertexHash(faceVertices[vertex]);
 
 		return vertexHashes;
 	}
 
-	private static final int[][] tzHaarRecolored = new int[4][3];
+	private static final int[] tzHaarRecolored = new int[4];
 	// used when calculating the gradient to apply to the walls of TzHaar
 	// to emulate the style from 2008 HD rework
 	private static final int[] gradientBaseColor = new int[]{3, 4, 26};
@@ -1030,19 +1047,28 @@ public class ProceduralGenerator {
 	private static final int gradientBottom = 200;
 	private static final int gradientTop = -200;
 
-	public static int[][] recolorTzHaar(
+	public static int[] recolorTzHaar(
 		ModelOverride modelOverride,
 		Model model,
 		int face,
 		int packedAlphaPriority,
 		ObjectType objectType,
-		int color1S,
-		int color1L,
-		int color2S,
-		int color2L,
-		int color3S,
-		int color3L
+		int color1,
+		int color2,
+		int color3
 	) {
+		// shift model hues from red->yellow
+		int hue = 7;
+		int color1H = hue;
+		int color2H = hue;
+		int color3H = hue;
+		int color1S = color1 >> 7 & 7;
+		int color1L = color1 & 0x7F;
+		int color2S = color2 >> 7 & 7;
+		int color2L = color2 & 0x7F;
+		int color3S = color3 >> 7 & 7;
+		int color3L = color3 & 0x7F;
+
 		// recolor tzhaar to look like the 2008+ HD version
 		if (objectType == ObjectType.GROUND_OBJECT) {
 			// remove the black parts of floor objects to allow the ground to show
@@ -1050,12 +1076,6 @@ public class ProceduralGenerator {
 			if (color1S <= 1)
 				packedAlphaPriority = 0xFF << 24;
 		}
-
-		// shift model hues from red->yellow
-		int hue = 7;
-		int color1H = hue;
-		int color2H = hue;
-		int color3H = hue;
 
 		if (modelOverride.tzHaarRecolorType == TzHaarRecolorType.GRADIENT) {
 			final int triA = model.getFaceIndices1()[face];
@@ -1068,26 +1088,26 @@ public class ProceduralGenerator {
 
 			// apply coloring to the rocky walls
 			if (color1L < 20) {
-				float pos = HDUtils.clamp((float) (heightA - gradientTop) / (float) gradientBottom, 0.0f, 1.0f);
-				color1H = (int) HDUtils.lerp(gradientDarkColor[0], gradientBaseColor[0], pos);
-				color1S = (int) HDUtils.lerp(gradientDarkColor[1], gradientBaseColor[1], pos);
-				color1L = (int) HDUtils.lerp(gradientDarkColor[2], gradientBaseColor[2], pos);
+				float pos = clamp((float) (heightA - gradientTop) / (float) gradientBottom, 0.0f, 1.0f);
+				color1H = (int) lerp(gradientDarkColor[0], gradientBaseColor[0], pos);
+				color1S = (int) lerp(gradientDarkColor[1], gradientBaseColor[1], pos);
+				color1L = (int) lerp(gradientDarkColor[2], gradientBaseColor[2], pos);
 			}
 
 			if (color2L < 20)
 			{
-				float pos = HDUtils.clamp((float) (heightB - gradientTop) / (float) gradientBottom, 0.0f, 1.0f);
-				color2H = (int)HDUtils.lerp(gradientDarkColor[0], gradientBaseColor[0], pos);
-				color2S = (int)HDUtils.lerp(gradientDarkColor[1], gradientBaseColor[1], pos);
-				color2L = (int)HDUtils.lerp(gradientDarkColor[2], gradientBaseColor[2], pos);
+				float pos = clamp((float) (heightB - gradientTop) / (float) gradientBottom, 0.0f, 1.0f);
+				color2H = (int) lerp(gradientDarkColor[0], gradientBaseColor[0], pos);
+				color2S = (int) lerp(gradientDarkColor[1], gradientBaseColor[1], pos);
+				color2L = (int) lerp(gradientDarkColor[2], gradientBaseColor[2], pos);
 			}
 
 			if (color3L < 20)
 			{
-				float pos = HDUtils.clamp((float) (heightC - gradientTop) / (float) gradientBottom, 0.0f, 1.0f);
-				color3H = (int)HDUtils.lerp(gradientDarkColor[0], gradientBaseColor[0], pos);
-				color3S = (int)HDUtils.lerp(gradientDarkColor[1], gradientBaseColor[1], pos);
-				color3L = (int)HDUtils.lerp(gradientDarkColor[2], gradientBaseColor[2], pos);
+				float pos = clamp((float) (heightC - gradientTop) / (float) gradientBottom, 0.0f, 1.0f);
+				color3H = (int) lerp(gradientDarkColor[0], gradientBaseColor[0], pos);
+				color3S = (int) lerp(gradientDarkColor[1], gradientBaseColor[1], pos);
+				color3L = (int) lerp(gradientDarkColor[2], gradientBaseColor[2], pos);
 			}
 		}
 		else if (modelOverride.tzHaarRecolorType == TzHaarRecolorType.HUE_SHIFT)
@@ -1099,16 +1119,10 @@ public class ProceduralGenerator {
 			color3L += 1;
 		}
 
-		tzHaarRecolored[0][0] = color1H;
-		tzHaarRecolored[0][1] = color1S;
-		tzHaarRecolored[0][2] = color1L;
-		tzHaarRecolored[1][0] = color2H;
-		tzHaarRecolored[1][1] = color2S;
-		tzHaarRecolored[1][2] = color2L;
-		tzHaarRecolored[2][0] = color3H;
-		tzHaarRecolored[2][1] = color3S;
-		tzHaarRecolored[2][2] = color3L;
-		tzHaarRecolored[3][0] = packedAlphaPriority;
+		tzHaarRecolored[0] = color1H << 10 | color1S << 7 | color1L;
+		tzHaarRecolored[1] = color2H << 10 | color2S << 7 | color2L;
+		tzHaarRecolored[2] = color3H << 10 | color3S << 7 | color3L;
+		tzHaarRecolored[3] = packedAlphaPriority;
 
 		return tzHaarRecolored;
 	}

--- a/src/main/java/rs117/hd/scene/SceneUploader.java
+++ b/src/main/java/rs117/hd/scene/SceneUploader.java
@@ -499,18 +499,18 @@ class SceneUploader {
 					if (overlay != Overlay.NONE)
 					{
 						groundMaterial = overlay.groundMaterial;
-						swColor = HDUtils.colorHSLToInt(overlay.modifyColor(HDUtils.colorIntToHSL(swColor)));
-						seColor = HDUtils.colorHSLToInt(overlay.modifyColor(HDUtils.colorIntToHSL(seColor)));
-						nwColor = HDUtils.colorHSLToInt(overlay.modifyColor(HDUtils.colorIntToHSL(nwColor)));
-						neColor = HDUtils.colorHSLToInt(overlay.modifyColor(HDUtils.colorIntToHSL(neColor)));
+						swColor = overlay.modifyColor(swColor);
+						seColor = overlay.modifyColor(seColor);
+						nwColor = overlay.modifyColor(nwColor);
+						neColor = overlay.modifyColor(neColor);
 					} else {
 						Underlay underlay = Underlay.getUnderlay(scene, tile, plugin);
 						if (underlay != Underlay.NONE) {
 							groundMaterial = underlay.groundMaterial;
-							swColor = HDUtils.colorHSLToInt(underlay.modifyColor(HDUtils.colorIntToHSL(swColor)));
-							seColor = HDUtils.colorHSLToInt(underlay.modifyColor(HDUtils.colorIntToHSL(seColor)));
-							nwColor = HDUtils.colorHSLToInt(underlay.modifyColor(HDUtils.colorIntToHSL(nwColor)));
-							neColor = HDUtils.colorHSLToInt(underlay.modifyColor(HDUtils.colorIntToHSL(neColor)));
+							swColor = underlay.modifyColor(swColor);
+							seColor = underlay.modifyColor(seColor);
+							nwColor = underlay.modifyColor(nwColor);
+							neColor = underlay.modifyColor(neColor);
 						}
 					}
 
@@ -849,17 +849,17 @@ class SceneUploader {
 							if (overlay != Overlay.NONE)
 								groundMaterial = overlay.groundMaterial;
 
-							colorA = HDUtils.colorHSLToInt(overlay.modifyColor(HDUtils.colorIntToHSL(colorA)));
-							colorB = HDUtils.colorHSLToInt(overlay.modifyColor(HDUtils.colorIntToHSL(colorB)));
-							colorC = HDUtils.colorHSLToInt(overlay.modifyColor(HDUtils.colorIntToHSL(colorC)));
+							colorA = overlay.modifyColor(colorA);
+							colorB = overlay.modifyColor(colorB);
+							colorC = overlay.modifyColor(colorC);
 						} else {
 							Underlay underlay = Underlay.getUnderlay(scene, tile, plugin);
 							if (underlay != Underlay.NONE)
 								groundMaterial = underlay.groundMaterial;
 
-							colorA = HDUtils.colorHSLToInt(underlay.modifyColor(HDUtils.colorIntToHSL(colorA)));
-							colorB = HDUtils.colorHSLToInt(underlay.modifyColor(HDUtils.colorIntToHSL(colorB)));
-							colorC = HDUtils.colorHSLToInt(underlay.modifyColor(HDUtils.colorIntToHSL(colorC)));
+							colorA = underlay.modifyColor(colorA);
+							colorB = underlay.modifyColor(colorB);
+							colorC = underlay.modifyColor(colorC);
 						}
 
 						if (plugin.configGroundTextures && groundMaterial != null) {

--- a/src/main/java/rs117/hd/utils/ColorUtils.java
+++ b/src/main/java/rs117/hd/utils/ColorUtils.java
@@ -224,7 +224,7 @@ public class ColorUtils {
 	 * @return float[3] linear rgb values from 0-1
 	 */
 	public static float[] rgb(float r, float g, float b) {
-		return srgbToLinear(new float[] { r / 255f, g / 255f, b / 255f });
+		return srgbToLinear(srgb(r, g, b));
 	}
 
 	/**
@@ -234,8 +234,63 @@ public class ColorUtils {
 	 * @return float[3] linear rgb values from 0-1
 	 */
 	public static float[] rgb(String hex) {
+		return srgbToLinear(srgb(hex));
+	}
+
+	/**
+	 * Convert sRGB color packed as an int to linear RGB in the range 0-1.
+	 *
+	 * @param rgbInt RGB hex color
+	 * @return float[3] linear rgb values from 0-1
+	 */
+	public static float[] rgb(int rgbInt) {
+		return srgbToLinear(srgb(rgbInt));
+	}
+
+	/**
+	 * Convert red, green and blue in the range 0-255 from sRGB to sRGB in the range 0-1.
+	 *
+	 * @param r red color
+	 * @param g green color
+	 * @param b blue color
+	 * @return float[3] non-linear srgb values from 0-1
+	 */
+	public static float[] srgb(float r, float g, float b) {
+		return new float[] { r / 255f, g / 255f, b / 255f };
+	}
+
+	/**
+	 * Convert hex color from sRGB to sRGB in the range 0-1.
+	 *
+	 * @param hex RGB hex color
+	 * @return float[3] non-linear srgb values from 0-1
+	 */
+	public static float[] srgb(String hex) {
 		Color color = Color.decode(hex);
-		return rgb(color.getRed(), color.getGreen(), color.getBlue());
+		return srgb(color.getRed(), color.getGreen(), color.getBlue());
+	}
+
+	/**
+	 * Convert sRGB color packed as an int to sRGB in the range 0-1.
+	 *
+	 * @param rgbInt RGB hex color
+	 * @return float[3] non-linear srgb values from 0-1
+	 */
+	public static float[] srgb(int rgbInt) {
+		return new float[] {
+			(rgbInt >> 16 & 0xFF) / (float) 0xFF,
+			(rgbInt >> 8 & 0xFF) / (float) 0xFF,
+			(rgbInt & 0xFF) / (float) 0xFF,
+		};
+	}
+
+	public static float[] srgba(int argbInt) {
+		return new float[] {
+			(argbInt >> 16 & 0xFF) / (float) 0xFF,
+			(argbInt >> 8 & 0xFF) / (float) 0xFF,
+			(argbInt & 0xFF) / (float) 0xFF,
+			(argbInt >> 24 & 0xFF) / (float) 0xFF
+		};
 	}
 
 	public static int packHsl(float[] hsl) {
@@ -253,6 +308,18 @@ public class ColorUtils {
 		return new float[] { H, S, L };
 	}
 
+	public static int[] unpackHslRaw(int hsl) {
+		// 6-bit hue | 3-bit saturation | 7-bit lightness
+		int H = clamp(hsl >> 10 & 0x3F, 0, 0x3F);
+		int S = clamp(hsl >> 7 & 0x7, 0, 0x7);
+		int L = clamp(hsl & 0x7F, 0, 0x7F);
+		return new int[] { H, S, L };
+	}
+
+	public static int packHslRaw(int... hsl) {
+		return hsl[0] << 10 | hsl[1] << 7 | hsl[2];
+	}
+
 	public static int srgbToPackedHsl(float[] srgb) {
 		return packHsl(srgbToHsl(srgb));
 	}
@@ -261,12 +328,11 @@ public class ColorUtils {
 		return hslToSrgb(unpackHsl(hsl));
 	}
 
-	public static float[] unpackARGB(int argb) {
-		return new float[] {
-			(argb >> 16 & 0xFF) / (float) 0xFF,
-			(argb >> 8 & 0xFF) / (float) 0xFF,
-			(argb & 0xFF) / (float) 0xFF,
-			(argb >> 24 & 0xFF) / (float) 0xFF
-		};
+	public static int linearRgbToPackedHsl(float[] srgb) {
+		return srgbToPackedHsl(linearToSrgb(srgb));
+	}
+
+	public static float[] packedHslToLinearRgb(int hsl) {
+		return srgbToLinear(packedHslToSrgb(hsl));
 	}
 }

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -49,7 +49,6 @@ public class HDUtils {
 
 	// directional vectors approximately opposite of the directional light used by the client
 	private static final float[] LIGHT_DIR_TILE = new float[] { 0.70710678f, 0.70710678f, 0f };
-	public static final float[] LIGHT_DIR_MODEL = new float[] { 0.57735026f, 0.57735026f, 0.57735026f };
 
 	// The epsilon for floating point values used by jogl
 	public static final float EPSILON = 1.1920929E-7f;
@@ -169,26 +168,6 @@ public class HDUtils {
 		subtract(c, a, c);
 		float[] n = new float[3];
 		return cross(n, b, c);
-	}
-
-	public static int[] colorIntToHSL(int colorInt) {
-		int[] outHSL = new int[3];
-		outHSL[0] = colorInt >> 10 & 0x3F;
-		outHSL[1] = colorInt >> 7 & 0x7;
-		outHSL[2] = colorInt & 0x7F;
-		return outHSL;
-	}
-
-	public static int colorHSLToInt(int[] colorHSL) {
-		return (colorHSL[0] << 3 | colorHSL[1]) << 7 | colorHSL[2];
-	}
-
-	public static float dotLightDirectionModel(float x, float y, float z) {
-		// Model normal vectors need to be normalized
-		float length = x * x + y * y + z * z;
-		if (length < EPSILON)
-			return 0;
-		return (x * LIGHT_DIR_MODEL[0] + y * LIGHT_DIR_MODEL[1] + z * LIGHT_DIR_MODEL[2]) / (float) Math.sqrt(length);
 	}
 
 	public static float dotLightDirectionTile(float x, float y, float z) {
@@ -439,7 +418,7 @@ public class HDUtils {
 		var paint = tile.getSceneTilePaint();
 		var model = tile.getSceneTileModel();
 		if (paint != null) {
-			return HDUtils.colorIntToHSL(paint.getSwColor());
+			return ColorUtils.unpackHslRaw(paint.getSwColor());
 		} else if (model != null) {
 			int faceCount = tile.getSceneTileModel().getFaceX().length;
 			final int[] faceColorsA = model.getTriangleColorA();
@@ -462,7 +441,7 @@ public class HDUtils {
 				}
 			}
 
-			return HDUtils.colorIntToHSL(hsl);
+			return ColorUtils.unpackHslRaw(hsl);
 		}
 
 		return null;


### PR DESCRIPTION
This tries to reduce unnecessary back and forth conversions when manipulating Jagex HSL colors. It does add a fair bit of inline manual conversions, but I think it's worthwhile. Since this stuff is easy to break, I figured it might be good to test this more thoroughly before merging it. I've also added some slightly unusual color util functions that return sRGB instead of linear RGB like our other shorthand functions.