### PR TITLE
Pirates Cove object fixes

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -3681,7 +3681,9 @@
       16961,
       16962
     ],
-    "uvType": "GEOMETRY"
+    "uvType": "BOX",
+    "uvScale": 1.1,
+    "uvOrientationZ": 128
   },
   {
     "description": "LUNAR_ISLE_BRIDGES",
@@ -3700,15 +3702,18 @@
       16992,
       16993
     ],
-    "uvType": "MODEL_XZ"
+    "uvType": "BOX"
   },
   {
     "description": "LUNAR_ISLE_DOCK_SUPPORTS",
-    "baseMaterial": "DOCK_FENCE",
+    "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       16963,
       16965
-    ]
+    ],
+    "uvType": "BOX",
+    "uvScale": 1.1,
+    "uvOrientation": 128
   },
   {
     "description": "RELLEKKA_DOCKS",
@@ -6549,6 +6554,15 @@
     "uvOrientationZ": 512
   },
   {
+    "description": "Objects - Wooden - Open Crate",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 16888 ],
+    "uvType": "BOX",
+    "flatNormals": true,
+    "uvOrientationX": 512,
+    "uvOrientationZ": 512
+  },
+  {
     "description": "Objects - Wooden - Stack of crates",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
@@ -6568,6 +6582,15 @@
       20369
     ],
     "uvType": "BOX",
+    "flatNormals": true
+  },
+  {
+    "description": "Objects - Wooden - Doublewide Crate",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 16863, 16864, 16865 ],
+    "uvType": "BOX",
+    "uvOrientationZ": 512,
+    "uvOrientationX": 512,
     "flatNormals": true
   },
   {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -7581,14 +7581,13 @@
   },
   {
     "description": "Objects - Wooden - Plank tables - Medium",
-    "baseMaterial": "WOOD_GRAIN_2",
+    "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       12884,
       16974,
       24333
     ],
-    "uvType": "BOX",
-    "uvScale": 0.4
+    "uvType": "BOX"
   },
   {
     "description": "Objects - Wooden - Plank tables - Wide",

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -9723,18 +9723,28 @@
     "uvType": "BOX"
   },
   {
-    "description": "Sacks Pile",
+    "description": "Sacks - Yellow",
     "baseMaterial": "CARPET",
     "objectIds": [
       23,
       365,
       2354,
       2356,
-      2663,
+      2663
+    ],
+    "uvType": "BOX",
+    "uvOrientation": 256,
+    "uvScale": 0.6
+  },
+  {
+    "description": "Sacks Pile",
+    "baseMaterial": "CARPET",
+    "objectIds": [
       12394,
+      16867,
       39696
     ],
-    "uvType": "MODEL_XZ",
+    "uvType": "BOX",
     "uvOrientation": 256,
     "uvScale": 0.6
   },
@@ -9742,9 +9752,10 @@
     "description": "Sacks with Sword",
     "baseMaterial": "CARPET",
     "objectIds": [
-      12392
+      12392,
+      16871
     ],
-    "uvType": "MODEL_XZ",
+    "uvType": "BOX",
     "uvOrientation": 256,
     "uvScale": 0.6
   },
@@ -9754,9 +9765,17 @@
     "objectIds": [
       12396
     ],
-    "uvType": "MODEL_XZ",
+    "uvType": "BOX",
     "uvOrientation": 256,
     "uvScale": 0.4
+  },
+  {
+    "description": "Object - Sack with Hey or Grain",
+    "baseMaterial": "FINE_CARPET",
+    "objectIds": [ 16878 ],
+    "uvType": "BOX",
+    "uvScale": 0.85,
+    "retainVanillaUvs": false
   },
   {
     "description": "Culinaromancers Floor",

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -6488,6 +6488,7 @@
       16252,
       16560,
       16561,
+      16887,
       17305,
       17655,
       17656,
@@ -7334,6 +7335,7 @@
       14872,
       15679,
       16246,
+      16875,
       17306,
       17551,
       17552,
@@ -9741,6 +9743,8 @@
     "objectIds": [
       12394,
       16867,
+      16868,
+      16870,
       39696
     ],
     "uvType": "BOX",
@@ -11343,11 +11347,13 @@
   },
   {
     "description": "Objects - Wooden - Crate - Tall",
-    "baseMaterial": "DOCK_FENCE",
+    "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       3045,
-      3205
+      3205,
+      16862
     ],
+    "uvType": "BOX",
     "flatNormals": true
   },
   {
@@ -11446,7 +11452,7 @@
     "uvOrientation": 512
   },
   {
-    "description": "Barbarian VIllage - Objects - Wooden - Crate",
+    "description": "Barbarian Village - Objects - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       11599,


### PR DESCRIPTION
- Applies materials to some wooden and cloth objects around/in the Lady Zay
- Corrects bad UVs on the docks and ladders
- Applies crate materials to the crates on/around the Lady Zay

![image](https://github.com/117HD/RLHD/assets/11658143/92478f7c-7028-4d65-9391-0c9f76e3f322)
![image](https://github.com/117HD/RLHD/assets/11658143/5a2f2989-c064-43df-86c5-f82d737984cd)
