### PR TITLE
South karamja buildings and plants

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13584,7 +13584,8 @@
     "uvScale": 0.25,
     "uvType": "MODEL_XZ",
     "objectIds": [
-      1390
+      1390,
+      1398
     ]
   },
   {
@@ -27209,6 +27210,26 @@
     ],
     "objectIds": [
       1721
+    ]
+  },
+  {
+    "description": "Karamja Bamboo potted plant",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 512,
+    "colorOverrides": [
+      {
+        "description": "Plant",
+        "baseMaterial": "LEAF_VEINS",
+        "colors": " h > 11",
+        "uvType": "MODEL_XZ",
+        "uvOrientation": 128,
+        "uvScale": 0.25
+      }
+    ],
+    "objectIds": [
+      1160
     ]
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -12423,13 +12423,20 @@
   },
   {
     "description": "Jungle Tree Large - Unusual Plant",
-    "baseMaterial": "PLANT_GRUNGE_2",
-    "objectIds": [
-      1314
-    ],
+    "baseMaterial": "BARK",
     "uvType": "BOX",
     "uvScale": 0.4,
-    "uvOrientation": 256
+    "uvOrientation": 768,
+    "colorOverrides": [
+      {
+        "description": "Leaves",
+        "baseMaterial": "LEAF_VEINS",
+        "colors": "h > 10"
+      }
+    ],
+    "objectIds": [
+      1314
+    ]
   },
   {
     "description": "Tropical Tree Big",

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -8852,6 +8852,34 @@
     "uvType": "GEOMETRY"
   },
   {
+    "description": "Objects - Vines with grass",
+    "baseMaterial": "GRUNGE_3_DARK",
+    "uvType": "BOX",
+    "colorOverrides": [
+      {
+        "description": "Grass",
+        "colors": "s == 7",
+        "baseMaterial": "NONE"
+      },
+      {
+        "description": "Leaves",
+        "colors": "s == 3",
+        "baseMaterial": "LEAF_VEINS"
+      }
+    ],
+    "objectIds": [
+      1222,
+      1223,
+      1224,
+      1225,
+      1226,
+      1227,
+      1228,
+      1229,
+      1230
+    ]
+  },
+  {
     "description": "Objects - White Mushrooms - Medium",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
@@ -13528,6 +13556,46 @@
       9604,
       9605,
       9606
+    ]
+  },
+  {
+    "description": "Karamja - Jungle plant - Leafy style",
+    "baseMaterial": "LEAF_VEINS",
+    "uvScale": 0.25,
+    "uvType": "BOX",
+    "objectIds": [
+      1204,
+      1399,
+      1400,
+      1401,
+      1402
+    ]
+  },
+  {
+    "description": "Karamja - Jungle plant - fern style",
+    "baseMaterial": "LEAF_VEINS",
+    "uvScale": 0.25,
+    "uvType": "MODEL_XZ",
+    "objectIds": [
+      1390
+    ]
+  },
+  {
+    "description": "Karamja - Creeping plant",
+    "baseMaterial": "LEAF_VEINS",
+    "uvScale": 0.25,
+    "uvType": "MODEL_XZ",
+    "objectIds": [
+      1184
+    ]
+  },
+  {
+    "description": "Karamja - Curling plant",
+    "baseMaterial": "LEAF_VEINS",
+    "uvScale": 0.25,
+    "uvType": "MODEL_XZ",
+    "objectIds": [
+      1186
     ]
   },
   {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -11065,11 +11065,31 @@
     "uvScale": 0.4
   },
   {
+    "description": "Walls - Double Rope Rails",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "uvType": "BOX",
+    "uvScale": 0.54,
+    "colorOverrides": [
+      {
+        "description": "Ropes",
+        "baseMaterial": "ROPE",
+        "colors": "h == 6",
+        "uvType": "BOX",
+        "uvOrientationZ": 512,
+        "uvOrientationY": 320,
+        "uvOrientationX": 768,
+        "uvScale": 0.4
+      }
+    ],
+    "objectIds": [
+      1982
+    ]
+  },
+  {
     "description": "Gnome - Walls - Rope Rails",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      1708,
-      1982
+      1708
     ]
   },
   {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -27251,5 +27251,86 @@
     "objectIds": [
       1160
     ]
+  },
+  {
+    "description": "Karamja Bamboo pots",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 512,
+    "objectIds": [
+      395,
+      396
+    ]
+  },
+  {
+    "description": "Karamja Bamboo booksehlf - Textured - Has a really bad UV even with boxed.",
+    "baseMaterial": "GRUNGE_2",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 512,
+    "objectIds": [
+      393
+    ]
+  },
+  {
+    "description": "Karamja Bamboo booksehlf - Has a really bad UV even with boxed.",
+    "baseMaterial": "GRUNGE_2",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 512,
+    "objectIds": [
+      394
+    ]
+  },
+  {
+    "description": "Karamja Bamboo table",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 512,
+    "colorOverrides": [
+      {
+        "description": "Dirt",
+        "baseMaterial": "DIRT_2",
+        "colors": " h == 4",
+        "uvType": "MODEL_XZ",
+        "uvOrientation": 128,
+        "uvScale": 0.33
+      }
+    ],
+    "objectIds": [
+      620
+    ]
+  },
+  {
+    "description": "Karamja Bamboo stool",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 512,
+    "objectIds": [
+      1113
+    ]
+  },
+  {
+    "description": "Karamja Bamboo raised bed",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 512,
+    "colorOverrides": [
+      {
+        "description": "Bed",
+        "baseMaterial": "CARPET",
+        "colors": " h == 8",
+        "uvType": "BOX",
+        "uvOrientation": 720,
+        "uvScale": 0.8
+      }
+    ],
+    "objectIds": [
+      433
+    ]
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -27081,5 +27081,59 @@
     "objectIds": [
       31675
     ]
+  },
+  {
+    "description": "Karamja hut walls",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvOrientation": 512,
+    "uvScale": 0.25,
+    "objectIds": [
+      1593,
+      1616,
+      1855
+    ]
+  },
+  {
+    "description": "Karamja hardwood grove doors",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvOrientation": 512,
+    "uvScale": 0.25,
+    "objectIds": [
+      9038,
+      9039
+    ]
+  },
+  {
+    "description": "Karamja Bamboo door",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvOrientation": 512,
+    "uvScale": 0.25,
+    "objectIds": [
+      779
+    ]
+  },
+  {
+    "description": "Karamja Bamboo bridge",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.5,
+    "uvOrientation": 1024,
+    "uvOrientationZ": 162,
+    "colorOverrides": [
+      {
+        "description": "Rope",
+        "baseMaterial": "ROPE",
+        "colors": " h == 11",
+        "uvType": "MODEL_XZ",
+        "uvOrientation": 128,
+        "uvScale": 0.25
+      }
+    ],
+    "objectIds": [
+      1721
+    ]
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -27332,5 +27332,24 @@
     "objectIds": [
       433
     ]
+  },
+  {
+    "description": "Karamja Bamboo access ramps - Model has bad UVs even with Box",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.25,
+    "uvOrientation": 256,
+    "colorOverrides": [
+      {
+        "description": "horizontal braces",
+        "baseMaterial": "GRUNGE_1",
+        "colors": " h == 7",
+        "uvType": "BOX",
+        "uvScale": 0.4
+      }
+    ],
+    "objectIds": [
+      1617
+    ]
   }
 ]


### PR DESCRIPTION
Adds texture definitions for the style of architecture and plants of Southern Karamja. Touches similar models like Brimhaven Agility Arena entrance.

Master/PR:
![image](https://github.com/user-attachments/assets/b7094039-6c65-478c-8f62-d164149e0a41)
![image](https://github.com/user-attachments/assets/6e9d9579-f368-40c0-98db-ea4c158e88eb)
![image](https://github.com/user-attachments/assets/99888487-5d72-4a1e-a7b9-a219e728c38a)
![image](https://github.com/user-attachments/assets/4b0381d6-7e1e-4219-847e-f5d4f560233f)


![image](https://github.com/user-attachments/assets/eea7b213-ed9b-4fad-a31b-c6329fc75aee)
![image](https://github.com/user-attachments/assets/940387ba-a248-4539-a59c-90ee99d9fa66)
![image](https://github.com/user-attachments/assets/5d064194-1dd6-4a7a-bad4-79ff1dc6a089)

