### PR TITLE
Assign materials to Wattle and HD hay homes

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -5494,15 +5494,23 @@
   },
   {
     "description": "Wattle Style Houses (Ardougne, Digsite)",
-    "baseMaterial": "WATTLE_1",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "uvType": "BOX",
+    "flatNormals": true,
+    "colorOverrides": [
+      {
+        "colors": "h == 10 && s == 0",
+        "baseMaterial": "WATTLE_1",
+        "uvType": "BOX"
+      }
+    ],
     "objectIds": [
       1602,
       1603,
       1606,
       1608,
       17349
-    ],
-    "flatNormals": true
+    ]
   },
   {
     "description": "Candelabra",
@@ -14692,6 +14700,16 @@
   {
     "description": "Objects - Hay - Roof",
     "textureMaterial": "HD_HAY",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "uvType": "BOX",
+    "retainVanillaUvs": false,
+    "colorOverrides": [
+        {
+          "colors": "h == 10 && s == 0",
+          "baseMaterial": "WATTLE_1",
+          "uvType": "BOX"
+        }
+    ],
     "objectIds": [
       1604,
       1605,
@@ -14703,9 +14721,7 @@
       4243,
       4244,
       4245
-    ],
-    "uvType": "BOX",
-    "retainVanillaUvs": false
+    ]
   },
   {
     "description": "Objects - Hay - Haystack",


### PR DESCRIPTION
fixes an eye sore of mishmashed textures for houses that use post/wall 1602.
![image](https://github.com/user-attachments/assets/85d79998-25a2-405b-8a1e-687c3f8d6016)
![image](https://github.com/user-attachments/assets/13515d07-0f0d-48df-be68-8ba332c3b895)
![image](https://github.com/user-attachments/assets/0414c066-28c6-4288-be92-1ef80e453ce1)
![image](https://github.com/user-attachments/assets/537416c3-5de2-4735-ba06-c3cbddef3775)
