### PR TITLE
Trollheim and Slayer Cave wall fixes

### DIFF
--- a/src/main/java/rs117/hd/data/materials/Material.java
+++ b/src/main/java/rs117/hd/data/materials/Material.java
@@ -379,8 +379,6 @@ public enum Material {
 	GRUNGE_2_SHINY(GRUNGE_2, p -> p
 		.setSpecular(0.7f, 300)
 	),
-	GRUNGE_2_TROLLHEIM_WALL_FIX_1(GRUNGE_2, p -> p.setBrightness(1.8f)),
-	GRUNGE_2_TROLLHEIM_WALL_FIX_2(GRUNGE_2, p -> p.setBrightness(1.2f)),
 	SUBMERGED_GRUNGE_2(GRUNGE_2, p -> p
 		.setFlowMap(UNDERWATER_FLOW_MAP)
 		.setFlowMapStrength(0.075f)
@@ -416,6 +414,8 @@ public enum Material {
 		.setSpecular(1, 20)
 	),
 	EADGARS_CAVE_FIX(ROCK_3, p -> p.setBrightness(0.65f)),
+	TROLLHEIM_WALL_FIX_1(ROCK_3, p -> p.setBrightness(1.8f)),
+	TROLLHEIM_WALL_FIX_2(ROCK_3, p -> p.setBrightness(1.2f)),
 
 	ROCK_4_D,
 	ROCK_4_N,

--- a/src/main/java/rs117/hd/data/materials/Material.java
+++ b/src/main/java/rs117/hd/data/materials/Material.java
@@ -379,7 +379,6 @@ public enum Material {
 	GRUNGE_2_SHINY(GRUNGE_2, p -> p
 		.setSpecular(0.7f, 300)
 	),
-	GRUNGE_2_EADGARS_CAVE_FIX(GRUNGE_2, p -> p.setBrightness(0.65f)),
 	GRUNGE_2_TROLLHEIM_WALL_FIX_1(GRUNGE_2, p -> p.setBrightness(1.8f)),
 	GRUNGE_2_TROLLHEIM_WALL_FIX_2(GRUNGE_2, p -> p.setBrightness(1.2f)),
 	SUBMERGED_GRUNGE_2(GRUNGE_2, p -> p
@@ -416,6 +415,7 @@ public enum Material {
 	ROCK_3_ORE(ROCK_3, p -> p
 		.setSpecular(1, 20)
 	),
+	EADGARS_CAVE_FIX(ROCK_3, p -> p.setBrightness(0.65f)),
 
 	ROCK_4_D,
 	ROCK_4_N,

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -3521,7 +3521,13 @@
     "objectIds": [
       2141,
       3669,
+      3737,
+      3740,
       3759,
+      3770,
+      3772,
+      3773,
+      3774,
       3812,
       6820,
       6822,
@@ -3537,6 +3543,8 @@
     "description": "Pale rock walls - Top",
     "baseMaterial": "ROCK_3",
     "objectIds": [
+      3738,
+      3739,
       6827
     ],
     "uvType": "WORLD_XZ",
@@ -13183,29 +13191,13 @@
   {
     "description": "Trollheim Cave Walls",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [
-      3737,
-      3738,
-      3739,
-      3740,
-      3770,
-      3772,
-      3773,
-      3774
-    ],
-    "uvType": "BOX",
-    "uvScale": 0.7
-  },
-  {
-    "description": "Trollheim Cave Walls",
-    "baseMaterial": "GRUNGE_2",
     "objectIds": [ 3790 ],
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Trollheim Eadgars Cave Exit",
-    "baseMaterial": "GRUNGE_2_EADGARS_CAVE_FIX",
+    "baseMaterial": "EADGARS_CAVE_FIX",
     "objectIds": [ 3760, 3761 ],
     "uvType": "BOX",
     "uvScale": 0.7

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13218,14 +13218,14 @@
   },
   {
     "description": "Trollheim Dark Wall in Doorway",
-    "baseMaterial": "GRUNGE_2_TROLLHEIM_WALL_FIX_1",
+    "baseMaterial": "TROLLHEIM_WALL_FIX_1",
     "objectIds": [ 3792 ],
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Trollheim Dark Wall in Doorway",
-    "baseMaterial": "GRUNGE_2_TROLLHEIM_WALL_FIX_2",
+    "baseMaterial": "TROLLHEIM_WALL_FIX_2",
     "objectIds": [ 3793 ],
     "uvType": "BOX",
     "uvScale": 0.7

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -3516,8 +3516,8 @@
     "flatNormals": true
   },
   {
-    "description": "UNKNOWN_3",
-    "baseMaterial": "GRUNGE_1",
+    "description": "Pale rock walls",
+    "baseMaterial": "ROCK_3",
     "objectIds": [
       2141,
       3669,
@@ -3527,11 +3527,20 @@
       6822,
       6824,
       6826,
-      6827,
       16539
     ],
     "uvType": "BOX",
-    "uvScale": 0.7
+    "uvScale": 0.7,
+    "uvOrientation": 256
+  },
+  {
+    "description": "Pale rock walls - Top",
+    "baseMaterial": "ROCK_3",
+    "objectIds": [
+      6827
+    ],
+    "uvType": "WORLD_XZ",
+    "uvScale": 1.3
   },
   {
     "description": "UNKNOWN_4",

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -5201,7 +5201,9 @@
       63,
       92
     ],
-    "groundMaterial": "EARTHEN_CAVE_FLOOR"
+    "groundMaterial": "EARTHEN_CAVE_FLOOR",
+    "uvOrientation": 144,
+    "uvScale": 1.25
   },
   {
     "name": "SHADOW_DUNGEON_FLOOR",


### PR DESCRIPTION
Improves the floor UVs and wall textures of the slayercave; which unfortunately also changes Trollheim. but it's a solid improvement i'd say.

Notable changes are using world UVs on the flat tiles instead of box.

Both image sets are Master/PR
![image](https://github.com/117HD/RLHD/assets/11658143/7d4b08a6-4f96-4da0-b4a8-d7ee05d6a71e)
![image](https://github.com/117HD/RLHD/assets/11658143/56ff3640-f59c-4d10-98e5-583ce677b9ef)


![image](https://github.com/117HD/RLHD/assets/11658143/448d0531-95d0-402d-afdb-1973fd767c43)
![image](https://github.com/117HD/RLHD/assets/11658143/e876775c-9f97-4f75-aa26-918983468328)
