### PR TITLE
Wilderness area hiding

### DIFF
--- a/src/main/resources/rs117/hd/scene/areas.json
+++ b/src/main/resources/rs117/hd/scene/areas.json
@@ -2471,6 +2471,13 @@
     "hideOtherAreas": true
   },
   {
+    "name": "Wilderness Slayer Cave",
+    "regionBoxes": [
+      [ 13469, 13726 ]
+    ],
+    "hideOtherAreas": true
+  },
+  {
     "name": "GIELINOR_SNOWY_NORTHERN_REGION",
     "aabbs": [
       [ 2748, 3711, 2942, 3980 ]

--- a/src/main/resources/rs117/hd/scene/areas.json
+++ b/src/main/resources/rs117/hd/scene/areas.json
@@ -2466,6 +2466,11 @@
     "hideOtherAreas": true
   },
   {
+    "name": "Lava Maze Dungeon",
+    "regions": [ 12192 ],
+    "hideOtherAreas": true
+  },
+  {
     "name": "GIELINOR_SNOWY_NORTHERN_REGION",
     "aabbs": [
       [ 2748, 3711, 2942, 3980 ]

--- a/src/main/resources/rs117/hd/scene/areas.json
+++ b/src/main/resources/rs117/hd/scene/areas.json
@@ -2458,6 +2458,14 @@
     "hideOtherAreas": true
   },
   {
+    "name": "Deep Wilderness Dungeon",
+    "aabbs": [
+      [ 3012, 10364, 3059, 10366, 0 ],
+      [ 3011, 10305, 3070, 10363, 0 ]
+    ],
+    "hideOtherAreas": true
+  },
+  {
     "name": "GIELINOR_SNOWY_NORTHERN_REGION",
     "aabbs": [
       [ 2748, 3711, 2942, 3980 ]


### PR DESCRIPTION
Applys area hiding to 3 underground wilderness areas:
- Deep Wilderness Dungeon
- Lava Maze Dungeon
- Wilderness Slayer Cave

This is a seprate pull request because adding area hiding to a PvP enabled area might be a bit spooky.

Does not touch the wilderness bosses Vet'ion, Callisto, Venenatis, the escape caves or their weaker variants as thats perhaps even spookier.