### PR TITLE
Clamp overbright grass

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -1,7 +1,8 @@
 [
   {
     "name": "DEFAULT_GRASS",
-    "groundMaterial": "OVERWORLD_GRASS_1"
+    "groundMaterial": "OVERWORLD_GRASS_1",
+    "maxLightness": 26
   },
   {
     "name": "DEFAULT_DIRT",
@@ -6540,6 +6541,7 @@
       126
     ],
     "groundMaterial": "OVERWORLD_GRASS_1",
+    "maxLightness": 22,
     "replacements": {
       "WINTER_GRASS": "season == WINTER"
     }

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -6658,7 +6658,7 @@
     "groundMaterial": "GRUNGE"
   },
   {
-    "name": "COMPLEX_TILES",
+    "name": "OVERWORLD_COMPLEX_TILES",
     "area": "OVERWORLD",
     "underlayIds": [
       13,


### PR DESCRIPTION
Clamp brightness of the default grass to fix a number of over bright areas in the over world

![image](https://github.com/user-attachments/assets/8eb7b66e-2269-4aed-aab4-96b2579e5424)
![image](https://github.com/user-attachments/assets/f90057d5-317f-49a6-b0f9-222d8fb6c7d4)
![image](https://github.com/user-attachments/assets/e2ad909c-dccc-4480-b966-e36ee57e8b9a)
![image](https://github.com/user-attachments/assets/17e41a15-11f3-4a0e-9c52-91550f1c02bb)
![image](https://github.com/user-attachments/assets/09f4d916-508d-4f90-bfe4-c80621ecc4eb)
![image](https://github.com/user-attachments/assets/46b4ed00-155a-4b68-833a-268640b64e37)
