### PR TITLE
Fix wilderness ditch fence materials

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -9108,12 +9108,30 @@
       23266,
       23267,
       23268,
-      23269,
-      23270,
       23271
     ],
     "uvType": "BOX",
     "uvScale": 0.8
+  },
+  {
+    "description": "Wilderness Ditch with fence",
+    "baseMaterial": "DIRT_1",
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "colorOverrides": [
+      {
+        "description": "Fence",
+        "colors": "s == 0",
+        "baseMaterial": "WOOD_GRAIN_3",
+        "uvType": "BOX",
+        "uvScale": 0.6,
+        "uvOrientation": 448
+      }
+    ],
+    "objectIds": [
+      23269,
+      23270
+    ]
   },
   {
     "description": "Wilderness Ditch Dirt clumps",


### PR DESCRIPTION
Master it is currently dirt; uses a color override to assign a wood texture.
![image](https://github.com/user-attachments/assets/e281ffb2-d9d6-4fa8-a782-9e8e8f4bff04)
![image](https://github.com/user-attachments/assets/a157c90c-bffa-470e-9bcb-49f055cf76c1)
