### PR TITLE
Use unmodified tile colors

### DIFF
--- a/src/main/java/rs117/hd/scene/SceneUploader.java
+++ b/src/main/java/rs117/hd/scene/SceneUploader.java
@@ -493,6 +493,15 @@ class SceneUploader {
 					plugin.configGroundBlending &&
 					textureId == -1 &&
 					!proceduralGenerator.useDefaultColor(tile, override);
+
+				if (!useBlendedMaterialAndColor) {
+					// Apply brightness clamping also with blending disabled
+					swColor = proceduralGenerator.clampBrightness(swColor);
+					seColor = proceduralGenerator.clampBrightness(seColor);
+					nwColor = proceduralGenerator.clampBrightness(nwColor);
+					neColor = proceduralGenerator.clampBrightness(neColor);
+				}
+
 				GroundMaterial groundMaterial = null;
 				if (override != TileOverride.NONE) {
 					groundMaterial = override.groundMaterial;
@@ -856,6 +865,14 @@ class SceneUploader {
 						plugin.configGroundBlending &&
 						textureId == -1 &&
 						!(isOverlay && proceduralGenerator.useDefaultColor(tile, override));
+
+					if (!useBlendedMaterialAndColor) {
+						// Apply brightness clamping also with blending disabled
+						colorA = proceduralGenerator.clampBrightness(colorA);
+						colorB = proceduralGenerator.clampBrightness(colorB);
+						colorC = proceduralGenerator.clampBrightness(colorC);
+					}
+
 					if (override != TileOverride.NONE) {
 						groundMaterial = override.groundMaterial;
 						uvOrientation = override.uvOrientation;

--- a/src/main/java/rs117/hd/scene/tile_overrides/TileOverride.java
+++ b/src/main/java/rs117/hd/scene/tile_overrides/TileOverride.java
@@ -32,15 +32,15 @@ public class TileOverride {
 	public WaterType waterType = WaterType.NONE;
 	public boolean blended = true;
 	public boolean blendedAsOpposite = false;
-	public int shiftHue;
-	public int minHue;
-	public int maxHue = 63;
-	public int shiftSaturation;
-	public int minSaturation;
-	public int maxSaturation = 7;
-	public int shiftLightness;
-	public int minLightness;
-	public int maxLightness = 127;
+	private int shiftHue;
+	private int minHue;
+	private int maxHue = 63;
+	private int shiftSaturation;
+	private int minSaturation;
+	private int maxSaturation = 7;
+	private int shiftLightness;
+	private int minLightness;
+	private int maxLightness = 127;
 	public int uvOrientation;
 	public float uvScale = 1;
 	@SerializedName("replacements")
@@ -134,6 +134,7 @@ public class TileOverride {
 	}
 
 	public int modifyColor(int jagexHsl) {
+		if (true) return jagexHsl;
 		int h = jagexHsl >> 10 & 0x3F;
 		h += shiftHue;
 		h = clamp(h, minHue, maxHue);

--- a/src/main/java/rs117/hd/utils/ColorUtils.java
+++ b/src/main/java/rs117/hd/utils/ColorUtils.java
@@ -340,8 +340,8 @@ public class ColorUtils {
 		return hslToSrgb(unpackHsl(hsl));
 	}
 
-	public static int linearRgbToPackedHsl(float[] srgb) {
-		return srgbToPackedHsl(linearToSrgb(srgb));
+	public static int linearRgbToPackedHsl(float[] rgb) {
+		return srgbToPackedHsl(linearToSrgb(rgb));
 	}
 
 	public static float[] packedHslToLinearRgb(int hsl) {

--- a/src/main/resources/rs117/hd/scene/environments.json
+++ b/src/main/resources/rs117/hd/scene/environments.json
@@ -1388,7 +1388,8 @@
     "key": "OVERWORLD",
     "area": "OVERWORLD",
     "ambientColor": "#97baff",
-    "directionalStrength": 4,
+    // change this
+    "directionalStrength": 1.5,
     "sunAngles": [ 52, 235 ],
     "fogDepth": 6.5
   },


### PR DESCRIPTION
Apply the same brightness clamping as with ground blending enabled:
![image](https://github.com/117HD/RLHD/assets/831317/a529bbfc-cd5b-4349-a374-54df692e3250)
![image](https://github.com/117HD/RLHD/assets/831317/4646c632-e190-435f-a1e7-e78fb2463df1)
![image](https://github.com/117HD/RLHD/assets/831317/a61450d4-6590-46c6-9c3f-e788ca649576)
