### PR TITLE
Added more accurate GPU Timing

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1631,6 +1631,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 
 		frameTimer.end(Timer.DRAW_SCENE);
 		frameTimer.begin(Timer.UPLOAD_GEOMETRY);
+		frameTimer.begin(Timer.RENDER_FRAME);
 
 		// The client only updates animations once per client tick, so we can skip updating geometry buffers,
 		// but the compute shaders should still be executed in case the camera angle has changed.
@@ -1889,6 +1890,10 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 		if (gameState == GameState.STARTING) {
 			frameTimer.end(Timer.DRAW_FRAME);
 			return;
+		}
+
+		if(sceneContext == null){
+			frameTimer.begin(Timer.RENDER_FRAME);
 		}
 
 		if (lastFrameTimeMillis > 0) {
@@ -2272,6 +2277,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 		drawUi(overlayColor, canvasHeight, canvasWidth);
 
 		try {
+			frameTimer.end(Timer.RENDER_FRAME);
 			frameTimer.begin(Timer.SWAP_BUFFERS);
 			awtContext.swapBuffers();
 			frameTimer.end(Timer.SWAP_BUFFERS);

--- a/src/main/java/rs117/hd/overlays/FrameTimerOverlay.java
+++ b/src/main/java/rs117/hd/overlays/FrameTimerOverlay.java
@@ -68,13 +68,10 @@ public class FrameTimerOverlay extends OverlayPanel implements FrameTimer.Listen
 				if (!t.isGpuTimer && t != Timer.DRAW_FRAME)
 					addTiming(t, timings);
 
-			long gpuTime = 0;
-			for (var t : Timer.values())
-				if (t.isGpuTimer)
-					gpuTime += timings[t.ordinal()];
+			long gpuTime = timings[Timer.RENDER_FRAME.ordinal()];
 			addTiming("GPU", gpuTime, true);
 			for (var t : Timer.values())
-				if (t.isGpuTimer)
+				if (t.isGpuTimer && t != Timer.RENDER_FRAME)
 					addTiming(t, timings);
 
 			panelComponent.getChildren().add(LineComponent.builder()

--- a/src/main/java/rs117/hd/overlays/Timer.java
+++ b/src/main/java/rs117/hd/overlays/Timer.java
@@ -20,6 +20,7 @@ public enum Timer {
 	UPDATE_LIGHTS,
 	IMPOSTOR_TRACKING,
 	REPLACE_FISHING_SPOTS,
+	RENDER_FRAME(true),
 	UPLOAD_GEOMETRY(true),
 	UPLOAD_UI(true, "Upload UI"),
 	COMPUTE(true),


### PR DESCRIPTION
**Problem:**

From doing GPU Captures & Traces, I've noticed that adding the GPU Markers together doesn't paint the full picture of how long a frame is being drawn. GPU Idle time,

**Solution:**
Added new Timer: RENDER_FRAME, to capture the time between PostDrawScene() & the Submit in Draw().

**Caveat:**
This does mean it'll capture the GPU Idle time between the compute & submit, but overall I've found this to be more accurate when testing changes.