### PR TITLE
Mainland Bank Booth textures

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13721,7 +13721,7 @@
     "uvScale": 0.65,
     "colorOverrides": [
       {
-        "colors": [43060, 43082, 43084, 43110, 43120, 43125],
+        "colors": [ 43060, 43082, 43084, 43110, 43120, 43125 ],
         "baseMaterial": "NONE",
         "uvType": "WORLD_XZ",
         "uvScale": 2
@@ -20611,7 +20611,7 @@
     "uvScale": 0.8,
     "colorOverrides": [
       {
-        "colors": [21549, 21594, 21630],
+        "colors": [ 21549, 21594, 21630 ],
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }
@@ -20632,7 +20632,7 @@
     "uvScale": 0.8,
     "colorOverrides": [
       {
-        "colors": [43054, 43082, 43102, 43125],
+        "colors": [ 43054, 43082, 43102, 43125 ],
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }
@@ -20653,7 +20653,7 @@
     "uvScale": 0.8,
     "colorOverrides": [
       {
-        "colors": [43054, 43082, 43102, 43125],
+        "colors": [ 43054, 43082, 43102, 43125 ],
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }
@@ -20667,7 +20667,7 @@
     "uvScale": 0.8,
     "colorOverrides": [
       {
-        "colors": [21549, 21594, 21630],
+        "colors": [ 21549, 21594, 21630 ],
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }
@@ -20688,7 +20688,7 @@
     "uvScale": 0.8,
     "colorOverrides": [
       {
-        "colors": [43011, 43054, 43102],
+        "colors": [ 43011, 43054, 43102 ],
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }
@@ -20702,7 +20702,7 @@
     "uvScale": 0.8,
     "colorOverrides": [
       {
-        "colors": [43011, 43054, 43121],
+        "colors": [ 43011, 43054, 43121 ],
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -20742,5 +20742,19 @@
     "objectIds": [ 10518 ],
     "uvType": "BOX",
     "uvScale": 0.8
+  },
+  {
+    "description": "Bankbooth with Glass Window - Nardah",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 20325 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [ 43025, 43068, 43116 ],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -20721,5 +20721,26 @@
     "objectIds": [ 16643 ],
     "uvType": "BOX",
     "uvScale": 0.8
+  },
+  {
+    "description": "Bankbooth with Glass Window - Nardah",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 10517 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [ 21535, 21576, 21630 ],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
+  },
+  {
+    "description": "Bankbooth with Shutters - Nardah",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 10518 ],
+    "uvType": "BOX",
+    "uvScale": 0.8
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13705,14 +13705,28 @@
   },
   {
     "description": "Objects - Concrete - Bank Booth",
-    "textureMaterial": "HD_CONCRETE",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "materialOverrides": {
+      "WOODEN_SCREEN": {
+        "textureMaterial": "WOODEN_SCREEN"
+      }
+    },
     "objectIds": [
       10355,
-      10527
+      10527,
+      10528
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
-    "uvScale": 0.65
+    "uvScale": 0.65,
+    "colorOverrides": [
+      {
+        "colors": [43060, 43082, 43084, 43110, 43125],
+        "baseMaterial": "METALLIC_NONE_GLOSS",
+        "uvType": "WORLD_XZ",
+        "uvScale": 2
+      }
+    ]
   },
   {
     "description": "Objects - Concrete - Gravestone",
@@ -20588,5 +20602,103 @@
     "uvType": "BOX",
     "uvOrientation": 512,
     "uvScale": 0.8
+  },
+  {
+    "description": "Bankbooth with Glass Window - Lumbridge",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 18491 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [21549, 21594, 21630],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
+  },
+  {
+    "description": "Bankbooth with Shutters - Lumbridge",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 18492 ],
+    "uvType": "BOX",
+    "uvScale": 0.8
+  },
+  {
+    "description": "Bankbooth with Glass Window - Varrock",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 10583 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [43054, 43082, 43102, 43125],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
+  },
+  {
+    "description": "Bankbooth with Glass Window - Falador",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 24101 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [43054, 43082, 43102, 43125],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
+  },
+  {
+    "description": "Bankbooth with Glass Window - Seers",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 25808 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [21549, 21594, 21630],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
+  },
+  {
+    "description": "Bankbooth with Shutters - Seers",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 25809 ],
+    "uvType": "BOX",
+    "uvScale": 0.8
+  },
+  {
+    "description": "Bankbooth with Glass Window - Lunar Island",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 16700 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [43011, 43054, 43102],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
+  },
+  {
+    "description": "Bankbooth with Glass Window - Canifis",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 24347 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [43011, 43054, 43121],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -20639,6 +20639,13 @@
     ]
   },
   {
+    "description": "Bankbooth with Shutters - Corsair Cove",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 10585 ],
+    "uvType": "BOX",
+    "uvScale": 0.8
+  },
+  {
     "description": "Bankbooth with Glass Window - Falador",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [ 24101 ],

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13721,8 +13721,8 @@
     "uvScale": 0.65,
     "colorOverrides": [
       {
-        "colors": [43060, 43082, 43084, 43110, 43125],
-        "baseMaterial": "METALLIC_NONE_GLOSS",
+        "colors": [43060, 43082, 43084, 43110, 43120, 43125],
+        "baseMaterial": "NONE",
         "uvType": "WORLD_XZ",
         "uvScale": 2
       }
@@ -20700,5 +20700,26 @@
         "uvType": "WORLD_XY"
       }
     ]
+  },
+  {
+    "description": "Bankbooth with Glass Window - Phasmatys",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 16642 ],
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "colors": [ 21507, 21548, 21595 ],
+        "baseMaterial": "NONE",
+        "uvType": "WORLD_XY"
+      }
+    ]
+  },
+  {
+    "description": "Bankbooth with Shutters - Phasmatys",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "objectIds": [ 16643 ],
+    "uvType": "BOX",
+    "uvScale": 0.8
   }
 ]


### PR DESCRIPTION
Applies textures to the bank booths around the mainland overworld.

![image](https://github.com/user-attachments/assets/04f7f223-989b-4cc7-8ae1-eb168afdb97d)
![image](https://github.com/user-attachments/assets/da71173a-dd56-4f0c-af2a-d20dfab17d42)
![image](https://github.com/user-attachments/assets/beec70f7-4c7e-43da-b68f-6fe6aa2058a0)
![image](https://github.com/user-attachments/assets/36b0d154-8dd4-4c8f-bfc0-d11c8bf15cc4)
