### PR TITLE
Cold war - Iceberg Tweaks

### DIFF
--- a/src/main/resources/rs117/hd/scene/environments.json
+++ b/src/main/resources/rs117/hd/scene/environments.json
@@ -661,7 +661,7 @@
   },
   {
     "area": "ICEBERG",
-    "ambientColor": "#6fb0ff",
+    "ambientColor": "#7CB6EF",
     "ambientStrength": 1,
     "directionalColor": "#f4e5c9",
     "directionalStrength": 1.5,

--- a/src/main/resources/rs117/hd/scene/environments.json
+++ b/src/main/resources/rs117/hd/scene/environments.json
@@ -666,7 +666,10 @@
     "directionalColor": "#f4e5c9",
     "directionalStrength": 1.5,
     "fogColor": "#aebde0",
-    "fogDepth": 20
+    "fogDepth": 20,
+    "sunAngles": [
+      45, 235
+    ]
   },
   {
     "area": "MOUNTAIN_CAMP_ENTRY_PATH",

--- a/src/main/resources/rs117/hd/scene/environments.json
+++ b/src/main/resources/rs117/hd/scene/environments.json
@@ -660,6 +660,15 @@
     "fogDepth": 70
   },
   {
+    "area": "ICEBERG",
+    "ambientColor": "#6fb0ff",
+    "ambientStrength": 1,
+    "directionalColor": "#f4e5c9",
+    "directionalStrength": 1.5,
+    "fogColor": "#aebde0",
+    "fogDepth": 20
+  },
+  {
     "area": "MOUNTAIN_CAMP_ENTRY_PATH",
     "ambientColor": "#97baff",
     "ambientStrength": 0.9,

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -32416,8 +32416,7 @@
   },
   {
     "description": "PENGUIN_BASE_LAMP",
-    "height": 120,
-    "alignment": "FRONT",
+    "height": 140,
     "radius": 140,
     "strength": 10.5,
     "color": [

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -9331,6 +9331,15 @@
     "uvScale": 1.1
   },
   {
+    "description": "Iceberg - Agility Course - Snow Drift",
+    "baseMaterial": "SNOW_2",
+    "objectIds": [
+      21142,
+      21143
+    ],
+    "uvType": "BOX"
+  },
+  {
     "description": "Penguin Footprints",
     "baseMaterial": "SNOW_2",
     "uvType": "WORLD_XZ",

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -9303,6 +9303,34 @@
     "uvType": "GEOMETRY"
   },
   {
+    "description": "Cold War - Larrys Boat",
+    "baseMaterial": "GRUNGE_3",
+    "objectIds": [
+      21177
+    ],
+    "uvType": "BOX"
+  },
+  {
+    "description": "Iceberg - Bird Hide - Uncovered and Broken",
+    "baseMaterial": "GRUNGE_3",
+    "objectIds": [
+      21180,
+      21182
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.76
+  },
+  {
+    "description": "Iceberg - Bird Hide - Covered",
+    "baseMaterial": "SNOW_2",
+    "objectIds": [
+      21181
+    ],
+    "uvType": "BOX",
+    "uvOrientation": 256,
+    "uvScale": 1.1
+  },
+  {
     "description": "Penguin Footprints",
     "baseMaterial": "SNOW_2",
     "uvType": "WORLD_XZ",

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -5558,6 +5558,7 @@
   {
     "name": "ICEBERG_BLEND",
     "area": "ICEBERG",
+    "description": "For when ground blending is ENABLED",
     "underlayIds": [ 58, 59, 60 ],
     "groundMaterial": "SNOW_2",
     "replacements": {
@@ -5567,7 +5568,8 @@
   },
   {
     "name": "ICEBERG_UNBLEND",
-    "description": "Note, this doesn't apply to anything directly. Only via replacements",
+    "area": "ICEBERG",
+    "description": "For when ground blending is DISABLED",
     "groundMaterial": "SNOW_2",
     "shiftLightness": 12
   },

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -5556,13 +5556,20 @@
     }
   },
   {
-    "name": "ICEBERG_TEXTURE",
+    "name": "ICEBERG_BLEND",
     "area": "ICEBERG",
-    "underlayIds": [
-      59
-    ],
+    "underlayIds": [ 58, 59, 60 ],
     "groundMaterial": "SNOW_2",
-    "shiftLightness": 5
+    "replacements": {
+      "ICEBERG_UNBLEND": "!blending"
+    },
+    "shiftLightness": 35
+  },
+  {
+    "name": "ICEBERG_UNBLEND",
+    "description": "Note, this doesn't apply to anything directly. Only via replacements",
+    "groundMaterial": "SNOW_2",
+    "shiftLightness": 12
   },
   {
     "name": "APE_ATOLL_COMPLEX_TILES",


### PR DESCRIPTION
Adjusts the environment on the iceberg visited during the Cold War quest and textures some objects related to it, below are before and after screenshots showing both blending enabled and disabled. It's no longer blindingly bright!

Before:
![java_kcDa6pbaiA](https://github.com/117HD/RLHD/assets/37377657/564ff679-988c-4e28-b0c1-ce74137a00da)
![java_inr3LdFDgF](https://github.com/117HD/RLHD/assets/37377657/6a7c693d-8915-4dc9-93c6-799cebd8a5f0)

After:
![java_UWobjU1q3x](https://github.com/117HD/RLHD/assets/37377657/52468979-f304-4e1e-90ca-e4b381d742ce)
![java_mF9tBIOO3t](https://github.com/117HD/RLHD/assets/37377657/3d0b04f4-5369-49a1-b22e-47bf0a9aaae1)
