### PR TITLE
Reduce garbage generation in FrameTimerOverlay::addTiming()

### DIFF
--- a/src/main/java/rs117/hd/overlays/FrameTimerOverlay.java
+++ b/src/main/java/rs117/hd/overlays/FrameTimerOverlay.java
@@ -23,6 +23,7 @@ public class FrameTimerOverlay extends OverlayPanel implements FrameTimer.Listen
 	private FrameTimer frameTimer;
 
 	private final ArrayDeque<FrameTimings> frames = new ArrayDeque<>();
+	private final StringBuilder sb = new StringBuilder();
 
 	@Inject
 	public FrameTimerOverlay(HdPlugin plugin) {
@@ -119,12 +120,16 @@ public class FrameTimerOverlay extends OverlayPanel implements FrameTimer.Listen
 			return;
 
 		// Round timers to zero if they are less than a microsecond off
-		String formatted = nanos < 3e3 && nanos > -1e5 ? "~0 ms" : String.format("%.3f ms", nanos / 1e6);
+		String result = "~0 ms";
+		if (nanos < -1e5 || nanos > 3e3) {
+			result = sb.append(Math.round(nanos / 1e3) / 1e3).append(" ms").toString();
+			sb.setLength(0);
+		}
 		var font = bold ? FontManager.getRunescapeBoldFont() : FontManager.getRunescapeFont();
 		panelComponent.getChildren().add(LineComponent.builder()
 			.left(name + ":")
 			.leftFont(font)
-			.right(formatted)
+			.right(result)
 			.rightFont(font)
 			.build());
 	}


### PR DESCRIPTION
**Problem:**
Using String.Format() generates a large amount of garbage, enough to increase the amount of garbage collection spikes, which messes with the reported timings over time.

![image](https://github.com/user-attachments/assets/ed6e323c-8af2-4138-8cb4-0db84f83d64d)

**Solution:**
Avoid usage of String,Format & instead use a StringBuilder to utilize the internal buffer to perform the formatting necessary.
Instead of using a string expression to round to 3 decimal places, do it manually using Math.Round()