### PR TITLE
Kourend Paths stone materials with normals

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -2507,7 +2507,7 @@
   },
   {
     "description": "KOUREND_PATHS",
-    "baseMaterial": "GRUNGE_1",
+    "baseMaterial": "STONE_NORMALED_DARK",
     "objectIds": [
       13705,
       13706,
@@ -2523,7 +2523,9 @@
       13716,
       13717,
       42722
-    ]
+    ],
+    "uvType": "WORLD_XZ",
+    "uvScale": 1.2
   },
   {
     "description": "KOUREND_PATH_STEPS",


### PR DESCRIPTION
Apply world UVs to the paths around Kourend, has normals and i think it looks better than grunge.

Master/PR
![image](https://github.com/117HD/RLHD/assets/11658143/15fa4862-cbef-44c4-8a79-83049f78ef65)
![image](https://github.com/117HD/RLHD/assets/11658143/354de12b-562e-4055-817c-9681412c9900)
