### PR TITLE
Remove FINE_CARPET

### DIFF
--- a/src/main/resources/rs117/hd/scene/ground_materials.json
+++ b/src/main/resources/rs117/hd/scene/ground_materials.json
@@ -111,12 +111,6 @@
     ]
   },
   {
-    "name": "FINE_CARPET",
-    "materials": [
-      "FINE_CARPET"
-    ]
-  },
-  {
     "name": "BRICK",
     "materials": [
       "BRICK"

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -6237,7 +6237,7 @@
     "overlayIds": [
       256
     ],
-    "groundMaterial": "FINE_CARPET"
+    "groundMaterial": "CARPET"
   },
 
   {


### PR DESCRIPTION
Removes FINE_CARPET from ground_materials.json that was left behind by mistake, fixes a crash caused by this.