### PR TITLE
Giants Upgrade-pt2

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Underlay.java
+++ b/src/main/java/rs117/hd/data/materials/Underlay.java
@@ -858,9 +858,25 @@ public enum Underlay {
 		.area(Area.MOTHERLODE_MINE)
 		.ids(63, 64, 71)
 	),
-	GIANTS_FOUNDRY(GroundMaterial.EARTHEN_CAVE_FLOOR, p -> p
-		.area(Area.GIANTS_FOUNDRY)
+	GIANTS_FOUNDRY_DESATURATION(p -> p.ids().groundMaterial(GroundMaterial.EARTHEN_CAVE_FLOOR).shiftSaturation(-1)),
+	GIANTS_FOUNDRY(p -> p
 		.ids(91, 101)
+		.area(Area.GIANTS_FOUNDRY)
+		.groundMaterial(GroundMaterial.EARTHEN_CAVE_FLOOR)
+		.replacementResolver(
+			(plugin, scene, tile, override) -> {
+				int[] hsl = getSouthWesternMostTileColor(tile);
+				if (hsl == null)
+					return override;
+
+				// Ash or stone
+				if (hsl[1] > 1 ) {
+					return GIANTS_FOUNDRY_DESATURATION;
+				}
+
+				return override;
+			}
+		)
 	),
 	MEIYERDITCH_MYREQUE_HIDEOUT(GroundMaterial.VARIED_DIRT, p -> p
 		.area(Area.MEIYERDITCH_MYREQUE_HIDEOUT)

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -28820,7 +28820,7 @@
     "worldX": 3375,
     "worldY": 11489,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28831,14 +28831,14 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_2",
     "worldX": 3379,
     "worldY": 11490,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28849,14 +28849,14 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_3",
     "worldX": 3385,
     "worldY": 11490,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28867,16 +28867,16 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_4",
     "worldX": 3374,
     "worldY": 11497,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
-    "radius": 2400,
+    "radius": 800,
     "strength": 3,
     "color": [
       255,
@@ -28885,14 +28885,14 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_5",
     "worldX": 3374,
     "worldY": 11501,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28903,14 +28903,14 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_6",
     "worldX": 3374,
     "worldY": 11505,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28921,14 +28921,14 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_7",
     "worldX": 3368,
     "worldY": 11503,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28939,14 +28939,14 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_8",
     "worldX": 3378,
     "worldY": 11508,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28957,14 +28957,14 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
   },
   {
     "description": "GIANTS_FOUNDRY_LAVA_9",
     "worldX": 3378,
     "worldY": 11503,
     "plane": 0,
-    "height": 200,
+    "height": 500,
     "alignment": "CENTER",
     "radius": 2400,
     "strength": 3,
@@ -28975,7 +28975,143 @@
     ],
     "type": "PULSE",
     "duration": 7000,
-    "range": 10
+    "range": 30
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_1",
+    "worldX": 3372,
+    "worldY": 11496,
+    "plane": 0,
+    "height": 250,
+    "alignment": "CENTER",
+    "radius": 1200,
+    "strength": 8,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 200
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_2",
+    "worldX": 3372,
+    "worldY": 11499,
+    "plane": 0,
+    "height": 250,
+    "alignment": "CENTER",
+    "radius": 1200,
+    "strength": 8,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 200
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_3",
+    "worldX": 3371,
+    "worldY": 11501,
+    "plane": 0,
+    "height": 250,
+    "alignment": "CENTER",
+    "radius": 1200,
+    "strength": 8,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 200
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_4",
+    "worldX": 3373,
+    "worldY": 11496,
+    "plane": 0,
+    "height": 150,
+    "alignment": "CENTER",
+    "radius": 1000,
+    "strength": 15,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 200
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_5",
+    "worldX": 3374,
+    "worldY": 11495,
+    "plane": 0,
+    "height": 65,
+    "alignment": "CENTER",
+    "radius": 450,
+    "strength": 15,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 150
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_6",
+    "worldX": 3373,
+    "worldY": 11490,
+    "plane": 0,
+    "height": 85,
+    "alignment": "CENTER",
+    "radius": 1000,
+    "strength": 15,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 250
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_7",
+    "worldX": 3374,
+    "worldY": 11488,
+    "plane": 0,
+    "height": 100,
+    "alignment": "CENTER",
+    "radius": 1000,
+    "strength": 15,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 200
+  },
+  {
+    "description": "GIANTS_FOUNDRY_LAVA_SHORE_8",
+    "worldX": 3376,
+    "worldY": 11488,
+    "plane": 0,
+    "height": 150,
+    "alignment": "CENTER",
+    "radius": 1000,
+    "strength": 15,
+    "color": [
+      235,
+      20,
+      0
+    ],
+    "type": "STATIC",
+    "range": 200
   },
   {
     "description": "GIANTS_FOUNDRY_DOORWAY",
@@ -28994,6 +29130,42 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 0
+  },
+  {
+    "description": "GIANTS_FOUNDRY_CRUCIBLE",
+    "height": 270,
+    "alignment": "CENTER",
+    "radius": 130,
+    "strength": 40,
+    "color": [
+      255,
+      182,
+      38
+    ],
+    "objectIds": [
+      44624
+    ],
+    "type": "PULSE",
+    "duration": 7000,
+    "range": 30
+  },
+  {
+    "description": "GIANTS_FOUNDRY_POURED_METAL_MOULD_JIG",
+    "height": 100,
+    "alignment": "CENTER",
+    "radius": 130,
+    "strength": 12,
+    "color": [
+      255,
+      182,
+      38
+    ],
+    "objectIds": [
+      44627
+    ],
+    "type": "PULSE",
+    "duration": 7000,
+    "range": 30
   },
   {
     "description": "LOVAKITE_FURNACE",

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -6545,6 +6545,7 @@
       44652,
       44681,
       44682,
+      44684,
       44713,
       44714,
       44715,
@@ -6592,7 +6593,8 @@
       17877,
       44744,
       44745
-    ]
+    ],
+    "uvType": "BOX"
   },
   {
     "description": "Objects - Stone - Mountain Daughter Burial",
@@ -10919,6 +10921,28 @@
     "uvScale": 0.6
   },
   {
+    "description": "Objects - Stone - Giants Foundry - Mould Jig",
+    "baseMaterial": "ROCK_3",
+    "objectIds": [
+      44625,
+      44626,
+      44627
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.7,
+    "uvOrientation": 128
+  },
+  {
+    "description": "Objects - Stone - Giants Foundry - Preform storage",
+    "baseMaterial": "ROCK_3",
+    "objectIds": [
+      44633
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "uvOrientation": 1024
+  },
+  {
     "description": "Objects - Stone - Giants Foundry - Lavapool Rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
@@ -10938,12 +10962,23 @@
     "uvScale": 0.6
   },
   {
+    "description": "Objects - Wooden - Steps",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [
+      44679
+    ],
+    "uvType": "BOX",
+    "uvScale": 1.1,
+    "uvOrientationY": 512
+  },
+  {
     "description": "Giants Foundry Single row fences",
-    "baseMaterial": "WOOD_GRAIN_2",
+    "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       44680
     ],
-    "uvType": "BOX"
+    "uvType": "BOX",
+    "uvOrientation": 512
   },
   {
     "description": "Giants Foundry Clamps",
@@ -10953,6 +10988,17 @@
     ],
     "uvType": "BOX",
     "uvScale": 0.28
+  },
+  {
+    "description": "Giants Foundry Crucible",
+    "baseMaterial": "METALLIC_2_SEMIGLOSS",
+    "objectIds": [
+      44622,
+      44623,
+      44624
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.5
   },
   {
     "description": "Objects - Stone - Giants Foundry - Lava Rocks",
@@ -10996,6 +11042,28 @@
     ],
     "uvType": "GEOMETRY",
     "uvScale": 0.28
+  },
+  {
+    "description": "Giants Foundry -  Wooden - Chest",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 44726 ],
+    "uvType": "BOX",
+    "uvOrientation": 512
+  },
+  {
+    "description": "Giants Foundry -  Wooden - Bank Chest",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 44630 ],
+    "uvType": "BOX",
+    "uvOrientation": 512
+  },
+  {
+    "description": "Giants Foundry -  Wooden - WheelBarrow",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 44728 ],
+    "uvType": "BOX",
+    "uvOrientationX": 576,
+    "uvOrientationZ": 512
   },
   {
     "description": "Replace vanilla scrolling waterfall texture with droplets, until a better solution is found",


### PR DESCRIPTION
A second pass over the Giants Foundry to upgrade the graphics in the area.

Changes of note:

- Dynamic light on Crucible that is stronger as it fills up.
- Textures added to wooden objects, as well as Mould Jig
- Changes Stalagmites to have Box uvs
- Remove lighting baked in the ground and replace it with actual lighting

Master\PR
![image](https://github.com/117HD/RLHD/assets/11658143/7477c121-4dd1-4643-a4d3-e9a2bcf0fdbf)
![image](https://github.com/117HD/RLHD/assets/11658143/69bab246-22f2-4f8e-9307-073e938e45dc)
