### PR TITLE
Karamja complex tiles fix

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Underlay.java
+++ b/src/main/java/rs117/hd/data/materials/Underlay.java
@@ -260,7 +260,9 @@ public enum Underlay {
 
 				// Grass
 				if (hsl[0] >= 13 ||
-					hsl[0] >= 9 && hsl[1] >= 3 ||
+					hsl[0] >= 10 && hsl[1] >= 3 ||
+					hsl[0] == 9 && hsl[1] >= 4 ||
+					hsl[0] == 9 && hsl[1] == 3 && hsl[2] <= 45 || // Fixes the southernmost beach
 					hsl[0] == 8 && hsl[1] > 5 && hsl[2] >= 30 && overlayId != 6
 				) {
 					switch (plugin.configSeasonalTheme) {

--- a/src/main/java/rs117/hd/data/materials/Underlay.java
+++ b/src/main/java/rs117/hd/data/materials/Underlay.java
@@ -244,6 +244,66 @@ public enum Underlay {
 		.area(Area.KARAMJA_VOLCANO)
 		.groundMaterial(GroundMaterial.EARTHEN_CAVE_FLOOR)
 	),
+	COMPLEX_TILES_KARAMJA(p -> p
+		.ids(50, 55, 61, 62, 63, 68)
+		.area(Area.KARAMJA)
+		.replacementResolver(
+			(plugin, scene, tile, override) -> {
+				int[] hsl = HDUtils.getSouthWesternMostTileColor(tile);
+				if (hsl == null)
+					return override;
+
+				LocalPoint localLocation = tile.getLocalLocation();
+				int tileExX = localLocation.getSceneX() + SCENE_OFFSET;
+				int tileExY = localLocation.getSceneY() + SCENE_OFFSET;
+				short overlayId = scene.getOverlayIds()[tile.getRenderLevel()][tileExX][tileExY];
+
+				// Grass
+				if (hsl[0] >= 13 ||
+					hsl[0] >= 9 && hsl[1] >= 3 ||
+					hsl[0] == 8 && hsl[1] > 5 && hsl[2] >= 30 && overlayId != 6
+				) {
+					switch (plugin.configSeasonalTheme) {
+						case SUMMER:
+						case AUTUMN:
+							return DEFAULT_GRASS;
+						case WINTER:
+							return WINTER_GRASS;
+					}
+				}
+
+				// Dirt
+				if (hsl[0] <= 8 && hsl[1] >= 4 && hsl[2] <= 71 ||
+					hsl[0] == 9 && hsl[1] == 2 && hsl[2] <= 44 ||
+					hsl[0] == 8 && hsl[1] == 4 && hsl[2] <= 40 ||
+					hsl[0] == 8 && hsl[1] == 3 && hsl[2] <= 34 // Breaks Sand if higher than 34; Can be fixed with tile averages or medians
+
+
+				) {
+					switch (plugin.configSeasonalTheme) {
+						case SUMMER:
+						case AUTUMN:
+							return DEFAULT_DIRT;
+						case WINTER:
+							return WINTER_DIRT;
+					}
+				}
+
+				// Stone
+				if (hsl[0] < 13 && hsl[1] <= 2 && hsl[2] <= 40) {
+					switch (plugin.configSeasonalTheme) {
+						case SUMMER:
+						case AUTUMN:
+							return DEFAULT_GRUNGE;
+						case WINTER:
+							return WINTER_GRUNGE;
+					}
+				}
+
+				return DEFAULT_SAND;
+			}
+		)
+	),
 
 	// Crandor
 	CRANDOR_SAND(-110, Area.CRANDOR, GroundMaterial.SAND, p -> p.saturation(3).hue(6)),
@@ -595,46 +655,6 @@ public enum Underlay {
 					}
 				}
 				return DEFAULT_DIRT;
-			}
-		)
-	),
-	COMPLEX_TILES_KARAMJA(p -> p
-		.ids(61, 62, 63, 68)
-		.area(Area.KARAMJA)
-		.replacementResolver(
-			(plugin, scene, tile, override) -> {
-				int[] hsl = HDUtils.getSouthWesternMostTileColor(tile);
-				if (hsl == null)
-					return override;
-
-				LocalPoint localLocation = tile.getLocalLocation();
-				int tileExX = localLocation.getSceneX() + SCENE_OFFSET;
-				int tileExY = localLocation.getSceneY() + SCENE_OFFSET;
-				short overlayId = scene.getOverlayIds()[tile.getRenderLevel()][tileExX][tileExY];
-
-				// Grass
-				if (hsl[0] >= 9 || hsl[0] == 8 && hsl[1] > 5 && overlayId != 6) {
-					switch (plugin.configSeasonalTheme) {
-						case SUMMER:
-						case AUTUMN:
-							return OVERWORLD_GRASS;
-						case WINTER:
-							return WINTER_GRASS;
-					}
-				}
-
-				// Dirt
-				if (hsl[0] <= 8 && hsl[1] >= 4 && hsl[2] <= 71) {
-					switch (plugin.configSeasonalTheme) {
-						case SUMMER:
-						case AUTUMN:
-							return OVERWORLD_DIRT;
-						case WINTER:
-							return WINTER_DIRT;
-					}
-				}
-
-				return OVERWORLD_SAND;
 			}
 		)
 	),


### PR DESCRIPTION
Fixes complex tiles on karamja.

On master the tiles do not apply at all since they are below the overworld tiles; this PR places Karamja properly within the underlay.java structure; it then also further refines it.