### PR TITLE
Fremennik Exiles Tweaks

### DIFF
--- a/src/main/resources/rs117/hd/scene/environments.json
+++ b/src/main/resources/rs117/hd/scene/environments.json
@@ -732,6 +732,16 @@
     "fogDepth": 45
   },
   {
+    "area": "ISLAND_OF_STONE",
+    "ambientColor": "#6fb0ff",
+    "ambientStrength": 1.75,
+    "sunAngles": [ 72, 235 ],
+    "directionalColor": "#f4e5c9",
+    "directionalStrength": 1.5,
+    "fogColor": "#adb9c4",
+    "fogDepth": 45
+  },
+  {
     "area": "PENGUIN_BASE",
     "ambientColor": "#aaafb6",
     "ambientStrength": 0.75,

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -35169,5 +35169,23 @@
     "objectIds": [ 14008 ],
     "fadeInDuration": 50,
     "fadeOutDuration": 100
+  },
+  {
+    "description": "the Jormungand - Magic Projectile",
+    "height": -20,
+    "alignment": "CENTER",
+    "radius": 200,
+    "strength": 25,
+    "color": [
+      252,
+      0,
+      0
+    ],
+    "type": "FLICKER",
+    "duration": 3,
+    "range": 35,
+    "projectileIds": [ 1737 ],
+    "fadeInDuration": 900,
+    "fadeOutDuration": 300
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -14916,6 +14916,17 @@
     "uvOrientation": 256
   },
   {
+    "description": "Isle of Stone - Cave and Pillars",
+    "baseMaterial": "STONE_NORMALED",
+    "objectIds": [
+      25846,
+      37409,
+      37410
+    ],
+    "uvType": "BOX",
+    "uvOrientation": 256
+  },
+  {
     "description": "Spinning Wheel",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -14927,6 +14927,38 @@
     "uvOrientation": 256
   },
   {
+    "description": "Isle of Stone Dungeon - The Jormungund",
+    "baseMaterial": "STONE_NORMALED",
+    "npcIds": [ 9289, 9290, 9291, 9292 ],
+    "objectIds": [ 37424 ],
+    "uvOrientation": 256
+  },
+  {
+    "description": "Isle of Stone Dungeon - Walls",
+    "baseMaterial": "STONE_NORMALED",
+    "objectIds": [
+      37412,
+      37413,
+      37414,
+      37415,
+      37416,
+      37425,
+      37426,
+      37427,
+      37429
+    ],
+    "uvOrientation": 256
+  },
+  {
+    "description": "Isle of Stone Dungeon - Stalagmite",
+    "baseMaterial": "STONE_NORMALED",
+    "objectIds": [
+      23373,
+      23374
+    ],
+    "uvOrientation": 256
+  },
+  {
     "description": "Spinning Wheel",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -6767,7 +6767,7 @@
       25159,
       25160
     ],
-    "uvType": "WORLD_XZ",
+    "uvType": "BOX",
     "uvScale": 0.25
   },
   {
@@ -14916,7 +14916,7 @@
     "uvOrientation": 256
   },
   {
-    "description": "Isle of Stone - Cave and Pillars",
+    "description": "Island of Stone - Cave and Pillars",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
       25846,
@@ -14927,36 +14927,58 @@
     "uvOrientation": 256
   },
   {
-    "description": "Isle of Stone Dungeon - The Jormungund",
+    "description": "Island of Stone Dungeon - The Jormungund",
     "baseMaterial": "STONE_NORMALED",
     "npcIds": [ 9289, 9290, 9291, 9292 ],
-    "objectIds": [ 37424 ],
-    "uvOrientation": 256
+    "objectIds": [ 37424 ]
   },
   {
-    "description": "Isle of Stone Dungeon - Walls",
+    "description": "Island of Stone Dungeon - Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
+      37411,
       37412,
       37413,
       37414,
       37415,
       37416,
+      37417,
+      37419,
+      37420,
       37425,
       37426,
       37427,
-      37429
-    ],
-    "uvOrientation": 256
+      37428,
+      37429,
+      37430
+    ]
   },
   {
-    "description": "Isle of Stone Dungeon - Stalagmite",
+    "description": "Island of Stone Dungeon - Old Gate",
+    "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
+    "objectIds": [
+      37421,
+      37422
+    ],
+    "uvType": "BOX"
+  },
+  {
+    "description": "Island of Stone Dungeon - Stalagmite",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
       23373,
       23374
     ],
     "uvOrientation": 256
+  },
+  {
+    "description": "Island of Stone Dungeon - Boat Ribs",
+    "baseMaterial": "WOOD_GRAIN",
+    "objectIds": [
+      4363
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.3
   },
   {
     "description": "Spinning Wheel",

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -5489,18 +5489,28 @@
     }
   },
   {
-    "name": "COMPLEX_TILES_ISLE_OF_STONE",
+    "name": "COMPLEX_TILES_ISLE_OF_STONE Blend",
     "area": "ISLAND_OF_STONE",
+    "description": "For when ground blending is ENABLED",
     "underlayIds": [
       58,
       97,
+      98,
       112
     ],
+    "groundMaterial": "SNOW_1",
     "replacements": {
+      "COMPLEX_TILES_ISLE_OF_STONE Unblend": "!blending",
       "SEASONAL_DIRT": "h == 7 && s >= 1 && l <= 71",
       "SEASONAL_ROCKY_GROUND": "h < 13 && s == 0 && l <= 40",
       "WINTER_DIRT": true
     }
+  },
+  {
+    "name": "COMPLEX_TILES_ISLE_OF_STONE Unblend",
+    "area": "ISLAND_OF_STONE",
+    "description": "For when ground blending is DISABLED",
+    "groundMaterial": "DIRT"
   },
   {
     "name": "FREMENNIK_SLAYER_DUNGEON",

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -5489,7 +5489,7 @@
     }
   },
   {
-    "name": "COMPLEX_TILES_ISLE_OF_STONE Blend",
+    "name": "Island of Stone Complex Tiles Blend",
     "area": "ISLAND_OF_STONE",
     "description": "For when ground blending is ENABLED",
     "underlayIds": [
@@ -5500,14 +5500,14 @@
     ],
     "groundMaterial": "SNOW_1",
     "replacements": {
-      "COMPLEX_TILES_ISLE_OF_STONE Unblend": "!blending",
+      "Island of Stone Complex Tiles Unblend": "!blending",
       "SEASONAL_DIRT": "h == 7 && s >= 1 && l <= 71",
       "SEASONAL_ROCKY_GROUND": "h < 13 && s == 0 && l <= 40",
       "WINTER_DIRT": true
     }
   },
   {
-    "name": "COMPLEX_TILES_ISLE_OF_STONE Unblend",
+    "name": "Island of Stone Complex Tiles Unblend",
     "area": "ISLAND_OF_STONE",
     "description": "For when ground blending is DISABLED",
     "groundMaterial": "DIRT"


### PR DESCRIPTION
Sorry if what ive done to the tile override for blending enabled and disabled is a mess/cursed, but it works...
Disables the snow for blending disabled on the Isle of Stone;
Blending Disabled:
![java_SLsxzerDqB](https://github.com/user-attachments/assets/8941ee4c-8eea-4273-9a5e-79748b692fa5)
![java_OkBSincBrt](https://github.com/user-attachments/assets/b907ac3c-0651-4f3c-9ef3-16d9b16f60b5)
Blending Enabled:
![java_C6ama2DckV](https://github.com/user-attachments/assets/da8378e5-2ea4-4c86-9abc-f4769d01c4f0)
![java_5cym8XkUAN](https://github.com/user-attachments/assets/5f4c970f-88a3-4e5f-850c-8ac419d5e290)
Drastic for disabled, only very subtly changed for enabled.

Texture cave and pillars:
![java_e4ZNRkhvID](https://github.com/user-attachments/assets/8a50cef5-f82d-42a6-94f9-301c352ca903)
![java_65nxg8J2HR](https://github.com/user-attachments/assets/0ae19c58-bc71-4d8d-9b5a-4d6007c74d7f)

Environment:
![java_MIzVN5AF4a](https://github.com/user-attachments/assets/3f3c3f26-fd39-4e74-bc10-4e9acb741fb3)

The Jormungand Fight:

https://github.com/user-attachments/assets/c4e6e528-bdce-443f-86fc-657f72e178dd

https://github.com/user-attachments/assets/18c92478-2c21-43b6-970d-7e2fe21f26ca

Dungeon General:
![java_Xc3aCHxXYk](https://github.com/user-attachments/assets/f939c685-6ad3-440a-bf80-481faf08720e)
![java_gOyO0FPd1P](https://github.com/user-attachments/assets/1b69787a-b3e8-48a6-a79c-9abc4908edf8)


