### PR TITLE
Drake & Wyrm Lighting

### DIFF
--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -28458,6 +28458,24 @@
     "fadeOutDuration": 50
   },
   {
+    "description": "Wyrm Magic Attack",
+    "offset": [ 0, 0, 0 ],
+    "radius": 250,
+    "strength": 20,
+    "color": [
+      0,
+      200,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 1,
+    "range": 80,
+    "projectileIds": [ 1634 ],
+    "spawnDelay": 400,
+    "fadeInDuration": 300,
+    "fadeOutDuration": 100
+  },
+  {
     "description": "KARUULM_INDOOR_LAVA_1",
     "worldX": 1307,
     "worldY": 10193,

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -28458,6 +28458,24 @@
     "fadeOutDuration": 50
   },
   {
+    "description": "Wyrm Slithering Light",
+    "offset": [ 0, 0, 0 ],
+    "radius": 170,
+    "strength": 50,
+    "color": [
+      0,
+      200,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 10,
+    "range": 70,
+    "npcIds": [ 8610 ],
+    "spawnDelay": 400,
+    "fadeInDuration": 300,
+    "fadeOutDuration": 100
+  },
+  {
     "description": "Wyrm Magic Attack",
     "offset": [ 0, 0, 0 ],
     "radius": 250,

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -28352,7 +28352,7 @@
     "height": 300,
     "offset": [ 100, 0, -100 ],
     "radius": 175,
-    "strength": 40,
+    "strength": 30,
     "color": [
       255,
       0,
@@ -28368,7 +28368,7 @@
   "height": 300,
   "offset": [ -100, 0, -100 ],
   "radius": 175,
-  "strength": 40,
+  "strength": 30,
   "color": [
     255,
     0,
@@ -28384,7 +28384,7 @@
     "height": 350,
     "offset": [ 0, 0, 100 ],
     "radius": 175,
-    "strength": 40,
+    "strength": 30,
     "color": [
       255,
       0,
@@ -28461,7 +28461,7 @@
     "description": "Wyrm Slithering Light",
     "offset": [ 0, 0, 0 ],
     "radius": 170,
-    "strength": 50,
+    "strength": 25,
     "color": [
       0,
       200,
@@ -28478,7 +28478,7 @@
     "description": "Shadow Wyrm Slithering Light",
     "offset": [ 0, 0, 0 ],
     "radius": 270,
-    "strength": 50,
+    "strength": 35,
     "color": [
       0,
       50,
@@ -28495,7 +28495,7 @@
   {
     "description": "Wyrm Magic Attack",
     "offset": [ 0, 0, 0 ],
-    "radius": 250,
+    "radius": 220,
     "strength": 20,
     "color": [
       0,

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -28471,10 +28471,27 @@
     "duration": 10,
     "range": 70,
     "npcIds": [ 8610 ],
-    "spawnDelay": 400,
-    "fadeInDuration": 300,
+    "fadeInDuration": 100,
     "fadeOutDuration": 100
   },
+  {
+    "description": "Shadow Wyrm Slithering Light",
+    "offset": [ 0, 0, 0 ],
+    "radius": 270,
+    "strength": 50,
+    "color": [
+      0,
+      50,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 10,
+    "range": 70,
+    "npcIds": [ 10398 ],
+    "fadeInDuration": 100,
+    "fadeOutDuration": 100
+  },
+
   {
     "description": "Wyrm Magic Attack",
     "offset": [ 0, 0, 0 ],
@@ -28489,6 +28506,24 @@
     "duration": 1,
     "range": 80,
     "projectileIds": [ 1634 ],
+    "spawnDelay": 400,
+    "fadeInDuration": 300,
+    "fadeOutDuration": 100
+  },
+  {
+    "description": "Shadow Wyrm Magic Attack",
+    "offset": [ 0, 0, 0 ],
+    "radius": 220,
+    "strength": 50,
+    "color": [
+      0,
+      50,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 10,
+    "range": 70,
+    "projectileIds": [ 1814 ],
     "spawnDelay": 400,
     "fadeInDuration": 300,
     "fadeOutDuration": 100

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -28348,6 +28348,116 @@
     ]
   },
   {
+    "description": "Drake Back Wound Right",
+    "height": 300,
+    "offset": [ 100, 0, -100 ],
+    "radius": 175,
+    "strength": 40,
+    "color": [
+      255,
+      0,
+      0
+    ],
+    "type": "FLICKER",
+    "duration": 10,
+    "range": 30,
+    "npcIds": [ 8612 ]
+  },
+  {
+  "description": "Drake Back Wound Left",
+  "height": 300,
+  "offset": [ -100, 0, -100 ],
+  "radius": 175,
+  "strength": 40,
+  "color": [
+    255,
+    0,
+    0
+  ],
+  "type": "FLICKER",
+  "duration": 10,
+  "range": 30,
+  "npcIds": [ 8612 ]
+  },
+  {
+    "description": "Drake Back Wound Front",
+    "height": 350,
+    "offset": [ 0, 0, 100 ],
+    "radius": 175,
+    "strength": 40,
+    "color": [
+      255,
+      0,
+      0
+    ],
+    "type": "FLICKER",
+    "duration": 10,
+    "range": 30,
+    "npcIds": [ 8612 ],
+    "animationIds": [ -1, 8276 ],
+    "fadeOutDuration": 300,
+    "fadeInDuration": 750
+  },
+  {
+    "description": "Drake Maw Idle",
+    "height": 50,
+    "offset": [ -20, 5, 252 ],
+    "radius": 32,
+    "strength": 120,
+    "color": "#ff8c00",
+    "type": "FLICKER",
+    "duration": 10,
+    "range": 5,
+    "npcIds": [ 8612 ],
+    "animationIds": [ -1 ],
+    "fadeInDuration": 300
+  },
+  {
+    "description": "Drake Ranged Attack",
+    "offset": [ 0, 0, 0 ],
+    "radius": 135,
+    "strength": 12,
+    "color": [
+      255,
+      0,
+      0
+    ],
+    "type": "FLICKER",
+    "duration": 1,
+    "range": 80,
+    "projectileIds": [ 1636 ],
+    "spawnDelay": 800,
+    "fadeInDuration": 300,
+    "fadeOutDuration": 100
+  },
+  {
+    "description": "Drake Flame Attack",
+    "offset": [ 0, 0, 0 ],
+    "radius": 175,
+    "strength": 12,
+    "color": "#ff8c00",
+    "type": "FLICKER",
+    "duration": 5,
+    "range": 60,
+    "projectileIds": [ 1637 ],
+    "spawnDelay": 255,
+    "fadeInDuration": 150,
+    "fadeOutDuration": 150
+  },
+  {
+    "description": "Drake Flame Explosion",
+    "offset": [ 0, 10, 0 ],
+    "radius": 150,
+    "strength": 45,
+    "color": "#ff8c00",
+    "type": "FLICKER",
+    "duration": 2,
+    "range": 80,
+    "graphicsObjectIds": [ 1638 ],
+    "fadeInDuration": 50,
+    "fadeOutDuration": 50
+  },
+  {
     "description": "KARUULM_INDOOR_LAVA_1",
     "worldX": 1307,
     "worldY": 10193,


### PR DESCRIPTION
Drake;
Before:

https://github.com/117HD/RLHD/assets/37377657/4cac0710-891c-4d4c-8e38-4b64b0948480

After:

https://github.com/117HD/RLHD/assets/37377657/96cec1e0-9113-4a3f-8163-d3a8b618734a

Combat:

https://github.com/117HD/RLHD/assets/37377657/4fc90ed2-6591-4110-8ebb-a77a1e14adcf

Wyrm;
Before:

https://github.com/117HD/RLHD/assets/37377657/961cfc20-58a8-4e43-b1fd-ad97015d4255

After:

https://github.com/117HD/RLHD/assets/37377657/0e2534a2-f91e-431f-adfa-276843e693ff

Combat:

https://github.com/117HD/RLHD/assets/37377657/b4f21760-8338-492a-9507-49e738287821

https://github.com/117HD/RLHD/assets/37377657/bfffaff3-a862-4892-a52d-29bb35c10a61

