### PR TITLE
Fix Lunar Ess mine water

### DIFF
--- a/src/main/java/rs117/hd/data/environments/Area.java
+++ b/src/main/java/rs117/hd/data/environments/Area.java
@@ -1399,6 +1399,7 @@ public enum Area
 		new AABB(2101, 3898, 2099, 3897, 1), // House 7
 		new AABB(2102, 3901, 2096, 3896, 1)  // House 7
 	),
+	LUNAR_ESSENCE_MINE(9377),
 	LUNAR_ISLE(regionBox(8252, 8509)),
 
 	// Ape Atoll

--- a/src/main/java/rs117/hd/data/materials/Overlay.java
+++ b/src/main/java/rs117/hd/data/materials/Overlay.java
@@ -937,6 +937,7 @@ public enum Overlay {
 		.blended(false)),
 	LUNAR_ISLAND_HOUSES_WOOD_FLOOR(81, Area.LUNAR_VILLAGE_HOUSE_INTERIORS_FIRST, GroundMaterial.HD_WOOD_PLANKS_1, p -> p
 		.blended(true)),
+	LUNAR_ESSENCE_MINE_WATER(p -> p.ids(151).area(Area.LUNAR_ESSENCE_MINE).waterType(WaterType.WATER)),
 	KELDAGRIM_PATHS(117, GroundMaterial.FALADOR_PATHS),
 
 	CERBERUS_WATER(128, Area.CERBERUS, WaterType.SWAMP_WATER_FLAT),


### PR DESCRIPTION
overlay 151 is unassigned; This tile is used as water in the Lunar Essence Mine.
This PR defines tile 151 in the newly defined Lunar Ess Mine region