### PR TITLE
Gameval Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ nb-configuration.xml
 nbproject/
 hs_err_pid*
 shader-dumps/
+/src/main/resources/rs117/hd/gamevals

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import groovy.json.JsonOutput
+import java.lang.reflect.Modifier
+
 plugins {
 	id 'java'
 //	id 'com.github.johnrengelman.shadow' version '6.1.0'
@@ -34,6 +37,55 @@ sourceCompatibility = '11'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
+}
+
+task exportConstantsToJson {
+	doLast {
+		def startTime = System.nanoTime()
+
+		def outputDir = file('src/main/resources/rs117/hd/gamevals')
+		outputDir.mkdirs()
+
+		def exportMap = [
+			'npcs.json'   : ['net.runelite.api.gameval.NpcID'],
+			'objects.json': ['net.runelite.api.gameval.ObjectID', 'net.runelite.api.gameval.ObjectID1'],
+			'anims.json'  : ['net.runelite.api.gameval.AnimationID'],
+			'spotanim.json' : ['net.runelite.api.gameval.SpotanimID']
+		]
+
+		URLClassLoader loader = new URLClassLoader(
+			configurations.compileClasspath.collect { it.toURI().toURL() } as URL[],
+			this.class.classLoader
+		)
+
+		exportMap.each { filename, classList ->
+			def constants = [:]
+
+			classList.each { className ->
+				def clazz = loader.loadClass(className)
+
+				clazz.declaredFields.each { field ->
+					if (Modifier.isPublic(field.modifiers) &&
+						Modifier.isStatic(field.modifiers) &&
+						Modifier.isFinal(field.modifiers)) {
+
+						field.accessible = true
+						constants[field.name] = field.get(null)
+					}
+				}
+			}
+
+			def outputFile = new File(outputDir, filename)
+			outputFile.text = JsonOutput.prettyPrint(JsonOutput.toJson(constants))
+		}
+
+		def elapsedMs = (System.nanoTime() - startTime) / 1_000_000
+		println "Export GameVal completed in ${elapsedMs} ms"
+	}
+}
+
+tasks.named('build') {
+	dependsOn exportConstantsToJson
 }
 
 //shadowJar {

--- a/schemas/lights.schema.json
+++ b/schemas/lights.schema.json
@@ -155,37 +155,37 @@
       },
       "npcIds": {
         "type": "array",
-        "description": "A set of NPC IDs or NpcID keys to apply the light to.",
+        "description": "A set of config name NPC IDs or NpcID keys to apply the light to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "objectIds": {
         "type": "array",
-        "description": "A set of object IDs or ObjectID keys to apply the light to.",
+        "description": "A set of object config name IDs or ObjectID keys to apply the light to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "projectileIds": {
         "type": "array",
-        "description": "A set of projectile IDs to apply the light to.",
+        "description": "A set of projectile config name IDs to apply the light to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "graphicsObjectIds": {
         "type": "array",
-        "description": "A set of graphics object IDs to apply the light to.",
+        "description": "A set of graphics object config name IDs to apply the light to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "animationIds": {
         "type": "array",
-        "description": "A set of animation IDs to display the light for. Must be specified alongside another kind of ID to apply to.",
+        "description": "A set of animation config name IDs to display the light for. Must be specified alongside another kind of ID to apply to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       }
     }

--- a/schemas/model_overrides.schema.json
+++ b/schemas/model_overrides.schema.json
@@ -32,28 +32,28 @@
         "type": "array",
         "description": "A set of NPC IDs which the override should apply to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "objectIds": {
         "type": "array",
-        "description": "A set of object IDs which the override should apply to.",
+        "description": "A set of object config name IDs which the override should apply to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "projectileIds": {
         "type": "array",
-        "description": "A set of projectile IDs which the override should apply to.",
+        "description": "A set of projectile config name IDs which the override should apply to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "graphicsObjectIds": {
         "type": "array",
-        "description": "A set of graphics object IDs which the override should apply to.",
+        "description": "A set of graphics object config name IDs which the override should apply to.",
         "items": {
-          "type": "integer"
+          "type": "string"
         }
       },
       "baseMaterial": {

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -85,6 +85,7 @@ import rs117.hd.config.ShadingMode;
 import rs117.hd.config.ShadowMode;
 import rs117.hd.config.UIScalingMode;
 import rs117.hd.config.VanillaShadowMode;
+import rs117.hd.data.GameValRepository;
 import rs117.hd.data.WaterType;
 import rs117.hd.data.materials.Material;
 import rs117.hd.model.ModelHasher;
@@ -238,6 +239,9 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 
 	@Inject
 	private ProceduralGenerator proceduralGenerator;
+
+	@Inject
+	private GameValRepository gameValRepository;
 
 	@Inject
 	private SceneUploader sceneUploader;
@@ -637,6 +641,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 				lastStretchedCanvasWidth = lastStretchedCanvasHeight = 0;
 				lastAntiAliasingMode = null;
 
+				gameValRepository.startUp();
 				areaManager.startUp();
 				groundMaterialManager.startUp();
 				tileOverrideManager.startUp();
@@ -2383,7 +2388,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 				int r = buffer.get() & 0xff;
 				int g = buffer.get() & 0xff;
 				int b = buffer.get() & 0xff;
-				buffer.get(); // alpha
+				buffer.get(); // alph a
 
 				pixels[(height - y - 1) * width + x] = (r << 16) | (g << 8) | b;
 			}

--- a/src/main/java/rs117/hd/data/GameValRepository.java
+++ b/src/main/java/rs117/hd/data/GameValRepository.java
@@ -1,0 +1,80 @@
+package rs117.hd.data;
+
+import com.google.gson.reflect.TypeToken;
+import java.io.IOException;
+import javax.inject.Singleton;
+import lombok.extern.slf4j.Slf4j;
+import rs117.hd.HdPlugin;
+
+import javax.inject.Inject;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Repository responsible for loading and providing access to
+ * various game value mappings (Jagex Internal config Names) categorized by {@link GameValType}.
+ */
+
+@Slf4j
+@Singleton
+public class GameValRepository {
+
+	@Inject
+	private HdPlugin plugin;
+
+	private final Map<GameValType, Map<String, Integer>> values = new EnumMap<>(GameValType.class);
+
+	public void startUp() throws IOException {
+		long startTime = System.nanoTime();
+
+		Type mapType = new TypeToken<Map<String, Integer>>() {}.getType();
+
+		for (GameValType type : GameValType.values()) {
+			String path = "/rs117/hd/gamevals/" + type.getFileName();
+
+			try (InputStream is = getClass().getResourceAsStream(path)) {
+				if (is == null) {
+					log.warn("Could not find resource: {}", path);
+					values.put(type, Collections.emptyMap());
+					continue;
+				}
+
+				try (InputStreamReader reader = new InputStreamReader(is)) {
+					Map<String, Integer> map = plugin.getGson().fromJson(reader, mapType);
+					values.put(type, Collections.unmodifiableMap(map));
+				}
+			} catch (Exception e) {
+				throw new RuntimeException("Failed to load JSON for " + type + ": " + path, e);
+			}
+		}
+
+		long endTime = System.nanoTime();
+		long durationMs = (endTime - startTime) / 1_000_000;
+
+		log.info("Loaded all GameValType data in {} ms", durationMs);
+	}
+
+	public Map<String, Integer> get(GameValType type) {
+		return values.getOrDefault(type, Collections.emptyMap());
+	}
+
+	public Integer get(GameValType type, String name) {
+		return get(type).get(name);
+	}
+
+	public String lookupNameById(GameValType type, Integer id) {
+		Map<String, Integer> map = values.get(type);
+		if (map == null) return null;
+
+		for (Map.Entry<String, Integer> entry : map.entrySet()) {
+			if (entry.getValue().equals(id)) {
+				return entry.getKey();
+			}
+		}
+		return null;
+	}
+}

--- a/src/main/java/rs117/hd/data/GameValType.java
+++ b/src/main/java/rs117/hd/data/GameValType.java
@@ -1,0 +1,18 @@
+package rs117.hd.data;
+
+public enum GameValType {
+	NPC("npcs.json"),
+	OBJECT("objects.json"),
+	ANIM("anims.json"),
+	SPOTANIM("spotanim.json");
+
+	private final String fileName;
+
+	GameValType(String fileName) {
+		this.fileName = fileName;
+	}
+
+	public String getFileName() {
+		return fileName;
+	}
+}

--- a/src/main/java/rs117/hd/scene/FishingSpotReplacer.java
+++ b/src/main/java/rs117/hd/scene/FishingSpotReplacer.java
@@ -3,6 +3,7 @@ package rs117.hd.scene;
 import com.google.common.collect.Sets;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -12,6 +13,8 @@ import net.runelite.api.events.*;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import rs117.hd.HdPluginConfig;
+import rs117.hd.data.GameValRepository;
+import rs117.hd.data.GameValType;
 import rs117.hd.overlays.FrameTimer;
 import rs117.hd.overlays.Timer;
 import rs117.hd.scene.model_overrides.ModelOverride;
@@ -29,7 +32,7 @@ public class FishingSpotReplacer {
 	private static final Set<Integer> FISHING_SPOT_IDS = Set.of(394, 635, 1506, 1507, 1508, 1509, 1510, 1511, 1512, 1513, 1514, 1515, 1516, 1517, 1518, 1519, 1520, 1521, 1522, 1523, 1524, 1525, 1526, 1527, 1528, 1529, 1530, 1531, 1532, 1533, 1534, 1535, 1536, 1542, 1544, 2146, 2653, 2654, 2655, 3317, 3417, 3418, 3419, 3657, 3913, 3914, 3915, 4079, 4080, 4081, 4082, 4316, 4476, 4477, 4710, 4711, 4712, 4713, 4714, 5233, 5234, 5820, 5821, 6731, 6825, 7155, 7199, 7200, 7323, 7459, 7460, 7461, 7462, 7463, 7464, 7465, 7466, 7467, 7468, 7469, 7470, 7946, 7947, 8524, 8525, 8526, 8527, 9171, 9172, 9173, 9174, 9478, 12267);
 	private static final Set<Integer> LAVA_FISHING_SPOT_IDS = Set.of(4928);
 	// @formatter:on
-	private static final Set<Integer> NPC_IDS = Sets.union(FISHING_SPOT_IDS, LAVA_FISHING_SPOT_IDS).immutableCopy();
+	private static final Set<String> NPC_IDS = new HashSet<>();
 
 	@Inject
 	private Client client;
@@ -46,6 +49,9 @@ public class FishingSpotReplacer {
 	@Inject
 	private FrameTimer frameTimer;
 
+	@Inject
+	private GameValRepository gameValRepository;
+
 	private final Map<Integer, RuneLiteObject> npcIndexToModel = new HashMap<>();
 	private Animation fishingSpotAnimation;
 	private Animation lavaFishingSpotAnimation;
@@ -54,6 +60,8 @@ public class FishingSpotReplacer {
 		eventBus.register(this);
 		fishingSpotAnimation = client.loadAnimation(FISHING_SPOT_ANIMATION_ID);
 		lavaFishingSpotAnimation = client.loadAnimation(LAVA_SPOT_ANIMATION_ID);
+		FISHING_SPOT_IDS.forEach(id -> NPC_IDS.add(gameValRepository.lookupNameById(GameValType.NPC,id)));
+		LAVA_FISHING_SPOT_IDS.forEach(id -> NPC_IDS.add(gameValRepository.lookupNameById(GameValType.NPC,id)));
 	}
 
 	public void shutDown() {

--- a/src/main/java/rs117/hd/scene/ModelOverrideManager.java
+++ b/src/main/java/rs117/hd/scene/ModelOverrideManager.java
@@ -11,6 +11,8 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import net.runelite.client.callback.ClientThread;
 import rs117.hd.HdPlugin;
+import rs117.hd.data.GameValRepository;
+import rs117.hd.data.GameValType;
 import rs117.hd.model.ModelPusher;
 import rs117.hd.scene.model_overrides.ModelOverride;
 import rs117.hd.utils.FileWatcher;
@@ -42,6 +44,9 @@ public class ModelOverrideManager {
 
 	@Inject
 	private FishingSpotReplacer fishingSpotReplacer;
+
+	@Inject
+	private GameValRepository gameValRepository;
 
 	private final HashMap<Integer, ModelOverride> modelOverrides = new HashMap<>();
 
@@ -107,14 +112,14 @@ public class ModelOverrideManager {
 		if (override == null || override.seasonalTheme != null && override.seasonalTheme != plugin.configSeasonalTheme)
 			return;
 
-		for (int id : override.npcIds)
-			addEntry(ModelHash.TYPE_NPC, id, override);
-		for (int id : override.objectIds)
-			addEntry(ModelHash.TYPE_OBJECT, id, override);
-		for (int id : override.projectileIds)
-			addEntry(ModelHash.TYPE_PROJECTILE, id, override);
-		for (int id : override.graphicsObjectIds)
-			addEntry(ModelHash.TYPE_GRAPHICS_OBJECT, id, override);
+		for (String configName : override.npcIds)
+			addEntry(ModelHash.TYPE_NPC, gameValRepository.get(GameValType.NPC,configName), override);
+		for (String configName : override.objectIds)
+			addEntry(ModelHash.TYPE_OBJECT, gameValRepository.get(GameValType.OBJECT,configName), override);
+		for (String configName : override.projectileIds)
+			addEntry(ModelHash.TYPE_PROJECTILE, gameValRepository.get(GameValType.SPOTANIM,configName), override);
+		for (String configName : override.graphicsObjectIds)
+			addEntry(ModelHash.TYPE_GRAPHICS_OBJECT, gameValRepository.get(GameValType.SPOTANIM,configName), override);
 	}
 
 	private void addEntry(int type, int id, ModelOverride entry) {

--- a/src/main/java/rs117/hd/scene/lights/LightDefinition.java
+++ b/src/main/java/rs117/hd/scene/lights/LightDefinition.java
@@ -36,17 +36,17 @@ public class LightDefinition {
 	public AABB[] areas = {};
 	@JsonAdapter(AABB.JsonAdapter.class)
 	public AABB[] excludeAreas = {};
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public HashSet<Integer> npcIds = new HashSet<>();
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public HashSet<Integer> objectIds = new HashSet<>();
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public HashSet<Integer> projectileIds = new HashSet<>();
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public HashSet<String> npcIds = new HashSet<>();
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public HashSet<String> objectIds = new HashSet<>();
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public HashSet<String> projectileIds = new HashSet<>();
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
 	@SerializedName("graphicsObjectIds") // TODO: rename this
-	public HashSet<Integer> spotAnimIds = new HashSet<>();
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public HashSet<Integer> animationIds = new HashSet<>();
+	public HashSet<String> spotAnimIds = new HashSet<>();
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public HashSet<String> animationIds = new HashSet<>();
 
 	public void normalize() {
 		if (description == null)

--- a/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
+++ b/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
@@ -31,7 +31,7 @@ public class ModelOverride
 {
 	public static final ModelOverride NONE = new ModelOverride(true);
 
-	private static final Set<Integer> EMPTY = new HashSet<>();
+	private static final Set<String> EMPTY = new HashSet<>();
 
 	public String description = "UNKNOWN";
 
@@ -39,14 +39,14 @@ public class ModelOverride
 	public SeasonalTheme seasonalTheme;
 	@JsonAdapter(AABB.JsonAdapter.class)
 	public AABB[] areas = {};
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public Set<Integer> npcIds = EMPTY;
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public Set<Integer> objectIds = EMPTY;
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public Set<Integer> projectileIds = EMPTY;
-	@JsonAdapter(GsonUtils.IntegerSetAdapter.class)
-	public Set<Integer> graphicsObjectIds = EMPTY;
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public Set<String> npcIds = EMPTY;
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public Set<String> objectIds = EMPTY;
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public Set<String> projectileIds = EMPTY;
+	@JsonAdapter(GsonUtils.StringSetAdapter.class)
+	public Set<String> graphicsObjectIds = EMPTY;
 
 	public Material baseMaterial = Material.NONE;
 	public Material textureMaterial = Material.NONE;

--- a/src/main/java/rs117/hd/utils/GsonUtils.java
+++ b/src/main/java/rs117/hd/utils/GsonUtils.java
@@ -23,6 +23,28 @@ public class GsonUtils {
 		return str;
 	}
 
+	public static HashSet<String> parseStringArray(JsonReader in) throws IOException {
+		HashSet<String> ids = new HashSet<>();
+		in.beginArray();
+		while (in.hasNext()) {
+			if (in.peek() == JsonToken.STRING) {
+				try {
+					ids.add(in.nextString());
+				} catch (NumberFormatException ex) {
+					String message = "Failed to parse int at " + location(in);
+					if (THROW_WHEN_PARSING_FAILS)
+						throw new RuntimeException(message, ex);
+					log.error(message, ex);
+				}
+			} else {
+				throw new RuntimeException("Unable to parse ID: " + in.peek() + " at " + location(in));
+			}
+		}
+		in.endArray();
+		return ids;
+	}
+
+
 	public static HashSet<Integer> parseIDArray(JsonReader in) throws IOException {
 		HashSet<Integer> ids = new HashSet<>();
 		in.beginArray();
@@ -44,6 +66,18 @@ public class GsonUtils {
         return ids;
     }
 
+	public static void writeStringArray(JsonWriter out, HashSet<String> listToWrite) throws IOException {
+		if (listToWrite.isEmpty()) {
+			out.nullValue();
+			return;
+		}
+
+		out.beginArray();
+		for (String id : listToWrite)
+			out.value(id);
+		out.endArray();
+	}
+
 	public static void writeIDArray(JsonWriter out, HashSet<Integer> listToWrite) throws IOException {
 		if (listToWrite.isEmpty()) {
 			out.nullValue();
@@ -54,6 +88,18 @@ public class GsonUtils {
 		for (int id : listToWrite)
 			out.value(id);
 		out.endArray();
+	}
+
+	public static class StringSetAdapter extends TypeAdapter<HashSet<String>> {
+		@Override
+		public HashSet<String> read(JsonReader in) throws IOException {
+			return parseStringArray(in);
+		}
+
+		@Override
+		public void write(JsonWriter out, HashSet<String> value) throws IOException {
+			writeStringArray(out, value);
+		}
 	}
 
 	public static class IntegerSetAdapter extends TypeAdapter<HashSet<Integer>> {

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -17600,15 +17600,15 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      1632,
-      6689,
-      5604,
-      5590,
-      6696,
-      1625,
-      6682,
-      6668,
-      5597
+      "LAZYCAT_HELL",
+      "POH_LAZYCAT_HELL",
+      "OVERGROWNCAT_HELL",
+      "WILEYCAT_HELL",
+      "POH_WILEYCAT_HELL",
+      "GROWNCAT_HELL",
+      "POH_OVERGROWNCAT_HELL",
+      "POH_GROWNCAT_HELL",
+      "KITTENPET_HELL"
     ]
   },
   {
@@ -17626,7 +17626,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      4809
+      "HUNDRED_DAVE_HELLRAT"
     ]
   },
   {
@@ -17644,7 +17644,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      6793
+      "HUNDRED_DAVE_BIGRAT"
     ]
   },
   {
@@ -17662,8 +17662,8 @@
     "duration": 5000,
     "range": 20,
     "npcIds": [
-      964,
-      3099
+      "POH_HELLPET",
+      "HELLPET"
     ]
   },
   {
@@ -17681,8 +17681,8 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      8519,
-      8494
+      "POH_HYDRA_PET_FIRE",
+      "HYDRA_PET_FIRE"
     ]
   },
   {
@@ -17700,8 +17700,8 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      8517,
-      8492
+      "POH_HYDRA_PET",
+      "HYDRA_PET"
     ]
   },
   {
@@ -17719,8 +17719,8 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      8518,
-      8493
+      "POH_HYDRA_PET_ELECTRIC",
+      "HYDRA_PET_ELECTRIC"
     ]
   },
   {
@@ -17738,8 +17738,8 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      8520,
-      8495
+      "POH_HYDRA_PET_EXTINGUISHED",
+      "HYDRA_PET_EXTINGUISHED"
     ]
   },
   {
@@ -17757,8 +17757,8 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      7368,
-      7370
+      "POH_PHOENIX_PET",
+      "PHOENIX_PET"
     ]
   },
   {
@@ -17776,8 +17776,8 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      3079,
-      3083
+      "POH_PHOENIX_PET_WHITE",
+      "PHOENIX_PET_WHITE"
     ]
   },
   {
@@ -17795,8 +17795,8 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      3078,
-      3082
+      "POH_PHOENIX_PET_BLUE",
+      "PHOENIX_PET_BLUE"
     ]
   },
   {
@@ -17814,8 +17814,8 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      3080,
-      3084
+      "POH_PHOENIX_PET_PURPLE",
+      "PHOENIX_PET_PURPLE"
     ]
   },
   {
@@ -17833,8 +17833,8 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      3077,
-      3081
+      "POH_PHOENIX_PET_GREEN",
+      "PHOENIX_PET_GREEN"
     ]
   },
   {
@@ -17852,8 +17852,8 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      8009,
-      8011
+      "POH_ZUK_PET",
+      "ZUK_PET"
     ]
   },
   {
@@ -17871,8 +17871,8 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      7890,
-      7893
+      "POH_DUSK_PET",
+      "DUSK_PET"
     ]
   },
   {
@@ -17890,8 +17890,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7337,
-      7354
+      "POH_SKILLPET_RUNECRAFTING_FIRE",
+      "SKILLPET_RUNECRAFTING_FIRE"
     ]
   },
   {
@@ -17909,8 +17909,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7338,
-      7355
+      "POH_SKILLPET_RUNECRAFTING_AIR",
+      "SKILLPET_RUNECRAFTING_AIR"
     ]
   },
   {
@@ -17928,8 +17928,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7339,
-      7356
+      "POH_SKILLPET_RUNECRAFTING_MIND",
+      "SKILLPET_RUNECRAFTING_MIND"
     ]
   },
   {
@@ -17947,8 +17947,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7340,
-      7357
+      "POH_SKILLPET_RUNECRAFTING_WATER",
+      "SKILLPET_RUNECRAFTING_WATER"
     ]
   },
   {
@@ -17966,8 +17966,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7341,
-      7358
+      "POH_SKILLPET_RUNECRAFTING_EARTH",
+      "SKILLPET_RUNECRAFTING_EARTH"
     ]
   },
   {
@@ -17985,8 +17985,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7342,
-      7359
+      "POH_SKILLPET_RUNECRAFTING_BODY",
+      "SKILLPET_RUNECRAFTING_BODY"
     ]
   },
   {
@@ -18004,8 +18004,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7360,
-      7343
+      "SKILLPET_RUNECRAFTING_COSMIC",
+      "POH_SKILLPET_RUNECRAFTING_COSMIC"
     ]
   },
   {
@@ -18023,8 +18023,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7344,
-      7361
+      "POH_SKILLPET_RUNECRAFTING_CHAOS",
+      "SKILLPET_RUNECRAFTING_CHAOS"
     ]
   },
   {
@@ -18042,8 +18042,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7345,
-      7362
+      "POH_SKILLPET_RUNECRAFTING_NATURE",
+      "SKILLPET_RUNECRAFTING_NATURE"
     ]
   },
   {
@@ -18061,8 +18061,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7346,
-      7363
+      "POH_SKILLPET_RUNECRAFTING_LAW",
+      "SKILLPET_RUNECRAFTING_LAW"
     ]
   },
   {
@@ -18080,8 +18080,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7347,
-      7364
+      "POH_SKILLPET_RUNECRAFTING_DEATH",
+      "SKILLPET_RUNECRAFTING_DEATH"
     ]
   },
   {
@@ -18099,8 +18099,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7348,
-      7365
+      "POH_SKILLPET_RUNECRAFTING_SOUL",
+      "SKILLPET_RUNECRAFTING_SOUL"
     ]
   },
   {
@@ -18118,8 +18118,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7349,
-      7366
+      "POH_SKILLPET_RUNECRAFTING_ASTRAL",
+      "SKILLPET_RUNECRAFTING_ASTRAL"
     ]
   },
   {
@@ -18137,8 +18137,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      7350,
-      7367
+      "POH_SKILLPET_RUNECRAFTING_BLOOD",
+      "SKILLPET_RUNECRAFTING_BLOOD"
     ]
   },
   {
@@ -18156,8 +18156,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      8024,
-      8028
+      "POH_SKILLPET_RUNECRAFTING_WRATH",
+      "SKILLPET_RUNECRAFTING_WRATH"
     ]
   },
   {
@@ -18175,8 +18175,8 @@
     "duration": 20,
     "range": 20,
     "npcIds": [
-      2055,
-      5907
+      "CHAOS_ELEMENTAL_PET",
+      "POH_CHAOS_ELEMENTAL_PET"
     ]
   },
   {
@@ -18194,8 +18194,8 @@
     "duration": 20,
     "range": 0,
     "npcIds": [
-      2055,
-      5907
+      "CHAOS_ELEMENTAL_PET",
+      "POH_CHAOS_ELEMENTAL_PET"
     ]
   },
   {
@@ -18213,8 +18213,8 @@
     "duration": 3000,
     "range": 20,
     "npcIds": [
-      7671,
-      425
+      "SKOTIZO_PET",
+      "POH_SKOTIZO_PET"
     ]
   },
   {
@@ -18232,8 +18232,8 @@
     "duration": 2100,
     "range": 10,
     "npcIds": [
-      8198,
-      8203
+      "POH_VANGUARD_PET",
+      "VANGUARD_PET"
     ]
   },
   {
@@ -18251,8 +18251,8 @@
     "duration": 2400,
     "range": 30,
     "npcIds": [
-      8199,
-      8204
+      "POH_VASA_PET",
+      "VASA_PET"
     ]
   },
   {
@@ -18270,8 +18270,8 @@
     "duration": 2400,
     "range": 0,
     "npcIds": [
-      8197,
-      8202
+      "POH_TEKTON_PET",
+      "TEKTON_PET"
     ]
   },
   {
@@ -18289,8 +18289,8 @@
     "duration": 2400,
     "range": 0,
     "npcIds": [
-      9511,
-      9513
+      "POH_TEKTON_ENRAGED_PET",
+      "TEKTON_ENRAGED_PET"
     ]
   },
   {
@@ -18308,8 +18308,8 @@
     "duration": 3000,
     "range": 15,
     "npcIds": [
-      6639,
-      6655
+      "SMOKE_PET",
+      "POH_SMOKE_PET"
     ]
   },
   {
@@ -18327,8 +18327,8 @@
     "duration": 3000,
     "range": 15,
     "npcIds": [
-      8737,
-      8729
+      "GAUNTLET_PET",
+      "POH_GAUNTLET_PET"
     ]
   },
   {
@@ -18346,8 +18346,8 @@
     "duration": 3000,
     "range": 15,
     "npcIds": [
-      8738,
-      8730
+      "GAUNTLET_PET_CORRUPT",
+      "POH_GAUNTLET_PET_CORRUPT"
     ]
   },
   {
@@ -18365,8 +18365,8 @@
     "duration": 3200,
     "range": 20,
     "npcIds": [
-      10562,
-      10637
+      "POH_TEMPOROSS_PET",
+      "TEMPOROSS_PET"
     ]
   },
   {
@@ -18384,11 +18384,11 @@
     "duration": 0,
     "range": 20,
     "npcIds": [
-      433,
-      434,
-      435,
-      3139,
-      436
+      "SLAYER_PYREFIEND_1",
+      "SLAYER_PYREFIEND_2",
+      "SLAYER_PYREFIEND_3",
+      "GODWARS_PYREFIEND_1",
+      "SLAYER_PYREFIEND_4"
     ]
   },
   {
@@ -18406,8 +18406,8 @@
     "duration": 0,
     "range": 20,
     "npcIds": [
-      2916,
-      2917
+      "BRUT_WATERFIEND",
+      "WATERFIEND_STRONGHOLDCAVE"
     ]
   },
   {
@@ -18425,59 +18425,59 @@
     "duration": 1,
     "range": 10,
     "npcIds": [
-      3975,
-      3976,
-      3977,
-      3978,
-      3979,
-      920,
-      3625,
-      10538,
-      3516,
-      10558,
-      3008,
-      3009,
-      85,
-      86,
-      87,
-      88,
-      472,
-      89,
-      473,
-      90,
-      474,
-      91,
-      92,
-      93,
-      94,
-      95,
-      2527,
-      7263,
-      96,
-      2528,
-      7264,
-      97,
-      2529,
-      98,
-      2530,
-      99,
-      2531,
-      2532,
-      2533,
-      2534,
-      9194,
-      505,
-      506,
-      1786,
-      5370,
-      507,
-      3451,
-      3452,
-      3453,
-      3454,
-      3455,
-      10475,
-      11237
+      "DRAGONSLAYER_GHOST_1_KEY",
+      "DRAGONSLAYER_GHOST_2",
+      "DRAGONSLAYER_GHOST_3",
+      "DRAGONSLAYER_GHOST_4",
+      "DRAGONSLAYER_GHOST_5",
+      "AGRITH_NONCOMBAT_GHOST",
+      "HAUNTEDMINE_SUPRISE_GHOST",
+      "SOUL_WARS_PLAYER_GHOST",
+      "SHADOW_MAJ_GHOST",
+      "SW_BANDOS_GHOST_VIS",
+      "AHOY_GHOST_DISGUISE",
+      "AHOY_GHOST_DISGUISE_GREEN",
+      "GHOST",
+      "GHOST2",
+      "GHOST3",
+      "GHOST4",
+      "GHOST8_UNAGGRESSIVE",
+      "GHOST5",
+      "HOUSE_GHOST",
+      "GHOST6",
+      "HOUSE_GHOST2",
+      "GHOST7",
+      "GHOST8",
+      "GHOST_UNAGGRESSIVE",
+      "GHOST2_UNAGGRESSIVE",
+      "GHOST3_UNAGGRESSIVE",
+      "SOS_DEATH_GHOST",
+      "KOUREND_GHOST1",
+      "GHOST4_UNAGGRESSIVE",
+      "SOS_DEATH_GHOST_B",
+      "KOUREND_GHOST2",
+      "GHOST5_UNAGGRESSIVE",
+      "SOS_DEATH_GHOST_C",
+      "GHOST6_UNAGGRESSIVE",
+      "SOS_DEATH_GHOST_D",
+      "GHOST7_UNAGGRESSIVE",
+      "SOS_DEATH_GHOST2",
+      "SOS_DEATH_GHOST2_B",
+      "SOS_DEATH_GHOST2_C",
+      "SOS_DEATH_GHOST2_D",
+      "PRIF_GHOST_VISIBLE",
+      "HOUSE_GHOST3",
+      "HOUSE_GHOST4",
+      "UNATTACKABLE_GHOST",
+      "ZAMORAKGHOST",
+      "HOUSE_GHOST5",
+      "SECRET_GHOST_MAGE",
+      "SECRET_GHOST_EXPLORER",
+      "SECRET_GHOST_MESSENGER",
+      "SECRET_GHOST_SPY",
+      "SECRET_GHOST_SWORDSMAN",
+      "WILD_CAVE_INACTIVE_GHOST_SMALL_ROAM",
+      "WILD_CAVE_INACTIVE_GHOST_SMALL_ROAM2"
     ]
   },
   {
@@ -18495,15 +18495,15 @@
     "duration": 1,
     "range": 10,
     "npcIds": [
-      10544,
-      10545,
-      10534,
-      10535,
-      10536,
-      10537,
-      10524,
-      10525,
-      10526
+      "SW_TOWER_GHOST1",
+      "SW_TOWER_GHOST2",
+      "SOUL_WARS_SOUL_WEAK_1",
+      "SOUL_WARS_SOUL_WEAK_2",
+      "SOUL_WARS_SOUL_STRONG_1",
+      "SOUL_WARS_SOUL_STRONG_2",
+      "SOUL_WARS_TUT_SOUL_WEAK_2",
+      "SOUL_WARS_TUT_SOUL_STRONG_1",
+      "SOUL_WARS_TUT_SOUL_STRONG_2"
     ]
   },
   {
@@ -18521,24 +18521,24 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      3493,
-      3494,
-      8134,
-      2985,
-      2986,
-      6698,
-      2987,
-      2988,
-      2998,
-      2999,
-      3000,
-      3001,
-      3002,
-      3003,
-      3004,
-      3005,
-      3006,
-      3007
+      "MAKINGHISTORY_DROALAK_FADE_NPC",
+      "MAKINGHISTORY_DROALAK",
+      "SARAH_CORVO",
+      "AHOY_VELORINA",
+      "AHOY_NECROVARUS",
+      "DEADMAN_GUARD_PORTPHAS_VIS",
+      "AHOY_GHOST_PROTESTOR",
+      "AHOY_DISCIPLE",
+      "AHOY_GHOST_VILLAGER",
+      "AHOY_TORTURED_SOUL",
+      "AHOY_GHOST_SHOPKEEPER",
+      "AHOY_GHOST_INNKEEPER",
+      "AHOY_GHOST_FARMER",
+      "AHOY_GHOST_BANKER",
+      "AHOY_GHOST_SAILOR",
+      "AHOY_GHOST_CAPTAIN_1",
+      "AHOY_GHOST_CAPTAIN_2",
+      "AHOY_GHOST_GUARD"
     ]
   },
   {
@@ -18556,12 +18556,12 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      2,
-      3,
-      4,
-      5,
-      6,
-      7
+      "SLAYER_ABBERANT_SPECTRE_1",
+      "SLAYER_ABBERANT_SPECTRE_2",
+      "SLAYER_ABBERANT_SPECTRE_3",
+      "SLAYER_ABBERANT_SPECTRE_4",
+      "SLAYER_ABERRANTSPECTRE_1_STRONGHOLDCAVE",
+      "SLAYER_ABERRANTSPECTRE_2_STRONGHOLDCAVE"
     ]
   },
   {
@@ -18579,7 +18579,7 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      7279
+      "KOUREND_SPECTRE"
     ]
   },
   {
@@ -18597,7 +18597,7 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      7402
+      "SUPERIOR_ABBERANT_SPECTRE"
     ]
   },
   {
@@ -18615,7 +18615,7 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      7403
+      "SUPERIOR_KOUREND_SPECTRE"
     ]
   },
   {
@@ -18633,12 +18633,12 @@
     "duration": 1,
     "range": 0.7,
     "npcIds": [
-      1672,
-      1673,
-      1674,
-      1675,
-      1676,
-      1677
+      "BARROWS_AHRIM",
+      "BARROWS_DHAROK",
+      "BARROWS_GUTHAN",
+      "BARROWS_KARIL",
+      "BARROWS_TORAG",
+      "BARROWS_VERAC"
     ]
   },
   {
@@ -18656,16 +18656,16 @@
     "duration": 3200,
     "range": 10,
     "npcIds": [
-      8784,
-      8775,
-      8776,
-      8777,
-      8778,
-      8779,
-      8780,
-      8781,
-      8782,
-      8783
+      "SOTE_SEREN_IORWERTH",
+      "SOTE_SEREN_VIS",
+      "SOTE_SEREN_MEMORY",
+      "SOTE_SEREN_ITHELL",
+      "SOTE_SEREN_CADARN",
+      "SOTE_SEREN_CRWYS",
+      "SOTE_SEREN_AMLODD",
+      "SOTE_SEREN_MEILYR",
+      "SOTE_SEREN_HEFIN",
+      "SOTE_SEREN_TRAHAEARN"
     ]
   },
   {
@@ -18683,9 +18683,9 @@
     "duration": 3200,
     "range": 10,
     "npcIds": [
-      8917,
-      8919,
-      8920
+      "DARK_SEREN",
+      "DARK_SEREN_CUTSCENE",
+      "DARK_SEREN_CUTSCENE_TRAPPED"
     ]
   },
   {
@@ -18703,10 +18703,10 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9024,
-      9021,
-      9022,
-      9023
+      "CRYSTAL_HUNLLEF_DEATH",
+      "CRYSTAL_HUNLLEF_MELEE",
+      "CRYSTAL_HUNLLEF_RANGED",
+      "CRYSTAL_HUNLLEF_MAGIC"
     ]
   },
   {
@@ -18724,7 +18724,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9028
+      "CRYSTAL_BAT"
     ]
   },
   {
@@ -18742,7 +18742,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9026
+      "CRYSTAL_RAT"
     ]
   },
   {
@@ -18760,7 +18760,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9027
+      "CRYSTAL_SPIDER"
     ]
   },
   {
@@ -18778,7 +18778,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9033
+      "CRYSTAL_DRAGON"
     ]
   },
   {
@@ -18796,7 +18796,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9032
+      "CRYSTAL_BEAR"
     ]
   },
   {
@@ -18814,7 +18814,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9034
+      "CRYSTAL_DARK_BEAST"
     ]
   },
   {
@@ -18832,7 +18832,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9030
+      "CRYSTAL_SCORPION"
     ]
   },
   {
@@ -18850,7 +18850,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9029
+      "CRYSTAL_UNICORN"
     ]
   },
   {
@@ -18868,7 +18868,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9031
+      "CRYSTAL_WOLF"
     ]
   },
   {
@@ -18886,10 +18886,10 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9035,
-      9036,
-      9037,
-      9038
+      "CRYSTAL_HUNLLEF_MELEE_HM",
+      "CRYSTAL_HUNLLEF_RANGED_HM",
+      "CRYSTAL_HUNLLEF_MAGIC_HM",
+      "CRYSTAL_HUNLLEF_DEATH_HM"
     ]
   },
   {
@@ -18907,7 +18907,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9042
+      "CRYSTAL_BAT_HM"
     ]
   },
   {
@@ -18925,7 +18925,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9040
+      "CRYSTAL_RAT_HM"
     ]
   },
   {
@@ -18943,7 +18943,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9041
+      "CRYSTAL_SPIDER_HM"
     ]
   },
   {
@@ -18961,7 +18961,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9047
+      "CRYSTAL_DRAGON_HM"
     ]
   },
   {
@@ -18979,7 +18979,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9046
+      "CRYSTAL_BEAR_HM"
     ]
   },
   {
@@ -18997,7 +18997,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9048
+      "CRYSTAL_DARK_BEAST_HM"
     ]
   },
   {
@@ -19015,7 +19015,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9044
+      "CRYSTAL_SCORPION_HM"
     ]
   },
   {
@@ -19033,7 +19033,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9043
+      "CRYSTAL_UNICORN_HM"
     ]
   },
   {
@@ -19051,7 +19051,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9045
+      "CRYSTAL_WOLF_HM"
     ]
   },
   {
@@ -19069,9 +19069,9 @@
     "duration": 5000,
     "range": 20,
     "npcIds": [
-      5862,
-      5863,
-      5866
+      "CERBERUS_ATTACKING",
+      "CERBERUS_SITTING",
+      "CERBERUS_RESETTING"
     ]
   },
   {
@@ -19089,7 +19089,7 @@
     "duration": 3200,
     "range": 20,
     "npcIds": [
-      10572
+      "TEMPOROSS_BOSS_READY"
     ]
   },
   {
@@ -19107,8 +19107,8 @@
     "duration": 3200,
     "range": 20,
     "npcIds": [
-      10573,
-      10574
+      "TEMPOROSS_BOSS_UNENGAGED",
+      "TEMPOROSS_BOSS_WHIRLPOOL"
     ]
   },
   {
@@ -19126,7 +19126,7 @@
     "duration": 3200,
     "range": 20,
     "npcIds": [
-      10571
+      "TEMPOROSS_P2_FISHINGSPOT"
     ]
   },
   {
@@ -19144,7 +19144,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9672
+      "HALLOWED_PROJECTILE_NPC"
     ]
   },
   {
@@ -19162,7 +19162,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9673
+      "HALLOWED_PROJECTILE_NPC_T2"
     ]
   },
   {
@@ -19180,7 +19180,7 @@
     "duration": 0,
     "range": 0,
     "npcIds": [
-      9674
+      "HALLOWED_PROJECTILE_NPC_T3"
     ]
   },
   {
@@ -19198,7 +19198,7 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      8344
+      "TOB_NYLOCAS_INCOMING_MAGIC"
     ]
   },
   {
@@ -19216,8 +19216,8 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      8347,
-      8383
+      "TOB_NYLOCAS_BIG_INCOMING_MAGIC",
+      "VERZIK_NYLOCAS_MAGIC"
     ]
   },
   {
@@ -19235,7 +19235,7 @@
     "duration": 0,
     "range": 40,
     "npcIds": [
-      8356
+      "NYLOCAS_BOSS_MAGIC"
     ]
   },
   {
@@ -19253,30 +19253,30 @@
     "duration": 4500,
     "range": 10,
     "npcIds": [
-      5856,
-      3204,
-      7332,
-      7748,
-      5736,
-      1161,
-      5835,
-      5836,
-      2829,
-      5837,
-      5838,
-      5839,
-      1840,
-      1841,
-      1842,
-      404,
-      2868,
-      3092,
-      2869,
-      1847,
-      1848,
-      1849,
-      1850,
-      1851
+      "FAIRY_CHEF",
+      "FAIRY_LADDER_ATTENDANT",
+      "FAIRY2_REPAIR_1OP",
+      "FAIRY_CHILD",
+      "II_FAIRY",
+      "FAIRY_QUEEN",
+      "FAIRY_COORDINATOR",
+      "FAIRY_NUFF",
+      "FAIRY",
+      "FAIRY_GODFATHER",
+      "FAIRY_HENCHMAN1",
+      "FAIRY_HENCHMAN2",
+      "FAIRY_GODFATHER2",
+      "FAIRY_NUFF2",
+      "FAIRY_QUEEN2",
+      "SLAYER_MASTER_4",
+      "GENERALSHOPKEEPER8",
+      "FAIRY_BANKER",
+      "GENERALASSISTANT8",
+      "FAIRY2_ADVISOR",
+      "FAIRY2_BANDAGES",
+      "FAIRY2_BROKEN_LEG",
+      "FAIRY2_SLING_ARM",
+      "FAIRY2_NO_ARM"
     ]
   },
   {
@@ -19294,9 +19294,9 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      10880,
-      10878,
-      10879
+      "ARCEUUS_THRALL_GHOST_GREATER",
+      "ARCEUUS_THRALL_GHOST_LESSER",
+      "ARCEUUS_THRALL_GHOST_SUPERIOR"
     ]
   },
   {
@@ -19315,7 +19315,7 @@
     "fadeInDuration": 100,
     "range": 5,
     "projectileIds": [
-      1907
+      "THRALL_MAGIC_TRAVEL"
     ]
   },
   {
@@ -19333,9 +19333,9 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      10881,
-      10882,
-      10883
+      "ARCEUUS_THRALL_SKELETON_LESSER",
+      "ARCEUUS_THRALL_SKELETON_SUPERIOR",
+      "ARCEUUS_THRALL_SKELETON_GREATER"
     ]
   },
   {
@@ -19353,7 +19353,7 @@
     "fadeOutDuration": 200,
     "range": 5,
     "projectileIds": [
-      1906
+      "THRALL_RANGED_TRAVEL"
     ]
   },
   {
@@ -19371,9 +19371,9 @@
     "duration": 0,
     "range": 10,
     "npcIds": [
-      10884,
-      10885,
-      10886
+      "ARCEUUS_THRALL_ZOMBIE_LESSER",
+      "ARCEUUS_THRALL_ZOMBIE_SUPERIOR",
+      "ARCEUUS_THRALL_ZOMBIE_GREATER"
     ]
   },
   {
@@ -19391,7 +19391,7 @@
     "duration": 2400,
     "range": 20,
     "npcIds": [
-      7568
+      "RAIDS_VASANISTIRIO_CRYSTAL"
     ]
   },
   {
@@ -19409,8 +19409,8 @@
     "duration": 2400,
     "range": 30,
     "npcIds": [
-      7566,
-      7567
+      "RAIDS_VASANISTIRIO_WALKING",
+      "RAIDS_VASANISTIRIO_HEALING"
     ]
   },
   {
@@ -19428,10 +19428,10 @@
     "duration": 2400,
     "range": 0,
     "npcIds": [
-      7540,
-      7541,
-      7542,
-      7545
+      "RAIDS_TEKTON_WAITING",
+      "RAIDS_TEKTON_WALKING_STANDARD",
+      "RAIDS_TEKTON_FIGHTING_STANDARD",
+      "RAIDS_TEKTON_HAMMERING"
     ]
   },
   {
@@ -19449,8 +19449,8 @@
     "duration": 2400,
     "range": 0,
     "npcIds": [
-      7543,
-      7544
+      "RAIDS_TEKTON_WALKING_ENRAGED",
+      "RAIDS_TEKTON_FIGHTING_ENRAGED"
     ]
   },
   {
@@ -19468,11 +19468,11 @@
     "duration": 2400,
     "range": 0,
     "npcIds": [
-      7525,
-      7526,
-      7527,
-      7528,
-      7529
+      "RAIDS_VANGUARD_DORMANT",
+      "RAIDS_VANGUARD_WALKING",
+      "RAIDS_VANGUARD_MELEE",
+      "RAIDS_VANGUARD_RANGED",
+      "RAIDS_VANGUARD_MAGIC"
     ]
   },
   {
@@ -19490,7 +19490,7 @@
     "duration": 2400,
     "range": 20,
     "npcIds": [
-      7578
+      "RAIDS_LASERCRABS_CRAB_GREEN"
     ]
   },
   {
@@ -19508,7 +19508,7 @@
     "duration": 2400,
     "range": 20,
     "npcIds": [
-      7577
+      "RAIDS_LASERCRABS_CRAB_RED"
     ]
   },
   {
@@ -19526,7 +19526,7 @@
     "duration": 2400,
     "range": 20,
     "npcIds": [
-      7579
+      "RAIDS_LASERCRABS_CRAB_BLUE"
     ]
   },
   {
@@ -19546,10 +19546,10 @@
     "duration": 2300,
     "range": 8,
     "npcIds": [
-      9461,
-      9462,
-      9463,
-      9464
+      "NIGHTMARE_ENTRY_OPEN",
+      "NIGHTMARE_ENTRY_CLOSED_01",
+      "NIGHTMARE_ENTRY_CLOSED_02",
+      "NIGHTMARE_ENTRY_CLOSED_03"
     ]
   },
   {
@@ -19565,7 +19565,7 @@
     "type": "PULSE",
     "duration": 2950,
     "range": 10,
-    "objectIds": [ 29706 ]
+    "objectIds": [ "NIGHTMARE_CHALLENGE_PORTAL_ENABLED" ]
   },
   {
     "description": "Nightmare of Ashihama - Pool of Nightmares - Highlight South",
@@ -19578,7 +19578,7 @@
       166
     ],
     "type": "STATIC",
-    "objectIds": [ 29706 ]
+    "objectIds": [ "NIGHTMARE_CHALLENGE_PORTAL_ENABLED" ]
   },
   {
     "description": "Nightmare of Ashihama - Pool of Nightmares - Highlight North",
@@ -19591,7 +19591,7 @@
       166
     ],
     "type": "STATIC",
-    "objectIds": [ 29706 ]
+    "objectIds": [ "NIGHTMARE_CHALLENGE_PORTAL_ENABLED" ]
   },
   {
     "description": "Nightmare of Ashihama - Pool of Nightmares - Highlight East",
@@ -19604,7 +19604,7 @@
       166
     ],
     "type": "STATIC",
-    "objectIds": [ 29706 ]
+    "objectIds": [ "NIGHTMARE_CHALLENGE_PORTAL_ENABLED" ]
   },
   {
     "description": "Nightmare of Ashihama - Pool of Nightmares - Highlight West",
@@ -19617,7 +19617,7 @@
       166
     ],
     "type": "STATIC",
-    "objectIds": [ 29706 ]
+    "objectIds": [ "NIGHTMARE_CHALLENGE_PORTAL_ENABLED" ]
   },
   {
     "description": "Nightmare of Ashihama - Energy Barrier 1",
@@ -19633,8 +19633,8 @@
     "duration": 2000,
     "range": 7,
     "objectIds": [
-      37730,
-      37731
+      "NIGHTMARE_BARRIER_ESCAPE_INITIAL",
+      "NIGHTMARE_BARRIER_ESCAPE_FIGHT"
     ]
   },
   {
@@ -19651,8 +19651,8 @@
     "duration": 750,
     "range": 7,
     "objectIds": [
-      37730,
-      37731
+      "NIGHTMARE_BARRIER_ESCAPE_INITIAL",
+      "NIGHTMARE_BARRIER_ESCAPE_FIGHT"
     ]
   },
   {
@@ -19670,7 +19670,7 @@
     "type": "PULSE",
     "duration": 1750,
     "range": 20,
-    "projectileIds": [ 1764 ]
+    "projectileIds": [ "NIGHTMARE_MAGIC_TRAVEL" ]
   },
   {
     "description": "Nightmare of Ashihama - Charged Totem",
@@ -19688,7 +19688,7 @@
     "type": "PULSE",
     "duration": 1750,
     "range": 7,
-    "npcIds": [ 9445, 9442, 9439, 9436 ]
+    "npcIds": [ "NIGHTMARE_TOTEM_4_CHARGED", "NIGHTMARE_TOTEM_3_CHARGED", "NIGHTMARE_TOTEM_2_CHARGED", "NIGHTMARE_TOTEM_1_CHARGED" ]
   },
   {
     "description": "FIRE_GIANT",
@@ -19705,18 +19705,18 @@
     "duration": 0,
     "range": 20,
     "npcIds": [
-      2080,
-      2081,
-      2082,
-      2083,
-      7251,
-      2084,
-      7252,
-      2075,
-      2076,
-      2077,
-      2078,
-      2079
+      "FIREGIANT3",
+      "FIREGIANT_STRONGHOLDCAVE_1",
+      "FIREGIANT_STRONGHOLDCAVE_2",
+      "FIREGIANT_STRONGHOLDCAVE_3",
+      "KOUREND_FIREGIANT1",
+      "FIREGIANT_STRONGHOLDCAVE_4",
+      "KOUREND_FIREGIANT2",
+      "FIREGIANT_BIG",
+      "FIREGIANT_BIG2",
+      "FIREGIANT_BIG3",
+      "FIREGIANT",
+      "FIREGIANT2"
     ]
   },
   {
@@ -19734,10 +19734,10 @@
     "duration": 2000,
     "range": 25,
     "npcIds": [
-      1747,
-      1751,
-      1739,
-      1743
+      "PEST_PORTAL_1_ACTIVE_BT1",
+      "PEST_PORTAL_SHIELD_1_ACTIVE_BT1",
+      "PEST_PORTAL_1_ACTIVE",
+      "PEST_PORTAL_SHIELD_1_ACTIVE"
     ]
   },
   {
@@ -19755,10 +19755,10 @@
     "duration": 2000,
     "range": 25,
     "npcIds": [
-      1744,
-      1748,
-      1752,
-      1740
+      "PEST_PORTAL_SHIELD_2_ACTIVE",
+      "PEST_PORTAL_2_ACTIVE_BT1",
+      "PEST_PORTAL_SHIELD_2_ACTIVE_BT1",
+      "PEST_PORTAL_2_ACTIVE"
     ]
   },
   {
@@ -19776,10 +19776,10 @@
     "duration": 2000,
     "range": 25,
     "npcIds": [
-      1745,
-      1749,
-      1753,
-      1741
+      "PEST_PORTAL_SHIELD_3_ACTIVE",
+      "PEST_PORTAL_3_ACTIVE_BT1",
+      "PEST_PORTAL_SHIELD_3_ACTIVE_BT1",
+      "PEST_PORTAL_3_ACTIVE"
     ]
   },
   {
@@ -19797,10 +19797,10 @@
     "duration": 2000,
     "range": 25,
     "npcIds": [
-      1746,
-      1750,
-      1754,
-      1742
+      "PEST_PORTAL_SHIELD_4_ACTIVE",
+      "PEST_PORTAL_4_ACTIVE_BT1",
+      "PEST_PORTAL_SHIELD_4_ACTIVE_BT1",
+      "PEST_PORTAL_4_ACTIVE"
     ]
   },
   {
@@ -19818,10 +19818,10 @@
     "duration": 1500,
     "range": 10,
     "npcIds": [
-      2950,
-      2951,
-      2952,
-      2953
+      "PEST_VOIDKNIGHT_CONTROL1",
+      "PEST_VOIDKNIGHT_CONTROL2",
+      "PEST_VOIDKNIGHT_CONTROL3",
+      "PEST_VOIDKNIGHT_CONTROL4"
     ]
   },
   {
@@ -19839,7 +19839,7 @@
     "duration": 0,
     "range": 20,
     "projectileIds": [
-      647
+      "TORCHER_FIREBALL_TRAVEL_SPOTANIM"
     ]
   },
   {
@@ -19857,7 +19857,7 @@
     "duration": 0,
     "range": 20,
     "graphicsObjectIds": [
-      654
+      "SHIFTER_TELEPORT_SPOTANIM"
     ]
   },
   {
@@ -19875,7 +19875,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7934
+      "WILD_CAVE_CYCLOPS"
     ]
   },
   {
@@ -19893,7 +19893,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7881
+      "WILD_CAVE_IMP"
     ]
   },
   {
@@ -19911,7 +19911,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7936
+      "WILD_CAVE_DEMON"
     ]
   },
   {
@@ -19929,7 +19929,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7940
+      "WILD_CAVE_DRAGON"
     ]
   },
   {
@@ -19947,7 +19947,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7931
+      "WILD_CAVE_GOBLIN"
     ]
   },
   {
@@ -19965,7 +19965,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7938
+      "WILD_CAVE_DARKBEAST"
     ]
   },
   {
@@ -19983,7 +19983,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7935
+      "WILD_CAVE_HELLHOUND"
     ]
   },
   {
@@ -20001,7 +20001,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7933
+      "WILD_CAVE_HOBGOBLIN"
     ]
   },
   {
@@ -20019,7 +20019,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7939
+      "WILD_CAVE_KNIGHT"
     ]
   },
   {
@@ -20037,7 +20037,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7937
+      "WILD_CAVE_ORK"
     ]
   },
   {
@@ -20055,7 +20055,7 @@
     "duration": 3400,
     "range": 10,
     "npcIds": [
-      7932
+      "WILD_CAVE_PYREFIEND"
     ]
   },
   {
@@ -20073,26 +20073,26 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      10178,
-      25122,
-      10179,
-      25123,
-      6404,
-      6406,
-      6408,
-      6410,
-      6412,
-      20716,
-      6413,
-      6414,
-      6415,
-      6416,
-      6896,
-      724,
-      5494,
-      11606,
-      15158,
-      6203
+      "DAGANNOTH_STANDING_TORCH",
+      "DRAGON_SLAYER_QIP_CANDLE",
+      "DAGANNOTH_STANDING_TORCH_LIT",
+      "DRAGON_SLAYER_QIP_CANDLE2",
+      "_4D_STANDING_TORCH",
+      "_4D_STANDING_TORCH1_UNLIT",
+      "_4D_STANDING_TORCH2_UNLIT",
+      "_4D_STANDING_TORCH3_UNLIT",
+      "_4D_STANDING_TORCH4_UNLIT",
+      "BARROWS_TORCH",
+      "_4D_STANDING_TORCH1_LIT",
+      "_4D_STANDING_TORCH2_LIT",
+      "_4D_STANDING_TORCH3_LIT",
+      "_4D_STANDING_TORCH4_LIT",
+      "ZOGRE_STANDING_TORCH",
+      "STANDING_TORCH",
+      "FAVOUR_STANDING_TORCH",
+      "FAI_BARBARIAN_TORCH",
+      "ROYAL_TORCH",
+      "DWARF_KELDAGRIM_LAMP_STAND"
     ]
   },
   {
@@ -20110,7 +20110,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      10658
+      "SNAKEBOSS_STANDING_TORCH"
     ]
   },
   {
@@ -20128,16 +20128,16 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      38512,
-      38513,
-      38514,
-      38562,
-      17237,
-      3478,
-      32118,
-      5881,
-      38555,
-      33454
+      "HS_TORCH_PILLAR_01",
+      "HS_TORCH_PILLAR_02",
+      "HS_TORCH_PILLAR_03",
+      "HS_NPT1_TORCH_PILLAR",
+      "EYEGLO_TORCH",
+      "CANDLE_STAND",
+      "DS2_LITHKREN_DUNGEON_TORCH_SMALL",
+      "MDAUGHTER_TORCH",
+      "HS_LOBBY_TORCH_PILLAR",
+      "_1V1ARENA_DUNGEON_BRAZIER"
     ],
     "visibleFromOtherPlanes": true
   },
@@ -20157,7 +20157,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      51759
+      "HG_TORCH_LANDING01"
     ],
     "visibleFromOtherPlanes": true
   },
@@ -20176,7 +20176,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      25156
+      "DRAGON_SLAYER_QIP_FIRE_1X1"
     ]
   },
   {
@@ -20194,7 +20194,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      37826
+      "SANCTUARY_BRAZIER"
     ]
   },
   {
@@ -20212,7 +20212,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      34856
+      "HOSDUN_TORCH"
     ]
   },
   {
@@ -20230,7 +20230,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6202
+      "DWARF_KELDAGRIM_LAMP"
     ]
   },
   {
@@ -20248,7 +20248,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      198
+      "CAVE_TORCH"
     ]
   },
   {
@@ -20266,26 +20266,26 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6537,
-      18891,
-      12300,
-      31628,
-      12238,
-      43122,
-      43123,
-      43124,
-      43125,
-      4694,
-      43126,
-      43127,
-      5208,
-      10297,
-      15161,
-      25659,
-      5247,
-      7376,
-      5247,
-      15016
+      "FOUR_DIAMONDS_TOMB_WALL_TORCH",
+      "TOURTRAP_QIP_MINE_WALL_LAMP_SINGLE",
+      "_100_DUNGEON_SKULLTORCH",
+      "DS2_GUILD_WALL_SCONCE",
+      "_100_DAVE_CANDLE_WALL",
+      "LOTG_CRYPT_PRIEST_GRAVE1",
+      "LOTG_CRYPT_PRIEST_GRAVE2",
+      "LOTG_CRYPT_PRIEST_GRAVE3",
+      "LOTG_CRYPT_PRIEST_GRAVE4",
+      "MISC_TORCHES",
+      "LOTG_CRYPT_PRIEST_GRAVE5",
+      "LOTG_CRYPT_MODEST_GRAVE",
+      "FENK_TORCH",
+      "VC_CANDLE",
+      "ROYAL_CAVEWALL_TORCH_FLAMES",
+      "KR_UNDERGROUND_JAIL_TOURCH",
+      "FAVOUR_TORCH",
+      "FALADOR_TORCH",
+      "FAVOUR_TORCH",
+      "LUNAR_MINE_TORCH_FLAMES"
     ]
   },
   {
@@ -20302,17 +20302,17 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      196,
-      197,
-      202,
-      203,
-      206,
-      11474,
-      5746,
-      5787,
-      24414,
-      2175,
-      30130
+      "TORCH",
+      "TORCH_GRUBBY",
+      "CANDLES",
+      "GOLDCANDLES",
+      "SKULLTORCH",
+      "DRAYNOR_CANDLE_WALL",
+      "OLDROOFEDGE_HL_GREYSLATE",
+      "ROOFEDGE_DOUBLELENGTH_RR_OFFSET",
+      "VM_BASEMENT_WALL_FIRST_FLOOR_LAMP",
+      "SLAYER_TORCH",
+      "MISTMYST_CANDLE_LIT"
     ]
   },
   {
@@ -20329,7 +20329,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      7432
+      "FAI_VARROCK_POSH_CANDLESTICK"
     ]
   },
   {
@@ -20346,7 +20346,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      4501
+      "FAI_VARROCK_OILLAMP"
     ]
   },
   {
@@ -20364,7 +20364,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      38027
+      "MYQ5_TORCH"
     ]
   },
   {
@@ -20382,7 +20382,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      24173
+      "FAI_FALADOR_HOUSE_TORCH"
     ]
   },
   {
@@ -20400,8 +20400,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      9746,
-      18355
+      "MOURNING_CAVEWALL_CANDLE_FACE1",
+      "SLUG2_DUNGEON_WALL"
     ]
   },
   {
@@ -20418,8 +20418,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      11472,
-      12301
+      "DRAYNOR_CANDLES_1",
+      "_100_DAVE_CANDLES_1"
     ]
   },
   {
@@ -20436,7 +20436,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      12302
+      "_100_DAVE_CANDLES_2"
     ],
     "offset": [ 3, 0, 40 ]
   },
@@ -20455,10 +20455,10 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      4691,
-      10307,
-      16901,
-      23577
+      "MISC_LANTERN",
+      "VC_LANTERN_DECOR",
+      "QUEST_LUNAR_HANGING_LANTERN",
+      "ATJUN_MINE_WALL_LAMP"
     ]
   },
   {
@@ -20476,7 +20476,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      2492
+      "FAI_VARROCK_GYPSY_LANTERN"
     ]
   },
   {
@@ -20494,7 +20494,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      2458
+      "FAI_VARROCK_GYPSY_CANDEL"
     ]
   },
   {
@@ -20512,7 +20512,7 @@
     "duration": 10,
     "range": 30,
     "objectIds": [
-      2459
+      "FAI_VARROCK_CRYSTALBALLTABLE"
     ]
   },
   {
@@ -20530,7 +20530,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      11468
+      "DRAYNOR_OUTSIDE_LAMP"
     ]
   },
   {
@@ -20548,10 +20548,10 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      42132,
-      42133,
-      42134,
-      42135
+      "SHAYZIEN_LANTERN01_LIT_STATIC",
+      "SHAYZIEN_LANTERN01_LIT_SWAYR",
+      "SHAYZIEN_LANTERN01_LIT_SWAYL",
+      "SHAYZIEN_LANTERN01_LIT_IDLE01"
     ]
   },
   {
@@ -20569,7 +20569,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      4650
+      "BOARDGAMES_FIREPLACE"
     ]
   },
   {
@@ -20587,8 +20587,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      5608,
-      4267
+      "MISC_SPITROAST",
+      "VIKING_PIG_ROAST"
     ]
   },
   {
@@ -20606,8 +20606,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      26180,
-      30932
+      "FIREPLACECOOKINGPOT",
+      "FOSSIL_RANGE_BUILT"
     ]
   },
   {
@@ -20625,44 +20625,44 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      732,
-      5249,
-      30021,
-      23046,
-      9735,
-      23175,
-      35912,
-      26185,
-      35913,
-      26577,
-      26578,
-      43475,
-      13337,
-      14169,
-      5981,
-      29085,
-      25374,
-      35810,
-      35811,
-      10660,
-      4265,
-      19881,
-      32297,
-      4266,
-      19884,
-      15156,
-      21620,
-      29300,
-      31798,
-      28791,
-      3769,
-      13881,
-      25465,
-      34682,
-      5499,
-      12796,
-      3775,
-      49927
+      "LAVAFIRE",
+      "ROVING_FIRE",
+      "RAIDS_TEKTON_FIRE",
+      "DORGESH_FROG_SPIT_FIRE",
+      "NEWBIEFIRE",
+      "OLAF2_CAVE_OLD_CAMP_FIRE",
+      "SOTE_SCENE_FIRE",
+      "FIRE",
+      "SOTE_SCENE_FIRE_LARGE",
+      "EMBERS_WITH_PANS",
+      "EMBERS",
+      "FIRE_COOK",
+      "POH_OUBLIETTE_FLOOR_FIRE",
+      "OLAF_FIRE",
+      "DWARF_LIGHTS",
+      "BR_CAMPFIRE_FIRE",
+      "BRUT_CAMPFIRE_FIRE",
+      "SOTE_FIRE",
+      "SOTE_FIRE_2X1",
+      "SNAKEBOSS_VILLAGE_FIRE",
+      "VIKING_LONGHALL_FIRE",
+      "EAGLEPEAK_CAMPFIRE_TIDY",
+      "DS2_VIKING_SHIP_FIRE",
+      "VIKING_HOUSE_FIRE",
+      "EAGLEPEAK_CAMPFIRE_MESSY",
+      "ROYAL_VILLAGE_FIRE",
+      "FRIS_FIRE",
+      "WINT_BONFIRE",
+      "DS2_OGRE_CORSAIR_FIRE",
+      "MM2_MONKEY_FIRE",
+      "TROLL_STRONGHOLD_CAMP_FIRE",
+      "SOULBANE_FIREWALL",
+      "QIP_OBS_CAMPFIRE",
+      "OSB6_DISPLAY_MYARM_FIRE",
+      "FAVOUR_CAMPFIRE",
+      "BURGH_VILLAGE_FIRE",
+      "TROLL_EADGAR_COOKING_POT",
+      "FORESTRY_FIRE"
     ]
   },
   {
@@ -20680,9 +20680,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      25155,
-      35812,
-      40728
+      "DRAGON_SLAYER_QIP_FIRE_2X2",
+      "SOTE_FIRE_LARGE",
+      "SW_CAMP_FIRE"
     ]
   },
   {
@@ -20700,7 +20700,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      37996
+      "MYQ5_DAMIEN_FIRE_SMALL"
     ]
   },
   {
@@ -20718,8 +20718,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      37994,
-      37995
+      "MYQ5_DAMIEN_FIRE_NOOP",
+      "MYQ5_DAMIEN_FIRE"
     ]
   },
   {
@@ -20737,34 +20737,34 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6785,
-      26179,
-      40775,
-      8712,
-      10824,
-      40777,
-      4618,
-      10058,
-      6093,
-      6094,
-      6095,
-      6096,
-      9439,
-      9440,
-      9441,
-      21795,
-      17640,
-      17641,
-      17642,
-      17643,
-      5165,
-      17325,
-      18039,
-      30136,
-      30137,
-      30138,
-      6781,
-      6783
+      "POH_FIREPLACE_3_LIT",
+      "GRANDFIREPLACE_OLDBRICK",
+      "XMAS20_POH_FIREPLACE_2_LIT",
+      "FARM_FIREPLACE",
+      "DRAYNOR_FIREPLACE",
+      "XMAS20_POH_FIREPLACE_3_LIT",
+      "BOARDGAMES_FIREPLACE_SMALL",
+      "FAI_VARROCK_SHANTY_FIREPLACE",
+      "DWARF_KELDAGRIM_KEBAB_FIREPLACE",
+      "DWARF_KELDAGRIM_POOR_FIREPLACE",
+      "DWARF_KELDAGRIM_FIREPLACE",
+      "DWARF_KELDAGRIM_BIG_FIREPLACE",
+      "TWOCATS_FIREPLACE_LIT",
+      "TWOCATS_FIREPLACE_GONE_OUT",
+      "TWOCATS_FIREPLACE_GOT_WOOD",
+      "SORCERESS_FIREPLACE",
+      "MYQ3_GHETTO_FIREPLACE_BOTTOM",
+      "MYQ3_GHETTO_FIREPLACE_MIDDLE",
+      "MYQ3_GHETTO_FIREPLACE_TOP",
+      "MYQ3_GHETTO_FIREPLACE_TOP_NOOFFSET",
+      "FENK_FIREPLACE",
+      "QIP_DIGSITE_FIREPLACE",
+      "MYQ3_FIREPLACE_LOOSE_TILE",
+      "MISTMYST_FIREPLACE_UNLIT",
+      "MISTMYST_FIREPLACE_REVEALED",
+      "MISTMYST_FIREPLACE_LIT",
+      "POH_FIREPLACE_1_LIT",
+      "POH_FIREPLACE_2_LIT"
     ]
   },
   {
@@ -20781,7 +20781,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      24970
+      "GRANDFIREPLACE"
     ]
   },
   {
@@ -20798,7 +20798,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      7185
+      "FAI_VARROCK_FIREPLACE"
     ]
   },
   {
@@ -20815,7 +20815,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      24969
+      "FIREPLACE"
     ]
   },
   {
@@ -20833,7 +20833,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      19129
+      "ZEP_BASKET"
     ]
   },
   {
@@ -20851,7 +20851,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      35806
+      "SOTE_BARRICADE_BURNING"
     ]
   },
   {
@@ -20869,7 +20869,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      34345
+      "BRIMSTONE_STONE_TORCH"
     ]
   },
   {
@@ -20887,7 +20887,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      34346
+      "BRIMSTONE_CRUDE_TORCH"
     ]
   },
   {
@@ -20905,8 +20905,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      20001,
-      49932
+      "TRAIL_PURPLE_FIRE",
+      "FORESTRY_FIRE_PURPLE"
     ]
   },
   {
@@ -20924,8 +20924,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      26186,
-      49928
+      "RED_FIRE",
+      "FORESTRY_FIRE_RED"
     ]
   },
   {
@@ -20943,8 +20943,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      26576,
-      49930
+      "BLUE_FIRE",
+      "FORESTRY_FIRE_BLUE"
     ]
   },
   {
@@ -20962,8 +20962,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      20000,
-      49931
+      "TRAIL_WHITE_FIRE",
+      "FORESTRY_FIRE_WHITE"
     ]
   },
   {
@@ -20981,8 +20981,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      26575,
-      49929
+      "GREEN_FIRE",
+      "FORESTRY_FIRE_GREEN"
     ]
   },
   {
@@ -21000,10 +21000,10 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      18967,
-      18968,
-      18969,
-      25213
+      "CLIMBING_ROPE",
+      "CLIMBING_ROPE_TOP",
+      "CLIMBING_ROPE2",
+      "DRAGON_SLAYER_QIP_CLIMBING_ROPE"
     ]
   },
   {
@@ -21020,10 +21020,10 @@
     "duration": 0,
     "range": 15,
     "objectIds": [
-      15796,
-      17829,
-      25055,
-      25056
+      "LOTR_MINE_WALL_LAMP",
+      "AREA_SANGUINE_MINE_WALL_LAMP",
+      "DRAGON_SLAYER_MINE_WALL_LAMP_SINGLE",
+      "DRAGON_SLAYER_MINE_WALL_LAMP"
     ]
   },
   {
@@ -21040,7 +21040,7 @@
     "duration": 0,
     "range": 15,
     "objectIds": [
-      37573
+      "WYVERN_CAVE_WALL_COLDMUD_LAMP_SINGLE"
     ]
   },
   {
@@ -21058,7 +21058,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      12005
+      "FAIRY_MUSHROOM_TORCH_RED"
     ]
   },
   {
@@ -21076,7 +21076,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      12006
+      "FAIRY_MUSHROOM_TORCH_BLUE"
     ]
   },
   {
@@ -21094,8 +21094,8 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      12101,
-      24012
+      "FAIRY_FURNACE_GLOW",
+      "FAI_FALADOR_FURNACE_GLOW"
     ]
   },
   {
@@ -21113,7 +21113,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      12809
+      "BURGH_FURNACE_FIRED"
     ]
   },
   {
@@ -21131,8 +21131,8 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      16657,
-      16469
+      "AHOY_NEW_FURNACE",
+      "VARROCK_DIARY_FURNACE"
     ]
   },
   {
@@ -21149,8 +21149,8 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      16657,
-      16469
+      "AHOY_NEW_FURNACE",
+      "VARROCK_DIARY_FURNACE"
     ]
   },
   {
@@ -21168,7 +21168,7 @@
     "duration": 4000,
     "range": 15,
     "objectIds": [
-      16648
+      "AHOY_ECTOFUNTUS"
     ]
   },
   {
@@ -21312,7 +21312,7 @@
     "duration": 4000,
     "range": 15,
     "objectIds": [
-      16649
+      "AHOY_ECTOFUNTUS_SMALL"
     ]
   },
   {
@@ -21546,12 +21546,12 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      20720,
-      20721,
-      20722,
-      20770,
-      20771,
-      20772
+      "BARROW_DHAROK_SARCOPHAGUS",
+      "BARROW_TORAG_SARCOPHAGUS",
+      "BARROW_GUTHAN_SARCOPHAGUS",
+      "BARROW_AHRIM_SARCOPHAGUS",
+      "BARROW_KARIL_SARCOPHAGUS",
+      "BARROW_VERAC_SARCOPHAGUS"
     ]
   },
   {
@@ -21569,7 +21569,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      2282
+      "FAI_VARROCK_SMITHY_HEARTH"
     ]
   },
   {
@@ -21587,9 +21587,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6197,
-      6199,
-      6201
+      "DWARF_KELDAGRIM_TABLE_SMALL_LAMP",
+      "DWARF_KELDAGRIM_TABLE_BIG_LAMP",
+      "DWARF_KELDAGRIM_TABLE_POSH_LAMP"
     ]
   },
   {
@@ -21607,7 +21607,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      26765
+      "CHAOS_FANATIC_RIFT"
     ]
   },
   {
@@ -21625,7 +21625,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      11909
+      "FAI_THORNSKIT_TORCH"
     ]
   },
   {
@@ -21643,7 +21643,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      4470
+      "CASTLEWARS_ZAMORAK_SPAWNDOOR"
     ]
   },
   {
@@ -21661,7 +21661,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      4469
+      "CASTLEWARS_SARADOMIN_SPAWNDOOR"
     ]
   },
   {
@@ -21679,9 +21679,9 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      4388,
-      4390,
-      4407
+      "CASTLEWARS_ZAMORAK_TELE",
+      "CASTLEWARS_ZAMORAK_EXIT",
+      "CASTLEWARS_ZAMORAK_QUIT"
     ]
   },
   {
@@ -21699,8 +21699,8 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      4387,
-      4389
+      "CASTLEWARS_SARADOMIN_TELE",
+      "CASTLEWARS_SARADOMIN_EXIT"
     ]
   },
   {
@@ -21718,7 +21718,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      4408
+      "CASTLEWARS_RANDOM_TELE"
     ]
   },
   {
@@ -21736,7 +21736,7 @@
     "duration": 1600,
     "range": 20,
     "objectIds": [
-      40454
+      "SOUL_WARS_BLUE_GRAVEYARD_BARRIER"
     ]
   },
   {
@@ -21754,8 +21754,8 @@
     "duration": 1600,
     "range": 20,
     "objectIds": [
-      40456,
-      40457
+      "SOUL_WARS_RED_WESTERN_BARRIER",
+      "SOUL_WARS_RED_GRAVEYARD_BARRIER"
     ]
   },
   {
@@ -21773,7 +21773,7 @@
     "duration": 1600,
     "range": 20,
     "objectIds": [
-      41200
+      "SOUL_WARS_CLAN_WAITING_AREA_BARRIER"
     ]
   },
   {
@@ -21791,7 +21791,7 @@
     "duration": 1600,
     "range": 20,
     "objectIds": [
-      41199
+      "SOUL_WARS_MAIN_WAITING_AREA_BARRIER"
     ]
   },
   {
@@ -21809,8 +21809,8 @@
     "duration": 1000,
     "range": 20,
     "objectIds": [
-      40474,
-      40476
+      "SOUL_WARS_EDGEVILLE_PORTAL",
+      "SOUL_WARS_LEAVE_SOULWARS_PORTAL"
     ]
   },
   {
@@ -21828,7 +21828,7 @@
     "duration": 1000,
     "range": 20,
     "objectIds": [
-      40460
+      "SOUL_WARS_BLUE_EXIT_PORTAL"
     ]
   },
   {
@@ -21846,7 +21846,7 @@
     "duration": 1000,
     "range": 20,
     "objectIds": [
-      40461
+      "SOUL_WARS_RED_EXIT_PORTAL"
     ]
   },
   {
@@ -21864,7 +21864,7 @@
     "duration": 1000,
     "range": 20,
     "objectIds": [
-      40475
+      "SOUL_WARS_ENCLAVE_PORTAL"
     ]
   },
   {
@@ -21882,8 +21882,8 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      40550,
-      40551
+      "SNP_PILLAR_TORCH_BLUE",
+      "SNP_PILLAR_TORCH_RED"
     ]
   },
   {
@@ -21901,8 +21901,8 @@
     "duration": 1000,
     "range": 30,
     "objectIds": [
-      40449,
-      40435
+      "SOUL_WARS_CENTRAL_OBELISK_NEUTRAL",
+      "SOUL_WARS_TUT_CENTRAL_OBELISK_NEUTRAL_CHILD"
     ]
   },
   {
@@ -21920,7 +21920,7 @@
     "duration": 3000,
     "range": 30,
     "objectIds": [
-      40451
+      "SOUL_WARS_CENTRAL_OBELISK_RED"
     ]
   },
   {
@@ -21938,7 +21938,7 @@
     "duration": 3000,
     "range": 30,
     "objectIds": [
-      40450
+      "SOUL_WARS_CENTRAL_OBELISK_BLUE"
     ]
   },
   {
@@ -21956,7 +21956,7 @@
     "duration": 2550,
     "range": 10,
     "objectIds": [
-      30386
+      "CASTLEWARS_F2P_PORTAL"
     ]
   },
   {
@@ -21974,7 +21974,7 @@
     "duration": 13800,
     "range": 5,
     "objectIds": [
-      39640
+      "BR_COMPETITIVE_ENTRANCE"
     ]
   },
   {
@@ -21992,7 +21992,7 @@
     "duration": 1500,
     "range": 20,
     "objectIds": [
-      39639
+      "BR_CASUAL_ENTRANCE"
     ]
   },
   {
@@ -22009,7 +22009,7 @@
     "duration": 2650,
     "range": 10,
     "objectIds": [
-      39656
+      "WILDY_HUB_ENTRANCE_FX"
     ]
   },
   {
@@ -22027,7 +22027,7 @@
     "duration": 1541,
     "range": 40,
     "objectIds": [
-      47346
+      "BH_PORTAL_ENTER"
     ]
   },
   {
@@ -22045,7 +22045,7 @@
     "duration": 2750,
     "range": 10,
     "objectIds": [
-      26642
+      "CLANWARS_CHALLENGEPORTAL_W"
     ]
   },
   {
@@ -22063,7 +22063,7 @@
     "duration": 2850,
     "range": 10,
     "objectIds": [
-      26645
+      "CLANWARS_FFAPORTAL"
     ]
   },
   {
@@ -22081,7 +22081,7 @@
     "duration": 1850,
     "range": 20,
     "objectIds": [
-      26646
+      "CLANWARS_FFAEXIT"
     ]
   },
   {
@@ -22099,7 +22099,7 @@
     "duration": 1650,
     "range": 5,
     "objectIds": [
-      39651
+      "WILDY_HUB_POOL"
     ]
   },
   {
@@ -22117,7 +22117,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      39694
+      "WILDY_HUB_SKULLTORCH"
     ]
   },
   {
@@ -22134,7 +22134,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      39582
+      "DEATH_OFFICE_TORCH"
     ]
   },
   {
@@ -22151,7 +22151,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      39551
+      "DEATH_OFFICE_WALL_FIRE"
     ]
   },
   {
@@ -22168,7 +22168,7 @@
     "duration": 1850,
     "range": 20,
     "objectIds": [
-      39549
+      "DEATH_OFFICE_EXITPORTAL"
     ]
   },
   {
@@ -22186,8 +22186,8 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      11833,
-      11834
+      "TZHAAR_FIGHTCAVE_WALL_ENTRANCE",
+      "TZHAAR_FIGHTCAVE_WALL_EXIT"
     ]
   },
   {
@@ -22205,7 +22205,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      11836
+      "TZHAAR_KARAMJADUNGEON_WALL_EXIT"
     ]
   },
   {
@@ -22223,8 +22223,8 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      30281,
-      30282
+      "INFERNO_ENTRANCE_NOOP",
+      "INFERNO_ENTRANCE_OP"
     ]
   },
   {
@@ -22242,7 +22242,7 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      4525
+      "POH_EXIT_PORTAL"
     ]
   },
   {
@@ -22260,13 +22260,13 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      15477,
-      15478,
-      28822,
-      15479,
-      15480,
-      15481,
-      30172
+      "POH_TAVERLY_PORTAL",
+      "POH_RIMMINGTON_PORTAL",
+      "POH_KOUREND_PORTAL",
+      "POH_POLLNIVNEACH_PORTAL",
+      "POH_RELLEKKA_PORTAL",
+      "POH_BRIMHAVEN_PORTAL",
+      "POH_PORTAL_OP"
     ]
   },
   {
@@ -22284,7 +22284,7 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      34947
+      "POH_PRIFDDINAS_PORTAL"
     ]
   },
   {
@@ -22302,12 +22302,12 @@
     "duration": 1250,
     "range": 20,
     "objectIds": [
-      27097,
-      33408,
-      33409,
-      33410,
-      37549,
-      37550
+      "LEAGUE_5_POH_SPIRIT_RING",
+      "POH_NEXUS_PORTAL_1",
+      "POH_NEXUS_PORTAL_2",
+      "POH_NEXUS_PORTAL_3",
+      "HUNTING_TRAIL4_7L",
+      "HUNTING_TRAIL4_8L"
     ]
   },
   {
@@ -22325,8 +22325,8 @@
     "duration": 800,
     "range": 20,
     "objectIds": [
-      29237,
-      40844
+      "POH_POOL_RESTORATION",
+      "XMAS20_POH_POOL_RESTORATION"
     ]
   },
   {
@@ -22344,8 +22344,8 @@
     "duration": 1200,
     "range": 6,
     "objectIds": [
-      29237,
-      40844
+      "POH_POOL_RESTORATION",
+      "XMAS20_POH_POOL_RESTORATION"
     ]
   },
   {
@@ -22363,8 +22363,8 @@
     "duration": 800,
     "range": 20,
     "objectIds": [
-      29238,
-      40845
+      "POH_POOL_REVITALISATION",
+      "XMAS20_POH_POOL_REVITALISATION"
     ]
   },
   {
@@ -22382,8 +22382,8 @@
     "duration": 1200,
     "range": 6,
     "objectIds": [
-      29238,
-      40845
+      "POH_POOL_REVITALISATION",
+      "XMAS20_POH_POOL_REVITALISATION"
     ]
   },
   {
@@ -22401,8 +22401,8 @@
     "duration": 800,
     "range": 20,
     "objectIds": [
-      29239,
-      40846
+      "POH_POOL_REJUVENATION",
+      "XMAS20_POH_POOL_REJUVENATION"
     ]
   },
   {
@@ -22420,8 +22420,8 @@
     "duration": 1200,
     "range": 6,
     "objectIds": [
-      29239,
-      40846
+      "POH_POOL_REJUVENATION",
+      "XMAS20_POH_POOL_REJUVENATION"
     ]
   },
   {
@@ -22439,8 +22439,8 @@
     "duration": 800,
     "range": 20,
     "objectIds": [
-      29240,
-      40847
+      "POH_POOL_RECOVERY",
+      "XMAS20_POH_POOL_RECOVERY"
     ]
   },
   {
@@ -22458,8 +22458,8 @@
     "duration": 1200,
     "range": 6,
     "objectIds": [
-      29240,
-      40847
+      "POH_POOL_RECOVERY",
+      "XMAS20_POH_POOL_RECOVERY"
     ]
   },
   {
@@ -22477,8 +22477,8 @@
     "duration": 1250,
     "range": 20,
     "objectIds": [
-      40848,
-      29241
+      "XMAS20_POH_POOL_REGENERATION",
+      "POH_POOL_REGENERATION"
     ]
   },
   {
@@ -22496,8 +22496,8 @@
     "duration": 1200,
     "range": 6,
     "objectIds": [
-      40848,
-      29241
+      "XMAS20_POH_POOL_REGENERATION",
+      "POH_POOL_REGENERATION"
     ]
   },
   {
@@ -22515,7 +22515,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      49993
+      "LEAGUE_4_POH_POOL_REJUVENATION"
     ]
   },
   {
@@ -22533,7 +22533,7 @@
     "duration": 0,
     "range": 40,
     "objectIds": [
-      49993
+      "LEAGUE_4_POH_POOL_REJUVENATION"
     ]
   },
   {
@@ -22551,7 +22551,7 @@
     "duration": 0,
     "range": 40,
     "objectIds": [
-      49993
+      "LEAGUE_4_POH_POOL_REJUVENATION"
     ]
   },
   {
@@ -22569,9 +22569,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      13639,
-      13640,
-      13641
+      "POH_SCRYING_POOL",
+      "POH_TELEPORT_CENTREPIECE",
+      "POH_TELEPORT_CENTREPIECE_GRAND"
     ]
   },
   {
@@ -22589,7 +22589,7 @@
     "duration": 0,
     "range": 25,
     "objectIds": [
-      49963
+      "POH_LEAGUEHALL_PEDESTAL_2_SIMPLE_LEAGUE_4_DRAGON"
     ]
   },
   {
@@ -22607,9 +22607,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      41416,
-      41417,
-      41418
+      "POH_PORTAL_TEAK_ARCEUUS_LIBRARY",
+      "POH_PORTAL_MAG_ARCEUUS_LIBRARY",
+      "POH_PORTAL_MARBLE_ARCEUUS_LIBRARY"
     ]
   },
   {
@@ -22627,9 +22627,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37607,
-      37595,
-      37583
+      "POH_PORTAL_MARBLE_DRAYNOR_MANOR",
+      "POH_PORTAL_MAG_DRAYNOR_MANOR",
+      "POH_PORTAL_TEAK_DRAYNOR_MANOR"
     ]
   },
   {
@@ -22647,9 +22647,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37584,
-      37608,
-      37596
+      "POH_PORTAL_TEAK_BATTLEFRONT",
+      "POH_PORTAL_MARBLE_BATTLEFRONT",
+      "POH_PORTAL_MAG_BATTLEFRONT"
     ]
   },
   {
@@ -22667,16 +22667,16 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      33092,
-      33092,
-      33093,
-      33093,
-      33098,
-      33099,
-      33104,
-      33104,
-      33105,
-      33105
+      "POH_PORTAL_TEAK_VARROCK_VARROCK1ST",
+      "POH_PORTAL_TEAK_VARROCK_VARROCK1ST",
+      "POH_PORTAL_TEAK_VARROCK_GE1ST",
+      "POH_PORTAL_TEAK_VARROCK_GE1ST",
+      "POH_PORTAL_MAHOGANY_VARROCK_VARROCK1ST",
+      "POH_PORTAL_MAHOGANY_VARROCK_GE1ST",
+      "POH_PORTAL_MARBLE_VARROCK_VARROCK1ST",
+      "POH_PORTAL_MARBLE_VARROCK_VARROCK1ST",
+      "POH_PORTAL_MARBLE_VARROCK_GE1ST",
+      "POH_PORTAL_MARBLE_VARROCK_GE1ST"
     ]
   },
   {
@@ -22694,9 +22694,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37585,
-      37609,
-      37597
+      "POH_PORTAL_TEAK_MIND_ALTAR",
+      "POH_PORTAL_MARBLE_MIND_ALTAR",
+      "POH_PORTAL_MAG_MIND_ALTAR"
     ]
   },
   {
@@ -22714,9 +22714,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      13616,
-      13623,
-      13630
+      "POH_PORTAL_TEAK_LUMBRIDGE",
+      "POH_PORTAL_MAG_LUMBRIDGE",
+      "POH_PORTAL_MARBLE_LUMBRIDGE"
     ]
   },
   {
@@ -22734,9 +22734,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      13617,
-      13624,
-      13631
+      "POH_PORTAL_TEAK_FALADOR",
+      "POH_PORTAL_MAG_FALADOR",
+      "POH_PORTAL_MARBLE_FALADOR"
     ]
   },
   {
@@ -22754,9 +22754,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37586,
-      37610,
-      37598
+      "POH_PORTAL_TEAK_SALVE_GRAVEYARD",
+      "POH_PORTAL_MARBLE_SALVE_GRAVEYARD",
+      "POH_PORTAL_MAG_SALVE_GRAVEYARD"
     ]
   },
   {
@@ -22774,12 +22774,12 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      33094,
-      33095,
-      33100,
-      33101,
-      33106,
-      33107
+      "POH_PORTAL_TEAK_CAMELOT_CAMELOT1ST",
+      "POH_PORTAL_TEAK_CAMELOT_SEERS1ST",
+      "POH_PORTAL_MAHOGANY_CAMELOT_CAMELOT1ST",
+      "POH_PORTAL_MAHOGANY_CAMELOT_SEERS1ST",
+      "POH_PORTAL_MARBLE_CAMELOT_CAMELOT1ST",
+      "POH_PORTAL_MARBLE_CAMELOT_SEERS1ST"
     ]
   },
   {
@@ -22797,9 +22797,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37587,
-      37611,
-      37599
+      "POH_PORTAL_TEAK_FENKENSTRAIN",
+      "POH_PORTAL_MARBLE_FENKENSTRAIN",
+      "POH_PORTAL_MAG_FENKENSTRAIN"
     ]
   },
   {
@@ -22817,9 +22817,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      13633,
-      13619,
-      13626
+      "POH_PORTAL_MARBLE_ARDOUGNE",
+      "POH_PORTAL_TEAK_ARDOUGNE",
+      "POH_PORTAL_MAG_ARDOUGNE"
     ]
   },
   {
@@ -22837,12 +22837,12 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      33108,
-      33109,
-      33096,
-      33097,
-      33102,
-      33103
+      "POH_PORTAL_MARBLE_YANILLE_WATCHTOWER1ST",
+      "POH_PORTAL_MARBLE_YANILLE_YANILLE1ST",
+      "POH_PORTAL_TEAK_YANILLE_WATCHTOWER1ST",
+      "POH_PORTAL_TEAK_YANILLE_YANILLE1ST",
+      "POH_PORTAL_MAHOGANY_YANILLE_WATCHTOWER1ST",
+      "POH_PORTAL_MAHOGANY_YANILLE_YANILLE1ST"
     ]
   },
   {
@@ -22860,9 +22860,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29348,
-      29340,
-      29356
+      "POH_PORTAL_MAG_SENNTISTEN",
+      "POH_PORTAL_TEAK_SENNTISTEN",
+      "POH_PORTAL_MARBLE_SENNTISTEN"
     ]
   },
   {
@@ -22880,9 +22880,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37600,
-      37588,
-      37612
+      "POH_PORTAL_MAG_WEST_ARDOUGNE",
+      "POH_PORTAL_TEAK_WEST_ARDOUGNE",
+      "POH_PORTAL_MARBLE_WEST_ARDOUGNE"
     ]
   },
   {
@@ -22900,9 +22900,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29344,
-      29360,
-      29352
+      "POH_PORTAL_TEAK_MARIM",
+      "POH_PORTAL_MARBLE_MARIM",
+      "POH_PORTAL_MAG_MARIM"
     ]
   },
   {
@@ -22920,9 +22920,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37601,
-      37589,
-      37613
+      "POH_PORTAL_MAG_HARMONY_ISLAND",
+      "POH_PORTAL_TEAK_HARMONY_ISLAND",
+      "POH_PORTAL_MARBLE_HARMONY_ISLAND"
     ]
   },
   {
@@ -22940,9 +22940,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29346,
-      29338,
-      29354
+      "POH_PORTAL_MAG_KHARYRLL",
+      "POH_PORTAL_TEAK_KHARYRLL",
+      "POH_PORTAL_MARBLE_KHARYRLL"
     ]
   },
   {
@@ -22960,9 +22960,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29347,
-      29339,
-      29355
+      "POH_PORTAL_MAG_LUNARISLE",
+      "POH_PORTAL_TEAK_LUNARISLE",
+      "POH_PORTAL_MARBLE_LUNARISLE"
     ]
   },
   {
@@ -22980,9 +22980,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29345,
-      29361,
-      29353
+      "POH_PORTAL_TEAK_KOUREND",
+      "POH_PORTAL_MARBLE_KOUREND",
+      "POH_PORTAL_MAG_KOUREND"
     ]
   },
   {
@@ -23000,9 +23000,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37602,
-      37590,
-      37614
+      "POH_PORTAL_MAG_CEMETERY",
+      "POH_PORTAL_TEAK_CEMETERY",
+      "POH_PORTAL_MARBLE_CEMETERY"
     ]
   },
   {
@@ -23020,9 +23020,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29350,
-      29342,
-      29358
+      "POH_PORTAL_MAG_WATERBIRTH",
+      "POH_PORTAL_TEAK_WATERBIRTH",
+      "POH_PORTAL_MARBLE_WATERBIRTH"
     ]
   },
   {
@@ -23040,9 +23040,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37603,
-      37591,
-      37615
+      "POH_PORTAL_MAG_BARROWS",
+      "POH_PORTAL_TEAK_BARROWS",
+      "POH_PORTAL_MARBLE_BARROWS"
     ]
   },
   {
@@ -23060,9 +23060,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      33440,
-      33434,
-      33437
+      "POH_PORTAL_MARBLE_CARRALLANGAR",
+      "POH_PORTAL_TEAK_CARRALLANGAR",
+      "POH_PORTAL_MAG_CARRALLANGAR"
     ]
   },
   {
@@ -23080,9 +23080,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29351,
-      29343,
-      29359
+      "POH_PORTAL_MAG_FISHINGGUILD",
+      "POH_PORTAL_TEAK_FISHINGGUILD",
+      "POH_PORTAL_MARBLE_FISHINGGUILD"
     ]
   },
   {
@@ -23100,9 +23100,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      33432,
-      33435,
-      33438
+      "POH_PORTAL_TEAK_CATHERBY",
+      "POH_PORTAL_MAG_CATHERBY",
+      "POH_PORTAL_MARBLE_CATHERBY"
     ]
   },
   {
@@ -23120,9 +23120,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      29349,
-      29341,
-      29357
+      "POH_PORTAL_MAG_ANNAKARL",
+      "POH_PORTAL_TEAK_ANNAKARL",
+      "POH_PORTAL_MARBLE_ANNAKARL"
     ]
   },
   {
@@ -23140,9 +23140,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37616,
-      37604,
-      37592
+      "POH_PORTAL_MARBLE_APE_ATOLL",
+      "POH_PORTAL_MAG_APE_ATOLL",
+      "POH_PORTAL_TEAK_APE_ATOLL"
     ]
   },
   {
@@ -23160,9 +23160,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      33433,
-      33436,
-      33439
+      "POH_PORTAL_TEAK_GHORROCK",
+      "POH_PORTAL_MAG_GHORROCK",
+      "POH_PORTAL_MARBLE_GHORROCK"
     ]
   },
   {
@@ -23180,9 +23180,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      33179,
-      33180,
-      33181
+      "POH_PORTAL_TEAK_STRONGHOLD",
+      "POH_PORTAL_MAG_STRONGHOLD",
+      "POH_PORTAL_MARBLE_STRONGHOLD"
     ]
   },
   {
@@ -23200,9 +23200,9 @@
     "duration": 4100,
     "range": 20,
     "objectIds": [
-      37605,
-      37593,
-      37581
+      "POH_PORTAL_MARBLE_WEISS",
+      "POH_PORTAL_MAG_WEISS",
+      "POH_PORTAL_TEAK_WEISS"
     ]
   },
   {
@@ -23220,7 +23220,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      3760
+      "TROLL_MAD_EADGAR_EXIT"
     ]
   },
   {
@@ -23238,8 +23238,8 @@
     "duration": 3000,
     "range": 7,
     "objectIds": [
-      4004,
-      4005
+      "REGICIDE_VOYAGE_TEMPLE_WELL1",
+      "REGICIDE_VOYAGE_TEMPLE_WELL2"
     ]
   },
   {
@@ -23257,11 +23257,11 @@
     "duration": 2000,
     "range": 7,
     "objectIds": [
-      35867,
-      35868,
-      3918,
-      34958,
-      8767
+      "SOTE_HUNTING_LAMP_OP",
+      "SOTE_HUNTING_LAMP_NOOP",
+      "REGICIDE_CRYSTAL_LAMP",
+      "REGICIDE_CRYSTAL_LAMP_BLOCKWALK_ONLY",
+      "ELF_VILLAGE_RAIL_LAMP"
     ]
   },
   {
@@ -23278,7 +23278,7 @@
     "duration": 1200,
     "range": 10,
     "objectIds": [
-      35075
+      "SOTE_LIBRARY_EXIT"
     ]
   },
   {
@@ -23295,7 +23295,7 @@
     "duration": 1200,
     "range": 10,
     "objectIds": [
-      35075
+      "SOTE_LIBRARY_EXIT"
     ]
   },
   {
@@ -23312,7 +23312,7 @@
     "duration": 3200,
     "range": 5,
     "objectIds": [
-      34998
+      "SOTE_WARPED_LIBRARY_PILLAR_LVL2_02"
     ]
   },
   {
@@ -23329,10 +23329,10 @@
     "duration": 3200,
     "range": 5,
     "objectIds": [
-      35059,
-      35061,
-      35064,
-      35384
+      "SOTE_WARPED_LIBRARY_PILLAR_LVL3_03",
+      "SOTE_WARPED_LIBRARY_PILLAR_LVL3_05",
+      "SOTE_WARPED_LIBRARY_PILLAR_LVL3_08",
+      "SOTE_WARPED_LIBRARY_PILLAR_02"
     ]
   },
   {
@@ -23350,7 +23350,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      35000
+      "SOTE_WARPED_LIBRARY_PILLAR_LVL2_04"
     ]
   },
   {
@@ -23367,9 +23367,9 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      35065,
-      35066,
-      35386
+      "SOTE_WARPED_LIBRARY_PILLAR_LIGHT_LVL3",
+      "SOTE_WARPED_LIBRARY_PILLAR_LIGHT_LVL3_02",
+      "SOTE_WARPED_LIBRARY_PILLAR_LIGHT_01"
     ]
   },
   {
@@ -23386,14 +23386,14 @@
     "duration": 3200,
     "range": 5,
     "objectIds": [
-      35451,
-      35453,
-      35455,
-      35457,
-      35459,
-      35461,
-      35463,
-      35465
+      "SOTE_CADARN_SEAL_FIXED",
+      "SOTE_CRWYS_SEAL_FIXED",
+      "SOTE_AMLODD_SEAL_FIXED",
+      "SOTE_HEFIN_SEAL_FIXED",
+      "SOTE_IORWERTH_SEAL_FIXED",
+      "SOTE_ITHELL_SEAL_FIXED",
+      "SOTE_MEILYR_SEAL_FIXED",
+      "SOTE_TRAHAEARN_SEAL_FIXED"
     ],
     "fadeOutDuration": 300
   },
@@ -23411,14 +23411,14 @@
     "duration": 3200,
     "range": 5,
     "objectIds": [
-      35451,
-      35453,
-      35455,
-      35457,
-      35459,
-      35461,
-      35463,
-      35465
+      "SOTE_CADARN_SEAL_FIXED",
+      "SOTE_CRWYS_SEAL_FIXED",
+      "SOTE_AMLODD_SEAL_FIXED",
+      "SOTE_HEFIN_SEAL_FIXED",
+      "SOTE_IORWERTH_SEAL_FIXED",
+      "SOTE_ITHELL_SEAL_FIXED",
+      "SOTE_MEILYR_SEAL_FIXED",
+      "SOTE_TRAHAEARN_SEAL_FIXED"
     ],
     "fadeOutDuration": 300
   },
@@ -23436,14 +23436,14 @@
     "duration": 3200,
     "range": 5,
     "objectIds": [
-      35451,
-      35453,
-      35455,
-      35457,
-      35459,
-      35461,
-      35463,
-      35465
+      "SOTE_CADARN_SEAL_FIXED",
+      "SOTE_CRWYS_SEAL_FIXED",
+      "SOTE_AMLODD_SEAL_FIXED",
+      "SOTE_HEFIN_SEAL_FIXED",
+      "SOTE_IORWERTH_SEAL_FIXED",
+      "SOTE_ITHELL_SEAL_FIXED",
+      "SOTE_MEILYR_SEAL_FIXED",
+      "SOTE_TRAHAEARN_SEAL_FIXED"
     ],
     "fadeOutDuration": 300
   },
@@ -23462,15 +23462,15 @@
     "duration": 3200,
     "range": 5,
     "objectIds": [
-      35452,
-      35454,
-      35456,
-      35458,
-      35460,
-      35462,
-      35464,
-      35466,
-      35467
+      "SOTE_CADARN_SEAL_BROKEN",
+      "SOTE_CRWYS_SEAL_BROKEN",
+      "SOTE_AMLODD_SEAL_BROKEN",
+      "SOTE_HEFIN_SEAL_BROKEN",
+      "SOTE_IORWERTH_SEAL_BROKEN",
+      "SOTE_ITHELL_SEAL_BROKEN",
+      "SOTE_MEILYR_SEAL_BROKEN",
+      "SOTE_TRAHAEARN_SEAL_BROKEN",
+      "SOTE_FORGOTTEN_SEAL"
     ]
   },
   {
@@ -23488,7 +23488,7 @@
     "duration": 3200,
     "range": 10,
     "objectIds": [
-      35901
+      "DARK_SEREN_DEFEATED_VIS"
     ]
   },
   {
@@ -23506,15 +23506,15 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      35984,
-      35985,
-      36082,
-      36197,
-      36198,
-      36614,
-      36615,
-      36490,
-      36062
+      "GAUNTLET_LOBBY_ENTRANCE_HM",
+      "GAUNTLET_LOBBY_EXIT_HM",
+      "GAUNTLET_LOBBY_EXIT",
+      "ZALCANO_EXIT",
+      "ZALCANO_ENTRANCE",
+      "PRIF_LIBRARY_TELEPORTER1",
+      "PRIF_LIBRARY_TELEPORTER2",
+      "PRIF_CLAN_TOWER_TELEPORTER",
+      "GAUNTLET_EXIT"
     ]
   },
   {
@@ -23532,7 +23532,7 @@
     "duration": 5000,
     "range": 20,
     "objectIds": [
-      36081
+      "GAUNTLET_LOBBY_ENTRANCE"
     ]
   },
   {
@@ -23550,8 +23550,8 @@
     "duration": 2000,
     "range": 20,
     "objectIds": [
-      36083,
-      36084
+      "GAUNTLET_ENTRANCE_HM_DISABLED",
+      "GAUNTLET_ENTRANCE_HM_ENABLED"
     ]
   },
   {
@@ -23569,8 +23569,8 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36087,
-      36088
+      "GAUNTLET_CHEST_CLOSED",
+      "GAUNTLET_CHEST_OPEN"
     ]
   },
   {
@@ -23588,7 +23588,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36074
+      "GAUNTLET_TOOLS"
     ]
   },
   {
@@ -23606,7 +23606,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      36077
+      "GAUNTLET_RANGE"
     ]
   },
   {
@@ -23624,7 +23624,7 @@
     "duration": 3100,
     "range": 20,
     "objectIds": [
-      36063
+      "GAUNTLET_SINGING_BOWL"
     ]
   },
   {
@@ -23641,7 +23641,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36103
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_01"
     ]
   },
   {
@@ -23658,7 +23658,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36104
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_02"
     ]
   },
   {
@@ -23676,7 +23676,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36066
+      "GAUNTLET_TREE"
     ]
   },
   {
@@ -23694,7 +23694,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      36064
+      "GAUNTLET_ROCK"
     ]
   },
   {
@@ -23710,7 +23710,7 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      36068
+      "GAUNTLET_POND"
     ],
     "fadeOutDuration": 100
   },
@@ -23729,7 +23729,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      35965
+      "GAUNTLET_EXIT_HM"
     ]
   },
   {
@@ -23747,7 +23747,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      35977
+      "GAUNTLET_TOOLS_HM"
     ]
   },
   {
@@ -23765,7 +23765,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      35980
+      "GAUNTLET_RANGE_HM"
     ]
   },
   {
@@ -23783,7 +23783,7 @@
     "duration": 3100,
     "range": 20,
     "objectIds": [
-      35966
+      "GAUNTLET_SINGING_BOWL_HM"
     ]
   },
   {
@@ -23800,7 +23800,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36000
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_01_HM"
     ]
   },
   {
@@ -23817,7 +23817,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36001
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_02_HM"
     ]
   },
   {
@@ -23835,7 +23835,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      35969
+      "GAUNTLET_TREE_HM"
     ]
   },
   {
@@ -23853,7 +23853,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      35967
+      "GAUNTLET_ROCK_HM"
     ]
   },
   {
@@ -23869,7 +23869,7 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      35971
+      "GAUNTLET_POND_HM"
     ],
     "fadeOutDuration": 100
   },
@@ -23888,7 +23888,7 @@
     "duration": 4300,
     "range": 20,
     "objectIds": [
-      36192
+      "ZALCANO_ROCK_ACTIVE"
     ]
   },
   {
@@ -23906,7 +23906,7 @@
     "duration": 4300,
     "range": 20,
     "objectIds": [
-      36193
+      "ZALCANO_ROCK_PARTIAL"
     ]
   },
   {
@@ -23924,7 +23924,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36196
+      "ZALCANO_ALTAR"
     ]
   },
   {
@@ -23942,7 +23942,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      36195
+      "ZALCANO_FURNACE"
     ]
   },
   {
@@ -23960,7 +23960,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      6551
+      "DT_PORTAL"
     ]
   },
   {
@@ -23978,7 +23978,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6483
+      "DESERT_TREASURE_OBLIX_A"
     ]
   },
   {
@@ -23996,7 +23996,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6484
+      "FD_BLOOD_COLUMN"
     ]
   },
   {
@@ -24014,7 +24014,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6486
+      "DESERT_TREASURE_OBLIX_B"
     ]
   },
   {
@@ -24032,7 +24032,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6487
+      "FD_SMOKE_COLUMN"
     ]
   },
   {
@@ -24050,7 +24050,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6489
+      "DESERT_TREASURE_OBLIX_C"
     ]
   },
   {
@@ -24068,7 +24068,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6490
+      "FD_ICE_COLUMN"
     ]
   },
   {
@@ -24086,7 +24086,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6492
+      "DESERT_TREASURE_OBLIX_D"
     ]
   },
   {
@@ -24104,7 +24104,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      6493
+      "FD_SHADOW_COLUMN"
     ]
   },
   {
@@ -24121,7 +24121,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      20931
+      "NTK_TOMB_DOOR_EXIT"
     ]
   },
   {
@@ -24138,7 +24138,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      20932
+      "NTK_ANTECHAMBER_EXIT"
     ]
   },
   {
@@ -24156,7 +24156,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      20942
+      "NTK_TOMB_WALL_TORCH"
     ]
   },
   {
@@ -24174,9 +24174,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      26616,
-      20946,
-      20947
+      "NTK_GOLDEN_CHEST_MULTI",
+      "NTK_GOLDEN_CHEST_CLOSED",
+      "NTK_GOLDEN_CHEST_OPEN"
     ]
   },
   {
@@ -24194,7 +24194,7 @@
     "duration": 6200,
     "range": 30,
     "objectIds": [
-      27878
+      "ARCHEUS_CRYSTAL_LARGE"
     ]
   },
   {
@@ -24212,7 +24212,7 @@
     "duration": 4000,
     "range": 30,
     "objectIds": [
-      27882
+      "ARCHEUS_CRYSTAL_MEDIUM"
     ]
   },
   {
@@ -24230,7 +24230,7 @@
     "duration": 2400,
     "range": 30,
     "objectIds": [
-      27886
+      "ARCHEUS_CRYSTAL_SMALL"
     ]
   },
   {
@@ -24248,7 +24248,7 @@
     "duration": 6100,
     "range": 30,
     "objectIds": [
-      27879
+      "ARCHEUS_CRYSTAL_LARGE_DARK"
     ]
   },
   {
@@ -24266,7 +24266,7 @@
     "duration": 3900,
     "range": 30,
     "objectIds": [
-      27883
+      "ARCHEUS_CRYSTAL_MEDIUM_DARK"
     ]
   },
   {
@@ -24284,7 +24284,7 @@
     "duration": 2300,
     "range": 30,
     "objectIds": [
-      27887
+      "ARCHEUS_CRYSTAL_SMALL_DARK"
     ]
   },
   {
@@ -24302,7 +24302,7 @@
     "duration": 6300,
     "range": 30,
     "objectIds": [
-      27881
+      "ARCHEUS_CRYSTAL_LARGE_REFLECT_RED"
     ]
   },
   {
@@ -24320,8 +24320,8 @@
     "duration": 4100,
     "range": 30,
     "objectIds": [
-      27884,
-      27885
+      "ARCHEUS_CRYSTAL_MEDIUM_RED",
+      "ARCHEUS_CRYSTAL_MEDIUM_REFLECT_RED"
     ]
   },
   {
@@ -24339,7 +24339,7 @@
     "duration": 2500,
     "range": 30,
     "objectIds": [
-      27888
+      "ARCHEUS_CRYSTAL_SMALL_RED"
     ]
   },
   {
@@ -24357,7 +24357,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      27978
+      "ARCHEUS_ALTAR_BLOOD"
     ]
   },
   {
@@ -24375,7 +24375,7 @@
     "duration": 2000,
     "range": 10,
     "objectIds": [
-      43479
+      "BLOOD_ALTAR"
     ]
   },
   {
@@ -24393,7 +24393,7 @@
     "duration": 1800,
     "range": 5,
     "objectIds": [
-      43478
+      "BLOODTEMPLE_EXIT_PORTAL"
     ]
   },
   {
@@ -24483,7 +24483,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      27979
+      "ARCHEUS_ALTAR_DARK"
     ]
   },
   {
@@ -24501,7 +24501,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      27980
+      "ARCHEUS_ALTAR_SOUL"
     ]
   },
   {
@@ -24519,10 +24519,10 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29794,
-      30018,
-      30027,
-      30015
+      "RAIDS_CRYTAL1",
+      "RAIDS_BLOCKAGE_GREEN",
+      "RAIDS_REWARD_CRYSTAL",
+      "RAIDS_BLOCKAGE_PURPLE"
     ]
   },
   {
@@ -24540,7 +24540,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29800
+      "RAIDS_WALL_TOP_CRYSTAL_LARGE"
     ]
   },
   {
@@ -24558,7 +24558,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29796
+      "RAIDS_CRYTAL3"
     ]
   },
   {
@@ -24576,8 +24576,8 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      30016,
-      29775
+      "RAIDS_BLOCKAGE_PURPLE_SMALL",
+      "RAIDS_VASANISTIRIO_CRYSTAL_OFF"
     ]
   },
   {
@@ -24595,7 +24595,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29801
+      "RAIDS_WALL_TOP_CRYSTAL_LARGE2"
     ]
   },
   {
@@ -24613,8 +24613,8 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      30017,
-      29798
+      "RAIDS_BLOCKAGE_ORANGE",
+      "RAIDS_CRYTAL5"
     ]
   },
   {
@@ -24632,7 +24632,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29802
+      "RAIDS_WALL_TOP_CRYSTAL_LARGE3"
     ]
   },
   {
@@ -24650,8 +24650,8 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      33147,
-      30014
+      "DEADMAN_CRYSTAL_BLOOD",
+      "RAIDS_BLOOD_CRYSTAL"
     ]
   },
   {
@@ -24669,7 +24669,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29867
+      "RAIDS_TEKTON_ANVIL"
     ]
   },
   {
@@ -24687,7 +24687,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      29748
+      "RAIDS_ICEDEMON_BRAZIER_LIT"
     ]
   },
   {
@@ -24705,7 +24705,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      30019
+      "RAIDS_VASANISTIRIO_FIRE"
     ]
   },
   {
@@ -24723,8 +24723,8 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29760,
-      31958
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_MAGENTA",
+      "SHAYZIENQUEST_CRYSTAL_MAGENTA"
     ]
   },
   {
@@ -24742,8 +24742,8 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      31957,
-      29759
+      "SHAYZIENQUEST_CRYSTAL_CYAN",
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_CYAN"
     ]
   },
   {
@@ -24761,8 +24761,8 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29761,
-      31959
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_YELLOW",
+      "SHAYZIENQUEST_CRYSTAL_YELLOW"
     ]
   },
   {
@@ -24780,7 +24780,7 @@
     "duration": 2400,
     "range": 20,
     "objectIds": [
-      29758
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_BLACK"
     ]
   },
   {
@@ -24798,7 +24798,7 @@
     "duration": 1400,
     "range": 20,
     "objectIds": [
-      29879
+      "RAIDS_OLM_BARRIER"
     ]
   },
   {
@@ -24816,7 +24816,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      10433
+      "ELID_SPIRIT_FIRE"
     ]
   },
   {
@@ -24834,7 +24834,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      34421
+      "MOLCH_TEMPLE_GODRAY"
     ]
   },
   {
@@ -24852,7 +24852,7 @@
     "duration": 1400,
     "range": 20,
     "objectIds": [
-      34432
+      "MOLCH_TEMPLE_BARRIER_GREEN"
     ]
   },
   {
@@ -24866,7 +24866,7 @@
     "duration": 1400,
     "range": 20,
     "objectIds": [
-      34433
+      "MOLCH_TEMPLE_BARRIER_ORANGE"
     ]
   },
   {
@@ -24880,7 +24880,7 @@
     "duration": 1400,
     "range": 20,
     "objectIds": [
-      34434
+      "MOLCH_TEMPLE_BARRIER_RED"
     ]
   },
   {
@@ -24898,7 +24898,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      9368
+      "CORP_PRIVATEPORTAL_OUTSIDE"
     ]
   },
   {
@@ -24915,7 +24915,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      9369
+      "CORP_PRIVATEPORTAL_INSIDE"
     ]
   },
   {
@@ -24934,7 +24934,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      41016
+      "CORP_IRONMAN_BRAZIER_ON"
     ]
   },
   {
@@ -24953,7 +24953,7 @@
     "duration": 1000,
     "range": 25,
     "objectIds": [
-      41016
+      "CORP_IRONMAN_BRAZIER_ON"
     ]
   },
   {
@@ -24973,8 +24973,8 @@
     "duration": 1000,
     "range": 25,
     "projectileIds": [
-      314,
-      316
+      "CORP_SPIRIT_BEAST_WEAK_PROJ",
+      "CORP_SPIRIT_BEAST_STRONG_PROJ"
     ]
   },
   {
@@ -24994,7 +24994,7 @@
     "duration": 1000,
     "range": 25,
     "projectileIds": [
-      315
+      "CORP_SPIRIT_BEAST_MID_PROJ"
     ]
   },
   {
@@ -25012,7 +25012,7 @@
     "type": "FLICKER",
     "duration": 1000,
     "range": 10,
-    "npcIds": [ 320 ]
+    "npcIds": [ "DARK_CORE" ]
   },
   {
     "description": "Corporeal Beast Dark Core - Moving",
@@ -25029,7 +25029,7 @@
     "type": "FLICKER",
     "duration": 1000,
     "range": 10,
-    "projectileIds": [ 319 ]
+    "projectileIds": [ "DARK_CORE_JUMP" ]
   },
   {
     "description": "TUNNEL_EXIT",
@@ -25046,7 +25046,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      2141
+      "SLAYER_DUNGEON_EXIT"
     ]
   },
   {
@@ -25064,7 +25064,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      31790
+      "DS2_OGRE_CORSAIR_VINE_LADDER"
     ]
   },
   {
@@ -25082,7 +25082,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      32119
+      "DS2_LITHKREN_DUNGEON_BRAZIER"
     ]
   },
   {
@@ -25100,8 +25100,8 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      6661,
-      6665
+      "TOG_WEEPING_WALL_GOOD_R",
+      "TOG_WEEPING_WALL_GOOD_L"
     ]
   },
   {
@@ -25119,8 +25119,8 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      6662,
-      6666
+      "TOG_WEEPING_WALL_BAD_R",
+      "TOG_WEEPING_WALL_BAD_L"
     ]
   },
   {
@@ -25138,7 +25138,7 @@
     "duration": 0,
     "range": 7.5,
     "objectIds": [
-      41467
+      "BIM_RUINS_WALLKIT_STREETLAMP01"
     ]
   },
   {
@@ -25156,7 +25156,7 @@
     "duration": 1700,
     "range": 30,
     "objectIds": [
-      41585
+      "DECOKIT_CRYSTAL_BARRONITE01"
     ]
   },
   {
@@ -25174,8 +25174,8 @@
     "duration": 2200,
     "range": 20,
     "objectIds": [
-      41547,
-      41548
+      "CAMDOZAALROCK1",
+      "CAMDOZAALROCK2"
     ]
   },
   {
@@ -25193,8 +25193,8 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      41412,
-      41481
+      "BIM_RUINS_WALLKIT_SACRED_FORGE_OP",
+      "BIM_RUINS_WALLKIT_SACRED_FORGE"
     ]
   },
   {
@@ -25212,7 +25212,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      41520
+      "BIM_VAULT_WALL01"
     ]
   },
   {
@@ -25230,7 +25230,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      41588
+      "CAVEKIT_WATERFALL_CAMDOZAAL"
     ]
   },
   {
@@ -25248,7 +25248,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      41565
+      "CAVEKIT_IMCANDO_STALAGMITE01"
     ]
   },
   {
@@ -25266,7 +25266,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      41236
+      "TEMPOROSS_SHRINE_FIRE"
     ]
   },
   {
@@ -25284,7 +25284,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      37582
+      "TEMPOROSS_FIRE_VISUALS"
     ]
   },
   {
@@ -25302,10 +25302,10 @@
     "duration": 0,
     "range": 40,
     "objectIds": [
-      41242,
-      41243,
-      41244,
-      41245
+      "TEMPOROSS_CANNON_1_DISABLED",
+      "TEMPOROSS_CANNON_2_DISABLED",
+      "TEMPOROSS_CANNON_3_DISABLED",
+      "TEMPOROSS_CANNON_4_DISABLED"
     ]
   },
   {
@@ -25322,7 +25322,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      41724
+      "CLAN_HUB_PORTAL"
     ]
   },
   {
@@ -25340,7 +25340,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      20868
+      "LIGHT_MIND_BEAM"
     ]
   },
   {
@@ -25358,7 +25358,7 @@
     "duration": 2100,
     "range": 20,
     "objectIds": [
-      38451
+      "HALLOWED_EXIT"
     ],
     "visibleFromOtherPlanes": true
   },
@@ -25377,7 +25377,7 @@
     "duration": 1000,
     "range": 10,
     "objectIds": [
-      38829
+      "HALLOWED_TREASURE_MAGIC_FINAL"
     ]
   },
   {
@@ -25395,8 +25395,8 @@
     "duration": 1000,
     "range": 10,
     "objectIds": [
-      38798,
-      38801
+      "HALLOWED_TREASURE_PRAYER_READY",
+      "HALLOWED_TREASURE_PRAYER_READY_MIRROR"
     ]
   },
   {
@@ -25414,7 +25414,7 @@
     "duration": 600,
     "range": 10,
     "objectIds": [
-      38804
+      "HALLOWED_TREASURE_PRAYER_BARRIER_READY"
     ]
   },
   {
@@ -25432,7 +25432,7 @@
     "duration": 600,
     "range": 10,
     "objectIds": [
-      38840
+      "HALLOWED_FINAL_CHEST_BARRIER_INACTIVE"
     ]
   },
   {
@@ -25450,7 +25450,7 @@
     "duration": 600,
     "range": 10,
     "objectIds": [
-      38841
+      "HALLOWED_FINAL_CHEST_BARRIER_ACTIVE"
     ]
   },
   {
@@ -25461,7 +25461,7 @@
     "strength": 25,
     "color": "#5577ff",
     "graphicsObjectIds": [
-      1799
+      "HALLOWED_TELEPAD_TELEGRAPH_FORWARD"
     ]
   },
   {
@@ -25472,7 +25472,7 @@
     "strength": 5,
     "color": "#ffff00",
     "graphicsObjectIds": [
-      1800
+      "HALLOWED_TELEPAD_TELEGRAPH_BACKWARD"
     ]
   },
   {
@@ -25485,11 +25485,11 @@
     "type": "FLICKER",
     "range": 50,
     "objectIds": [
-      38427
+      "HALLOWED_FIRE_TRAP_ANIMATIONS"
     ],
     "animationIds": [
-      8660,
-      8663
+      "HALLOWED_STATUE_READY_FIRE_BLAST",
+      "HALLOWED_STATUE_END_FIRE_BLAST"
     ]
   },
   {
@@ -25502,11 +25502,11 @@
     "type": "FLICKER",
     "range": 50,
     "objectIds": [
-      38427
+      "HALLOWED_FIRE_TRAP_ANIMATIONS"
     ],
     "animationIds": [
-      8661,
-      8662
+      "HALLOWED_STATUE_START_FIRE_BLAST",
+      "HALLOWED_STATUE_FIRE_BLAST"
     ]
   },
   {
@@ -25524,8 +25524,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      38797,
-      38800
+      "HALLOWED_TREASURE_PRAYER_INACTIVE",
+      "HALLOWED_TREASURE_PRAYER_INACTIVE_MIRROR"
     ]
   },
   {
@@ -25543,8 +25543,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      38799,
-      38802
+      "HALLOWED_TREASURE_PRAYER_FINAL",
+      "HALLOWED_TREASURE_PRAYER_FINAL_MIRROR"
     ]
   },
   {
@@ -25562,7 +25562,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      39152
+      "DARKM_STREET_LAMP"
     ]
   },
   {
@@ -25581,8 +25581,8 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      32992,
-      32990
+      "TOB_TREASUREROOM_CHEST_MINE_STANDARD",
+      "TOB_TREASUREROOM_CHEST_NOTMINE_STANDARD"
     ]
   },
   {
@@ -25600,8 +25600,8 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      32993,
-      32991
+      "TOB_TREASUREROOM_CHEST_MINE_RARE",
+      "TOB_TREASUREROOM_CHEST_NOTMINE_RARE"
     ]
   },
   {
@@ -25618,8 +25618,8 @@
     "duration": 30,
     "range": 20,
     "objectIds": [
-      32998,
-      32999
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_INSIDE_CORNER",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_OUTSIDE_CORNER"
     ]
   },
   {
@@ -25637,7 +25637,7 @@
     "duration": 1800,
     "range": 10,
     "objectIds": [
-      32996
+      "TOB_TREASUREROOM_TELEPORTOUT"
     ]
   },
   {
@@ -25658,7 +25658,7 @@
     "duration": 2200,
     "range": 30,
     "objectIds": [
-      32743
+      "TOB_XARPUS_EXHUMED"
     ]
   },
   {
@@ -25676,7 +25676,7 @@
     "duration": 2200,
     "range": 30,
     "objectIds": [
-      32662
+      "TOB_SURFACE_CASTLE_WINDOW_SINGLE"
     ]
   },
   {
@@ -25694,7 +25694,7 @@
     "duration": 2200,
     "range": 30,
     "objectIds": [
-      32755
+      "TOB_ARENA_BARRIER"
     ]
   },
   {
@@ -25712,8 +25712,8 @@
     "duration": 2200,
     "range": 30,
     "objectIds": [
-      33028,
-      47336
+      "TOB_WALKWAY_VERZIK_BARRIER",
+      "TOB_WALKWAY_VERZIK_BARRIER_OP"
     ]
   },
   {
@@ -25731,7 +25731,7 @@
     "duration": 1800,
     "range": 5,
     "objectIds": [
-      32957
+      "TOB_BLOAT_CHAMBER"
     ]
   },
   {
@@ -25748,7 +25748,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      32691
+      "TOB_DUNGEON_VERZIK_THRONE_WINDOW"
     ]
   },
   {
@@ -25765,7 +25765,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      32697
+      "TOB_DUNGEON_VERZIK_THRONE_WALL_WINDOW"
     ]
   },
   {
@@ -25782,7 +25782,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      32698
+      "TOB_DUNGEON_VERZIK_THRONE_WALL_WINDOW_LIGHT"
     ]
   },
   {
@@ -25799,7 +25799,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      33052
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_G"
     ]
   },
   {
@@ -25816,7 +25816,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      33052
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_G"
     ]
   },
   {
@@ -25833,7 +25833,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      33052
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_G"
     ]
   },
   {
@@ -25850,7 +25850,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      32776
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_BATLAMP"
     ]
   },
   {
@@ -25868,10 +25868,10 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      34748,
-      34749,
-      34752,
-      34751
+      "AIRTEMPLE_EXIT_PORTAL",
+      "MINDTEMPLE_EXIT_PORTAL",
+      "FIRETEMPLE_EXIT_PORTAL",
+      "EARTHTEMPLE_EXIT_PORTAL"
     ]
   },
   {
@@ -25889,8 +25889,8 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      34750,
-      34791
+      "WATERTEMPLE_EXIT_PORTAL",
+      "RUNETEMPLE_STANDINGSTONE_GLOW_WATER"
     ]
   },
   {
@@ -25908,8 +25908,8 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      34793,
-      34753
+      "RUNETEMPLE_STANDINGSTONE_GLOW_BODY",
+      "BODYTEMPLE_EXIT_PORTAL"
     ]
   },
   {
@@ -25927,7 +25927,7 @@
     "duration": 500,
     "range": 20,
     "objectIds": [
-      34790
+      "RUNETEMPLE_STANDINGSTONE_GLOW_AIR"
     ]
   },
   {
@@ -25945,7 +25945,7 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      34792
+      "RUNETEMPLE_STANDINGSTONE_GLOW_FIRE"
     ]
   },
   {
@@ -25963,17 +25963,17 @@
     "duration": 2200,
     "range": 30,
     "objectIds": [
-      20208,
-      20209,
-      20199,
-      20200,
-      20201,
-      20202,
-      20203,
-      20204,
-      20205,
-      20206,
-      20207
+      "BARBASSAULT_DOOR_10",
+      "BARBASSAULT_DOOR_NO_FRIENDS",
+      "BARBASSAULT_DOOR_01",
+      "BARBASSAULT_DOOR_02",
+      "BARBASSAULT_DOOR_03",
+      "BARBASSAULT_DOOR_04",
+      "BARBASSAULT_DOOR_05",
+      "BARBASSAULT_DOOR_06",
+      "BARBASSAULT_DOOR_07",
+      "BARBASSAULT_DOOR_08",
+      "BARBASSAULT_DOOR_09"
     ]
   },
   {
@@ -25991,7 +25991,7 @@
     "duration": 500,
     "range": 20,
     "objectIds": [
-      26274
+      "NZONE_LOBBY_WALLBLOCK"
     ]
   },
   {
@@ -26009,7 +26009,7 @@
     "duration": 800,
     "range": 20,
     "objectIds": [
-      34789
+      "RUNETEMPLE_STANDINGSTONE_GLOW"
     ]
   },
   {
@@ -26027,9 +26027,9 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      2156,
-      2157,
-      2158
+      "WIZTOWERPORTAL",
+      "DARKWIZPORTAL",
+      "THORMACPORTAL"
     ]
   },
   {
@@ -26047,11 +26047,11 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      22760,
-      22761,
-      22762,
-      22764,
-      22976
+      "DORGESH_LAMP_POST_LIGHT",
+      "DORGESH_LAMP_MARKET_LIGHT",
+      "DORGESH_LAMP_STAND_LIGHT",
+      "DORGESH_LAMP_STAND_LIGHT_OPEN",
+      "DORGESH_LAMP_STAND_LIGHT_ON"
     ]
   },
   {
@@ -26069,9 +26069,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      22736,
-      22737,
-      22735
+      "DORGESH_ZAPPER_LIGHT_INACTIVE",
+      "DORGESH_ZAPPER_LIGHT_ACTIVE",
+      "DORGESH_ZAPPER_LIGHT"
     ]
   },
   {
@@ -26089,7 +26089,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      22826
+      "DORGESH_OLDAK_PLASMA_BALL"
     ]
   },
   {
@@ -26107,7 +26107,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      22823
+      "DORGESH_OLDAK_CONDUCTOR_COIL"
     ]
   },
   {
@@ -26125,7 +26125,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      22721
+      "DORGESH_BLACKSMITH_FURNACE_COMBINE"
     ]
   },
   {
@@ -26143,7 +26143,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      43146
+      "LOTG_YU_CAMPFIRE"
     ]
   },
   {
@@ -26161,7 +26161,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      43089
+      "LOTG_TEMPLE_ALTAR"
     ]
   },
   {
@@ -26179,7 +26179,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      9098
+      "BLAST_FURNACE_CHIMNEY"
     ]
   },
   {
@@ -26196,7 +26196,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      9087
+      "BLAST_FURNACE_STOVE_FULL"
     ]
   },
   {
@@ -26213,7 +26213,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      9087
+      "BLAST_FURNACE_STOVE_FULL"
     ]
   },
   {
@@ -26231,7 +26231,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      15469
+      "POH_TAXIDERMIST_LOC_ITEM"
     ]
   },
   {
@@ -26249,7 +26249,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      26181
+      "RANGE"
     ]
   },
   {
@@ -26266,7 +26266,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      205
+      "LANTERN"
     ]
   },
   {
@@ -26284,7 +26284,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      26570
+      "HELLHOUND_LAIR_TORCH"
     ]
   },
   {
@@ -26302,9 +26302,9 @@
     "duration": 2200,
     "range": 10,
     "objectIds": [
-      42939,
-      42940,
-      42941
+      "NEX_FIGHT_BARRIER_OUTER_BUSY",
+      "NEX_FIGHT_BARRIER_OUTER_PRIV_BUSY",
+      "NEX_FIGHT_BARRIER_INNER_BUSY"
     ]
   },
   {
@@ -26322,7 +26322,7 @@
     "duration": 2200,
     "range": 10,
     "objectIds": [
-      42937, 42938
+      "NEX_FIGHT_BARRIER_OUTER", "NEX_FIGHT_BARRIER_OUTER_PRIV"
     ]
   },
   {
@@ -26340,7 +26340,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      42859
+      "NEX_FURNACE_NOOP"
     ]
   },
   {
@@ -26358,7 +26358,7 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      20843
+      "FORESTER_FORCEWALL"
     ]
   },
   {
@@ -26376,7 +26376,7 @@
     "duration": 2800,
     "range": 30,
     "objectIds": [
-      14985
+      "MACRO_MAZE_COMPLETE"
     ]
   },
   {
@@ -26396,7 +26396,7 @@
     "fadeInDuration": 1500,
     "fadeOutDuration": 1300,
     "graphicsObjectIds": [
-      803
+      "AIDE_PLAYER_BOOK_PORTAL"
     ]
   },
   {
@@ -26419,7 +26419,7 @@
     "fadeInDuration": 150,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      678
+      "POH_ABSORB_TABLET_MAGIC"
     ]
   },
   {
@@ -26439,7 +26439,7 @@
     "fadeInDuration": 1500,
     "fadeOutDuration": 1300,
     "graphicsObjectIds": [
-      1753
+      "LEAGUE_TWISTED_PLAYER_BOOK_PORTAL"
     ]
   },
   {
@@ -26459,7 +26459,7 @@
     "spawnDelay": 850,
     "fadeInDuration": 1000,
     "graphicsObjectIds": [
-      2619
+      "LEAGUE_4_HOME_TELEPORT_SPOTANIM_3"
     ]
   },
   {
@@ -26478,7 +26478,7 @@
     "range": 20,
     "fadeOutDuration": 1500,
     "graphicsObjectIds": [
-      2620
+      "LEAGUE_4_HOME_TELEPORT_SPOTANIM_4"
     ]
   },
   {
@@ -26497,7 +26497,7 @@
     "range": 20,
     "fadeInDuration": 1500,
     "graphicsObjectIds": [
-      2028
+      "LEAGUE03_HOME_TELEPORT_SPOTANIM_4"
     ]
   },
   {
@@ -26516,7 +26516,7 @@
     "range": 20,
     "fadeOutDuration": 1000,
     "graphicsObjectIds": [
-      2029
+      "LEAGUE03_HOME_TELEPORT_SPOTANIM_5"
     ]
   },
   {
@@ -26539,7 +26539,7 @@
     "despawnDelay": 100,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      2608
+      "SPOTANIM_CASTLOWLVLALCHEMY_FIRE"
     ]
   },
   {
@@ -26563,7 +26563,7 @@
     "despawnDelay": 2200,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      2609
+      "SPOTANIM_CASTHIGHLVLALCHEMY_FIRE"
     ]
   },
   {
@@ -26587,7 +26587,7 @@
     "despawnDelay": 100,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      2608
+      "SPOTANIM_CASTLOWLVLALCHEMY_FIRE"
     ]
   },
   {
@@ -26611,7 +26611,7 @@
     "despawnDelay": 2300,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      2609
+      "SPOTANIM_CASTHIGHLVLALCHEMY_FIRE"
     ]
   },
   {
@@ -26635,8 +26635,8 @@
     "despawnDelay": 550,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      2608,
-      2609
+      "SPOTANIM_CASTLOWLVLALCHEMY_FIRE",
+      "SPOTANIM_CASTHIGHLVLALCHEMY_FIRE"
     ]
   },
   {
@@ -26660,8 +26660,8 @@
     "despawnDelay": 550,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      2608,
-      2609
+      "SPOTANIM_CASTLOWLVLALCHEMY_FIRE",
+      "SPOTANIM_CASTHIGHLVLALCHEMY_FIRE"
     ]
   },
   {
@@ -26683,7 +26683,7 @@
     "fadeInDuration": 1350,
     "fadeOutDuration": 450,
     "graphicsObjectIds": [
-      2610
+      "TRAILBLAZER_DEATH_SPOTANIM"
     ]
   },
   {
@@ -26705,7 +26705,7 @@
     "fadeOutDuration": 450,
     "despawnDelay" : 900,
     "graphicsObjectIds": [
-      2611
+      "TRAILBLAZER_SPAWN_SPOTANIM"
     ]
   },
   {
@@ -26727,7 +26727,7 @@
     "fadeInDuration": 300,
     "fadeOutDuration": 300,
     "graphicsObjectIds": [
-      2605
+      "TRAILBLAZER_VENGEANCE_SPOTANIM_01"
     ]
   },
   {
@@ -26749,7 +26749,7 @@
     "fadeInDuration": 300,
     "fadeOutDuration": 300,
     "graphicsObjectIds": [
-      2605
+      "TRAILBLAZER_VENGEANCE_SPOTANIM_01"
     ]
   },
   {
@@ -26771,7 +26771,7 @@
     "fadeInDuration": 300,
     "fadeOutDuration": 300,
     "graphicsObjectIds": [
-      2605
+      "TRAILBLAZER_VENGEANCE_SPOTANIM_01"
     ]
   },
   {
@@ -26795,7 +26795,7 @@
     "despawnDelay": 875,
     "fadeOutDuration": 75,
     "graphicsObjectIds": [
-      148
+      "SUPERHEATITEM_CASTING"
     ]
   },
   {
@@ -26813,7 +26813,7 @@
     "duration": 0,
     "range": 10,
     "projectileIds": [
-      143
+      "TELEGRAB_TRAVEL"
     ]
   },
   {
@@ -26831,7 +26831,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      91
+      "WINDSTRIKE_TRAVEL"
     ]
   },
   {
@@ -26849,7 +26849,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      94
+      "WATERSTRIKE_TRAVEL"
     ]
   },
   {
@@ -26867,7 +26867,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      97
+      "EARTHSTRIKE_TRAVEL"
     ]
   },
   {
@@ -26885,7 +26885,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      100
+      "FIRESTRIKE_TRAVEL"
     ]
   },
   {
@@ -26903,7 +26903,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      118
+      "WINDBOLT_TRAVEL"
     ]
   },
   {
@@ -26921,7 +26921,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      121
+      "WATERBOLT_TRAVEL"
     ]
   },
   {
@@ -26939,7 +26939,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      124
+      "EARTHBOLT_TRAVEL"
     ]
   },
   {
@@ -26957,7 +26957,7 @@
     "fadeOutDuration": 250,
     "fadeInDuration": 1000,
     "projectileIds": [
-      127
+      "FIREBOLT_TRAVEL"
     ]
   },
   {
@@ -26975,7 +26975,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      133
+      "WINDBLAST_TRAVEL"
     ]
   },
   {
@@ -26993,7 +26993,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      136
+      "WATERBLAST_TRAVEL"
     ]
   },
   {
@@ -27011,7 +27011,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      139
+      "EARTHBLAST_TRAVEL"
     ]
   },
   {
@@ -27029,7 +27029,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      130
+      "FIREBLAST_TRAVEL"
     ]
   },
   {
@@ -27047,7 +27047,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      159
+      "WINDWAVE_TRAVEL"
     ]
   },
   {
@@ -27065,7 +27065,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      162
+      "WATERWAVE_TRAVEL"
     ]
   },
   {
@@ -27083,7 +27083,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      165
+      "EARTHWAVE_TRAVEL"
     ]
   },
   {
@@ -27101,7 +27101,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      156
+      "FIREWAVE_TRAVEL"
     ]
   },
   {
@@ -27119,7 +27119,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      1456
+      "WINDSURGE_TRAVEL"
     ]
   },
   {
@@ -27137,7 +27137,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      1459
+      "WATERSURGE_TRAVEL"
     ]
   },
   {
@@ -27155,7 +27155,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      1462
+      "EARTHSURGE_TRAVEL"
     ]
   },
   {
@@ -27173,7 +27173,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      1465
+      "FIRESURGE_TRAVEL"
     ]
   },
   {
@@ -27190,7 +27190,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      103
+      "CONFUSE_TRAVEL"
     ]
   },
   {
@@ -27207,7 +27207,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      106
+      "WEAKEN_TRAVEL"
     ]
   },
   {
@@ -27224,7 +27224,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      109
+      "CURSE_TRAVEL"
     ]
   },
   {
@@ -27241,7 +27241,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      168
+      "VULNERABILITY_TRAVEL"
     ]
   },
   {
@@ -27258,7 +27258,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      171
+      "ENFEEBLE_TRAVEL"
     ]
   },
   {
@@ -27275,7 +27275,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      174
+      "STUN_TRAVEL"
     ]
   },
   {
@@ -27292,7 +27292,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      178
+      "ENTANGLE_TRAVEL"
     ]
   },
   {
@@ -27309,7 +27309,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      146
+      "CRUMBLEUNDEAD_TRAVEL"
     ]
   },
   {
@@ -27326,7 +27326,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      328
+      "SLAYER_MAGICDART_TRAVEL"
     ]
   },
   {
@@ -27343,7 +27343,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      88
+      "IBANBLAST_TRAVEL"
     ]
   },
   {
@@ -27360,7 +27360,7 @@
     "range": 20,
     "fadeInDuration": 1000,
     "projectileIds": [
-      344
+      "BALLISTA_SPECIAL"
     ]
   },
   {
@@ -27377,7 +27377,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      1040
+      "TOXIC_TOTS_PROJECTILE"
     ]
   },
   {
@@ -27394,7 +27394,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      1252
+      "SLAYER_TOTS_PROJECTILE"
     ]
   },
   {
@@ -27412,7 +27412,7 @@
     "range": 10,
     "fadeOutDuration": 250,
     "projectileIds": [
-      2569
+      "VFX_WARPED_SCEPTRE_PROJECTILE_PROJECTILE"
     ]
   },
   {
@@ -27429,7 +27429,7 @@
     "fadeInDuration": 400,
     "fadeOutDuration": 600,
     "projectileIds": [
-      2126
+      "TUMEKENS_SHADOW_TRAVEL"
     ]
   },
   {
@@ -27448,7 +27448,7 @@
     "fadeInDuration": 100,
     "fadeOutDuration": 175,
     "graphicsObjectIds": [
-      2125
+      "TUMEKENS_SHADOW_CASTING"
     ]
   },
   {
@@ -27465,7 +27465,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      384
+      "SMOKE_RUSH_TRAVEL"
     ]
   },
   {
@@ -27482,7 +27482,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      378
+      "SHADOW_RUSH_TRAVEL"
     ]
   },
   {
@@ -27499,7 +27499,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      360
+      "ICE_RUSH_TRAVEL"
     ]
   },
   {
@@ -27516,7 +27516,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      386
+      "SMOKE_BLITZ_TRAVEL"
     ]
   },
   {
@@ -27533,7 +27533,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      380
+      "SHADOW_BLITZ_TRAVEL"
     ]
   },
   {
@@ -27550,7 +27550,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      374
+      "BLOOD_BLITZ_TRAVEL"
     ]
   },
   {
@@ -27572,7 +27572,7 @@
     "fadeInDuration": 200,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1856
+      "GHOSTLY_GRASP_CAST_SPOTANIM"
     ]
   },
   {
@@ -27595,8 +27595,8 @@
     "fadeInDuration": 200,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1857,
-      1858
+      "GHOSTLY_GRASP_HIT_SPOTANIM",
+      "GHOSTLY_GRASP_MISS_SPOTANIM"
     ]
   },
   {
@@ -27619,8 +27619,8 @@
     "fadeInDuration": 75,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      1857,
-      1858
+      "GHOSTLY_GRASP_HIT_SPOTANIM",
+      "GHOSTLY_GRASP_MISS_SPOTANIM"
     ]
   },
   {
@@ -27642,7 +27642,7 @@
     "fadeInDuration": 200,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1859
+      "SKELETAL_GRASP_CAST_SPOTANIM"
     ]
   },
   {
@@ -27665,8 +27665,8 @@
     "fadeInDuration": 200,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1860,
-      1861
+      "SKELETAL_GRASP_HIT_SPOTANIM",
+      "SKELETAL_GRASP_MISS_SPOTANIM"
     ]
   },
   {
@@ -27689,8 +27689,8 @@
     "fadeInDuration": 75,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      1860,
-      1861
+      "SKELETAL_GRASP_HIT_SPOTANIM",
+      "SKELETAL_GRASP_MISS_SPOTANIM"
     ]
   },
   {
@@ -27712,7 +27712,7 @@
     "fadeInDuration": 200,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1862
+      "UNDEAD_GRASP_CAST_SPOTANIM"
     ]
   },
   {
@@ -27735,8 +27735,8 @@
     "fadeInDuration": 200,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1863,
-      1864
+      "UNDEAD_GRASP_HIT_SPOTANIM",
+      "UNDEAD_GRASP_MISS_SPOTANIM"
     ]
   },
   {
@@ -27759,8 +27759,8 @@
     "fadeInDuration": 75,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      1863,
-      1864
+      "UNDEAD_GRASP_HIT_SPOTANIM",
+      "UNDEAD_GRASP_MISS_SPOTANIM"
     ]
   },
   {
@@ -27783,7 +27783,7 @@
     "despawnDelay": 1450,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1865
+      "INFERIOR_DEMONBANE_CAST_SPOTANIM"
     ]
   },
   {
@@ -27806,7 +27806,7 @@
     "despawnDelay": 500,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1866
+      "INFERIOR_DEMONBANE_HIT_SPOTANIM"
     ]
   },
   {
@@ -27829,7 +27829,7 @@
     "despawnDelay": 1450,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1867
+      "SUPERIOR_DEMONBANE_CAST_SPOTANIM"
     ]
   },
   {
@@ -27852,7 +27852,7 @@
     "despawnDelay": 500,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1868
+      "SUPERIOR_DEMONBANE_HIT_SPOTANIM"
     ]
   },
   {
@@ -27875,7 +27875,7 @@
     "despawnDelay": 1450,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1869
+      "DARK_DEMONBANE_CAST_SPOTANIM"
     ]
   },
   {
@@ -27898,7 +27898,7 @@
     "despawnDelay": 500,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1870
+      "DARK_DEMONBANE_HIT_SPOTANIM"
     ]
   },
   {
@@ -27920,7 +27920,7 @@
     "fadeOutDuration": 250,
     "despawnDelay": 1000,
     "graphicsObjectIds": [
-      1877
+      "LESSER_CORRUPTION_CAST_SPOTANIM"
     ]
   },
   {
@@ -27943,7 +27943,7 @@
     "spawnDelay": 1000,
     "despawnDelay": 600,
     "graphicsObjectIds": [
-      1877
+      "LESSER_CORRUPTION_CAST_SPOTANIM"
     ]
   },
   {
@@ -27963,7 +27963,7 @@
     "fadeInDuration": 250,
     "fadeOutDuration": 125,
     "graphicsObjectIds": [
-      1878
+      "GREATER_CORRUPTION_CAST_SPOTANIM"
     ]
   },
   {
@@ -27982,7 +27982,7 @@
     "fadeInDuration": 250,
     "fadeOutDuration": 250,
     "projectileIds": [
-      1883
+      "DARK_LURE_TRAVEL_PROJANIM"
     ]
   },
   {
@@ -28005,7 +28005,7 @@
     "despawnDelay": 1350,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1876
+      "VILE_VIGOUR_CAST_SPOTANIM"
     ]
   },
   {
@@ -28028,7 +28028,7 @@
     "despawnDelay": 1350,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1852
+      "MARK_OF_DARKNESS_CAST_SPOTANIM"
     ]
   },
   {
@@ -28052,7 +28052,7 @@
     "despawnDelay": 1500,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1852
+      "MARK_OF_DARKNESS_CAST_SPOTANIM"
     ]
   },
   {
@@ -28072,7 +28072,7 @@
     "fadeInDuration": 150,
     "fadeOutDuration": 150,
     "graphicsObjectIds": [
-      1886
+      "MARK_OF_DARKNESS_END_SPOTANIM"
     ]
   },
   {
@@ -28095,7 +28095,7 @@
     "despawnDelay": 2250,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1851
+      "WARD_OF_ARCEUUS_CAST_SPOTANIM"
     ]
   },
   {
@@ -28116,7 +28116,7 @@
     "spawnDelay": 500,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1854
+      "DEATH_CHARGE_CAST_SPOTANIM"
     ]
   },
   {
@@ -28139,7 +28139,7 @@
     "despawnDelay": 1250,
     "fadeOutDuration": 200,
     "graphicsObjectIds": [
-      1296
+      "ARCEUUS_TELEPORT_SPOTANIM"
     ]
   },
   {
@@ -28156,7 +28156,7 @@
     "range": 0,
     "fadeInDuration": 300,
     "projectileIds": [
-      249
+      "SP_ATTACK_GLOW_ARROW_TRAVEL"
     ]
   },
   {
@@ -28173,7 +28173,7 @@
     "range": 0,
     "fadeInDuration": 300,
     "projectileIds": [
-      1574
+      "WILD_CAVE_BOW_ARROW_TRAVEL"
     ]
   },
   {
@@ -28190,7 +28190,7 @@
     "range": 30,
     "fadeInDuration": 300,
     "projectileIds": [
-      17
+      "FIRE_ARROW_TRAVEL"
     ]
   },
   {
@@ -28207,7 +28207,7 @@
     "range": 0,
     "fadeInDuration": 300,
     "projectileIds": [
-      301
+      "ACB_SPECIALATTACK"
     ]
   },
   {
@@ -28224,7 +28224,7 @@
     "range": 0,
     "fadeInDuration": 500,
     "projectileIds": [
-      450
+      "TZHAAR_FIRE_SPIT_END_TRAVEL"
     ]
   },
   {
@@ -28241,7 +28241,7 @@
     "range": 0,
     "fadeInDuration": 500,
     "projectileIds": [
-      54
+      "FIREBREATH_TRAVEL"
     ]
   },
   {
@@ -28258,7 +28258,7 @@
     "range": 0,
     "fadeInDuration": 1000,
     "projectileIds": [
-      1679
+      "HOSDUN_DRUID_WAVE_TRAVEL"
     ]
   },
   {
@@ -28330,7 +28330,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      23105
+      "HELLHOUND_FIREWALL"
     ]
   },
   {
@@ -28348,7 +28348,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      21773
+      "SOUL_SKULL_EATER"
     ]
   },
   {
@@ -28366,7 +28366,7 @@
     "duration": 0,
     "range": 20,
     "npcIds": [
-      8144
+      "DS2_DRAGON_HEAD_LIT"
     ]
   },
   {
@@ -28384,12 +28384,12 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      32215,
-      32216,
-      32217,
-      32218,
-      32219,
-      32220
+      "DS2_AC_FORGE_ANVIL",
+      "DS2_AC_FORGE_ANVIL_UNLIT",
+      "DS2_AC_FORGE_BLANK",
+      "DS2_AC_FORGE_FLOW",
+      "DS2_AC_FORGE_INSIDE_CORNER",
+      "DS2_AC_FORGE_OUTER_CORNER"
     ]
   },
   {
@@ -28407,7 +28407,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      32213
+      "DS2_AC_FORGE_DRAGON_HEAD_LIT"
     ]
   },
   {
@@ -28425,9 +28425,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      32224,
-      32222,
-      32223
+      "DS2_AC_FORGE_WALL_WITH_HOLE",
+      "DS2_AC_FORGE_FLOOR_LIT_CORNER",
+      "DS2_AC_FORGE_FLOOR_LIT_STRAIGHT"
     ]
   },
   {
@@ -28445,7 +28445,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      32210
+      "DS2_DRAGONKIN_ORB_LIT"
     ]
   },
   {
@@ -28463,7 +28463,7 @@
     "duration": 1200,
     "range": 10,
     "objectIds": [
-      43765
+      "TOTE_PORTAL_TO_GOTR_CHILD"
     ]
   },
   {
@@ -28499,7 +28499,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      43695
+      "GOTR_REWARD_RIFT"
     ]
   },
   {
@@ -28517,7 +28517,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      43696
+      "GOTR_DEPOSITCHEST"
     ]
   },
   {
@@ -28535,9 +28535,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43704,
-      43787,
-      43812
+      "GOTR_PORTAL_FIRE",
+      "TOTE_PORTAL_FIRE",
+      "TOTE_TUTORIAL_PORTAL_FIRE"
     ]
   },
   {
@@ -28555,9 +28555,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43711,
-      43794,
-      43819
+      "GOTR_PORTAL_NATURE",
+      "TOTE_PORTAL_NATURE",
+      "TOTE_TUTORIAL_PORTAL_NATURE"
     ]
   },
   {
@@ -28575,9 +28575,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43703,
-      43786,
-      43811
+      "GOTR_PORTAL_EARTH",
+      "TOTE_PORTAL_EARTH",
+      "TOTE_TUTORIAL_PORTAL_EARTH"
     ]
   },
   {
@@ -28595,10 +28595,10 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43702,
-      43785,
-      43810,
-      43821
+      "GOTR_PORTAL_WATER",
+      "TOTE_PORTAL_WATER",
+      "TOTE_TUTORIAL_PORTAL_WATER",
+      "TOTE_PORTAL_WATER_ACTIVE"
     ]
   },
   {
@@ -28616,9 +28616,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43710,
-      43793,
-      43818
+      "GOTR_PORTAL_COSMIC",
+      "TOTE_PORTAL_COSMIC",
+      "TOTE_TUTORIAL_PORTAL_COSMIC"
     ]
   },
   {
@@ -28636,9 +28636,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43701,
-      43784,
-      43809
+      "GOTR_PORTAL_AIR",
+      "TOTE_PORTAL_AIR",
+      "TOTE_TUTORIAL_PORTAL_AIR"
     ]
   },
   {
@@ -28656,10 +28656,10 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43705,
-      43788,
-      43813,
-      43822
+      "GOTR_PORTAL_MIND",
+      "TOTE_PORTAL_MIND",
+      "TOTE_TUTORIAL_PORTAL_MIND",
+      "TOTE_PORTAL_MIND_ACTIVE"
     ]
   },
   {
@@ -28677,9 +28677,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43709,
-      43792,
-      43817
+      "GOTR_PORTAL_BODY",
+      "TOTE_PORTAL_BODY",
+      "TOTE_TUTORIAL_PORTAL_BODY"
     ]
   },
   {
@@ -28697,9 +28697,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43706,
-      43789,
-      43814
+      "GOTR_PORTAL_CHAOS",
+      "TOTE_PORTAL_CHAOS",
+      "TOTE_TUTORIAL_PORTAL_CHAOS"
     ]
   },
   {
@@ -28717,9 +28717,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43707,
-      43790,
-      43815
+      "GOTR_PORTAL_DEATH",
+      "TOTE_PORTAL_DEATH",
+      "TOTE_TUTORIAL_PORTAL_DEATH"
     ]
   },
   {
@@ -28737,9 +28737,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43712,
-      43795,
-      43820
+      "GOTR_PORTAL_LAW",
+      "TOTE_PORTAL_LAW",
+      "TOTE_TUTORIAL_PORTAL_LAW"
     ]
   },
   {
@@ -28757,9 +28757,9 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43708,
-      43791,
-      43816
+      "GOTR_PORTAL_BLOOD",
+      "TOTE_PORTAL_BLOOD",
+      "TOTE_TUTORIAL_PORTAL_BLOOD"
     ]
   },
   {
@@ -28777,8 +28777,8 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43729,
-      43730
+      "GOTR_AGILITY_PORTAL_TOP",
+      "GOTR_AGILITY_PORTAL_BOTTOM_CHILD"
     ]
   },
   {
@@ -28796,7 +28796,7 @@
     "duration": 4000,
     "range": 28,
     "objectIds": [
-      27029
+      "NEXUS_FONT_01"
     ]
   },
   {
@@ -28814,14 +28814,14 @@
     "duration": 1200,
     "range": 15,
     "objectIds": [
-      43713,
-      43714
+      "GOTR_ABYSSAL_RIFT",
+      "GOTR_ABYSSAL_RIFT_PHASE1"
     ]
   },
   {
     "description": "SIRE_BELLY_LIGHT_LOWER",
     "offset": [ 0, 250, 100 ],
-    "npcIds": [ 5890, 5889, 5891 ],
+    "npcIds": [ "ABYSSALSIRE_SIRE_WANDERING", "ABYSSALSIRE_SIRE_PUPPET", "ABYSSALSIRE_SIRE_PANICKING" ],
     "radius": 250,
     "strength": 125,
     "color": [
@@ -28836,7 +28836,7 @@
   {
     "description": "SIRE_BELLY_LIGHT_UPPER",
     "offset": [ 0, 350, 75 ],
-    "npcIds": [ 5890, 5889, 5891 ],
+    "npcIds": [ "ABYSSALSIRE_SIRE_WANDERING", "ABYSSALSIRE_SIRE_PUPPET", "ABYSSALSIRE_SIRE_PANICKING" ],
     "radius": 100,
     "strength": 125,
     "color": [
@@ -28851,7 +28851,7 @@
   {
     "description": "SIRE_BELLY_LIGHT_EXPLOSION",
     "offset": [ 0, 325, 200 ],
-    "npcIds": [ 5908 ],
+    "npcIds": [ "ABYSSALSIRE_SIRE_APOCALYPSE" ],
     "radius": 350,
     "strength": 200,
     "color": [
@@ -28864,8 +28864,8 @@
   {
     "description": "SIRE_BELLY_LIGHT_EXPLOSION_2",
     "offset": [ 0, 150, 275 ],
-    "npcIds": [ 5908 ],
-    "animationIds": [ -1, 7098, 7099 ],
+    "npcIds": [ "ABYSSALSIRE_SIRE_APOCALYPSE" ],
+    "animationIds": [ "SWARM_ATTACK", "SIRE_APOCALYPSE", "SIRE_IDLE_FOUR" ],
     "radius": 450,
     "strength": 15,
     "color": [
@@ -28883,7 +28883,7 @@
   {
     "description": "SIRE_THRONE_LIGHT",
     "offset": [ -50, 170, 50 ],
-    "objectIds": [ 26984 ],
+    "objectIds": [ "NEXUS_STASIS_CHAMBER_11" ],
     "radius": 700,
     "strength": 25,
     "color": [
@@ -28910,9 +28910,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      27014,
-      27015,
-      27016
+      "NEXUS_TENDRILS",
+      "NEXUS_TENDRILS_CORNER",
+      "NEXUS_TENDRILS_FALLOFF"
     ]
   },
   {
@@ -28926,7 +28926,7 @@
       242,
       31
     ],
-    "objectIds": [ 26953 ],
+    "objectIds": [ "NEXUS_LUNG_WHEEZING" ],
     "fadeInDuration": 200,
     "fadeOutDuration": 200
   },
@@ -28945,7 +28945,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43700
+      "GOTR_BARRIER"
     ]
   },
   {
@@ -28963,7 +28963,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43849
+      "GOTR_BARRIER_CLOSED"
     ]
   },
   {
@@ -28981,8 +28981,8 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43744,
-      43745
+      "GOTR_BARRIER_TIER1",
+      "GOTR_BARRIER_TIER1_3X3"
     ]
   },
   {
@@ -29000,8 +29000,8 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43746,
-      43747
+      "GOTR_BARRIER_TIER2",
+      "GOTR_BARRIER_TIER2_3X3"
     ]
   },
   {
@@ -29019,8 +29019,8 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43748,
-      43749
+      "GOTR_BARRIER_TIER3",
+      "GOTR_BARRIER_TIER3_3X3"
     ]
   },
   {
@@ -29038,8 +29038,8 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      43750,
-      43751
+      "GOTR_BARRIER_TIER4",
+      "GOTR_BARRIER_TIER4_3X3"
     ]
   },
   {
@@ -29057,7 +29057,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      43740
+      "GOTR_CELL_TILE_TIER1"
     ]
   },
   {
@@ -29075,7 +29075,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      43741
+      "GOTR_CELL_TILE_TIER2"
     ]
   },
   {
@@ -29093,7 +29093,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      43742
+      "GOTR_CELL_TILE_TIER3"
     ]
   },
   {
@@ -29111,7 +29111,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      43743
+      "GOTR_CELL_TILE_TIER4"
     ]
   },
   {
@@ -29128,23 +29128,23 @@
     "type": "FLICKER",
     "duration": 10,
     "range": 30,
-    "npcIds": [ 8612 ]
+    "npcIds": [ "DRAKE" ]
   },
   {
-  "description": "Drake Back Wound Left",
-  "height": 300,
-  "offset": [ -100, 0, -100 ],
-  "radius": 175,
-  "strength": 30,
-  "color": [
-    255,
-    0,
-    0
-  ],
-  "type": "FLICKER",
-  "duration": 10,
-  "range": 30,
-  "npcIds": [ 8612 ]
+    "description": "Drake Back Wound Left",
+    "height": 300,
+    "offset": [ -100, 0, -100 ],
+    "radius": 175,
+    "strength": 30,
+    "color": [
+      255,
+      0,
+      0
+    ],
+    "type": "FLICKER",
+    "duration": 10,
+    "range": 30,
+    "npcIds": [ "DRAKE" ]
   },
   {
     "description": "Drake Back Wound Front",
@@ -29160,8 +29160,8 @@
     "type": "FLICKER",
     "duration": 10,
     "range": 30,
-    "npcIds": [ 8612 ],
-    "animationIds": [ -1, 8276 ],
+    "npcIds": [ "DRAKE" ],
+    "animationIds": [ "SWARM_ATTACK", "DRAKE_RANGED" ],
     "fadeOutDuration": 300,
     "fadeInDuration": 750
   },
@@ -29175,8 +29175,8 @@
     "type": "FLICKER",
     "duration": 10,
     "range": 5,
-    "npcIds": [ 8612 ],
-    "animationIds": [ -1 ],
+    "npcIds": [ "DRAKE" ],
+    "animationIds": [ "SWARM_ATTACK" ],
     "fadeInDuration": 300
   },
   {
@@ -29192,7 +29192,7 @@
     "type": "FLICKER",
     "duration": 1,
     "range": 80,
-    "projectileIds": [ 1636 ],
+    "projectileIds": [ "DRAKE_RANGE_PROJ" ],
     "spawnDelay": 800,
     "fadeInDuration": 300,
     "fadeOutDuration": 100
@@ -29206,7 +29206,7 @@
     "type": "FLICKER",
     "duration": 5,
     "range": 60,
-    "projectileIds": [ 1637 ],
+    "projectileIds": [ "DRAKE_BURN_PROJ" ],
     "spawnDelay": 255,
     "fadeInDuration": 150,
     "fadeOutDuration": 150
@@ -29220,7 +29220,7 @@
     "type": "FLICKER",
     "duration": 2,
     "range": 80,
-    "graphicsObjectIds": [ 1638 ],
+    "graphicsObjectIds": [ "DRAKE_BURN_IMPACT" ],
     "fadeInDuration": 50,
     "fadeOutDuration": 50
   },
@@ -29237,7 +29237,7 @@
     "type": "FLICKER",
     "duration": 10,
     "range": 70,
-    "npcIds": [ 8610 ],
+    "npcIds": [ "WYRM_DARK" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 100
   },
@@ -29254,7 +29254,7 @@
     "type": "FLICKER",
     "duration": 10,
     "range": 70,
-    "npcIds": [ 10398 ],
+    "npcIds": [ "SUPERIOR_WYRM_DARK" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 100
   },
@@ -29272,7 +29272,7 @@
     "type": "FLICKER",
     "duration": 1,
     "range": 80,
-    "projectileIds": [ 1634 ],
+    "projectileIds": [ "WYRM_RANGE_PROJ" ],
     "spawnDelay": 400,
     "fadeInDuration": 300,
     "fadeOutDuration": 100
@@ -29290,7 +29290,7 @@
     "type": "FLICKER",
     "duration": 10,
     "range": 70,
-    "projectileIds": [ 1814 ],
+    "projectileIds": [ "SUPERIOR_WYRM_RANGE_PROJ" ],
     "spawnDelay": 400,
     "fadeInDuration": 300,
     "fadeOutDuration": 100
@@ -30804,7 +30804,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      34335
+      "BRIMSTONE_LAVA_CRATER"
     ]
   },
   {
@@ -30860,8 +30860,8 @@
     "fadeInDuration": 50,
     "fadeOutDuration": 100,
     "objectIds": [
-      29314,
-      31926
+      "WINT_BRAZIER_LIT",
+      "OSB5_BRAZIER_LIT"
     ]
   },
   {
@@ -30878,8 +30878,8 @@
     "duration": 10,
     "range": 45,
     "objectIds": [
-      29314,
-      31926
+      "WINT_BRAZIER_LIT",
+      "OSB5_BRAZIER_LIT"
     ]
   },
   {
@@ -30897,7 +30897,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      29322
+      "WINT_DOOR"
     ]
   },
   {
@@ -30915,7 +30915,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      29322
+      "WINT_DOOR"
     ]
   },
   {
@@ -30933,7 +30933,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      29322
+      "WINT_DOOR"
     ]
   },
   {
@@ -30951,7 +30951,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      29322
+      "WINT_DOOR"
     ]
   },
   {
@@ -30969,7 +30969,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      14437
+      "WILD_FALLOFF_CRATER"
     ]
   },
   {
@@ -30987,7 +30987,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      14438
+      "WILD_FALLOFF_CRATER_SMALL"
     ]
   },
   {
@@ -31005,7 +31005,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      14419
+      "WILD_FALLOFF4"
     ]
   },
   {
@@ -31516,7 +31516,7 @@
       38
     ],
     "objectIds": [
-      44624
+      "GIANTS_FOUNDRY_CRUCIBLE_FULL"
     ],
     "type": "PULSE",
     "duration": 7000,
@@ -31534,7 +31534,7 @@
       38
     ],
     "objectIds": [
-      44627
+      "GIANTS_FOUNDRY_JIG_MOULD_FILLED"
     ],
     "type": "PULSE",
     "duration": 7000,
@@ -31555,7 +31555,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      28562
+      "LOVAKENGJ_FURNACE_LARGE_01"
     ]
   },
   {
@@ -31573,7 +31573,7 @@
     "duration": 200,
     "range": 15,
     "objectIds": [
-      29088
+      "WCGUILD_SHRINE"
     ]
   },
   {
@@ -31591,7 +31591,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      40149
+      "CON_CONTRACT_FALADOR_SOUTH_RANGE_FIXED"
     ]
   },
   {
@@ -31609,7 +31609,7 @@
     "duration": 2000,
     "range": 10,
     "objectIds": [
-      31969
+      "SHAYZIENQUEST_CRYSTAL"
     ]
   },
   {
@@ -31627,7 +31627,7 @@
     "duration": 2000,
     "range": 10,
     "objectIds": [
-      31970
+      "SHAYZIENQUEST_CRYSTAL_LARGE"
     ]
   },
   {
@@ -31645,7 +31645,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      32524
+      "SHAY_CAVE_XERIC_RELIEF"
     ]
   },
   {
@@ -31663,8 +31663,8 @@
     "duration": 500,
     "range": 10,
     "objectIds": [
-      44023,
-      44024
+      "BCS_MAGIC_FIRE_SMALL_1",
+      "BCS_MAGIC_FIRE_SMALL_2"
     ]
   },
   {
@@ -31682,7 +31682,7 @@
     "duration": 1000,
     "range": 10,
     "objectIds": [
-      44022
+      "BCS_MAGIC_FIRE"
     ]
   },
   {
@@ -31700,7 +31700,7 @@
     "duration": 800,
     "range": 7,
     "objectIds": [
-      4767
+      "MM_PYRE"
     ]
   },
   {
@@ -31718,7 +31718,7 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      28687
+      "MM2_CAVE_BOSS_EXIT"
     ]
   },
   {
@@ -31772,7 +31772,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34562
+      "KARUULM_HYDRA_ROOM_FLOOR_VIAL_LARGE_BLUE"
     ]
   },
   {
@@ -31790,7 +31790,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34563
+      "KARUULM_HYDRA_ROOM_FLOOR_VIAL_LARGE_GREEN"
     ]
   },
   {
@@ -31808,7 +31808,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34564
+      "KARUULM_HYDRA_ROOM_FLOOR_VIAL_LARGE_RED"
     ]
   },
   {
@@ -31826,7 +31826,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34571
+      "KARUULM_HYDRA_ROOM_FLOOR_LONG_PIPE_BLUE"
     ]
   },
   {
@@ -31844,7 +31844,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34572
+      "KARUULM_HYDRA_ROOM_FLOOR_LONG_PIPE_GREEN"
     ]
   },
   {
@@ -31862,7 +31862,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34573
+      "KARUULM_HYDRA_ROOM_FLOOR_LONG_PIPE_RED"
     ]
   },
   {
@@ -31880,7 +31880,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34565
+      "KARUULM_HYDRA_ROOM_WALL_PIPE_BLUE"
     ]
   },
   {
@@ -31898,7 +31898,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34566
+      "KARUULM_HYDRA_ROOM_WALL_PIPE_GREEN"
     ]
   },
   {
@@ -31916,7 +31916,7 @@
     "duration": 7000,
     "range": 50,
     "objectIds": [
-      34567
+      "KARUULM_HYDRA_ROOM_WALL_PIPE_RED"
     ]
   },
   {
@@ -31934,13 +31934,13 @@
     "duration": 600,
     "range": 10,
     "objectIds": [
-      46089,
-      46090,
-      46164,
-      46161,
-      46155,
-      46158,
-      46167
+      "TOA_LOBBY_RAID_ENTRY",
+      "TOA_LOBBY_RAID_ENTRY_NOOP",
+      "TOA_NEXUS_HET_DOOR",
+      "TOA_NEXUS_CRONDIS_DOOR",
+      "TOA_NEXUS_SCABARAS_DOOR",
+      "TOA_NEXUS_APMEKEN_DOOR",
+      "TOA_NEXUS_WARDENS_DOOR"
     ]
   },
   {
@@ -31958,7 +31958,7 @@
     "duration": 600,
     "range": 4,
     "objectIds": [
-      46168
+      "TOA_NEXUS_WARDENS_DOOR_OPEN"
     ]
   },
   {
@@ -32109,11 +32109,11 @@
     "duration": 1800,
     "range": 9,
     "objectIds": [
-      45505,
-      45506,
-      45579,
-      45754,
-      45866
+      "KEPHRI_TELEPORT",
+      "ZEBAK_TELEPORT",
+      "WARDENS_TELEPORT",
+      "BABA_TELEPORT",
+      "AKKHA_TELEPORT"
     ]
   },
   {
@@ -32131,7 +32131,7 @@
     "duration": 600,
     "range": 10,
     "objectIds": [
-      45334
+      "TOA_FX_FIRE01_SMALL01"
     ]
   },
   {
@@ -32149,8 +32149,8 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      45135,
-      45335
+      "TOA_PATH_BARRIER",
+      "TOA_SCABARAS_BARRIER"
     ]
   },
   {
@@ -32168,7 +32168,7 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      45499
+      "TOA_PATH_APMEKEN_VENT"
     ]
   },
   {
@@ -32186,8 +32186,8 @@
     "duration": 1400,
     "range": 5,
     "graphicsObjectIds": [
-      2134,
-      2135
+      "TOA_PATH_APMEKEN_SIGHT_WARNING",
+      "TOA_PATH_APMEKEN_SIGHT_WARNING02"
     ]
   },
   {
@@ -32205,7 +32205,7 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      45344
+      "TOA_SCABARAS_LIGHTSOUT_TILE_OFF"
     ]
   },
   {
@@ -32223,18 +32223,18 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      45341,
-      45384,
-      45386,
-      45387,
-      45388,
-      45389,
-      45390,
-      45391,
-      45392,
-      45393,
-      45394,
-      45395
+      "TOA_SCABARAS_SIMONSAYS_TILE_DOWN",
+      "TOA_SCABARAS_FX01",
+      "TOA_SCABARAS_FX03",
+      "TOA_SCABARAS_FX04",
+      "TOA_SCABARAS_FX05",
+      "TOA_SCABARAS_FX06",
+      "TOA_SCABARAS_FX07",
+      "TOA_SCABARAS_FX08",
+      "TOA_SCABARAS_FX09",
+      "TOA_SCABARAS_FX10",
+      "TOA_SCABARAS_FX11",
+      "TOA_SCABARAS_FX12"
     ]
   },
   {
@@ -32252,7 +32252,7 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      45342
+      "TOA_SCABARAS_SIMONSAYS_TILE_DOWN_PLAYER"
     ]
   },
   {
@@ -32270,7 +32270,7 @@
     "duration": 600,
     "range": 3,
     "npcIds": [
-      11699
+      "TOA_SCABARAS_GUESSER_OBELISK_HIT"
     ]
   },
   {
@@ -32288,7 +32288,7 @@
     "duration": 1800,
     "range": 5,
     "npcIds": [
-      11706
+      "TOA_HET_GOAL"
     ]
   },
   {
@@ -32306,7 +32306,7 @@
     "duration": 1800,
     "range": 5,
     "npcIds": [
-      11707
+      "TOA_HET_GOAL_VULNERABLE"
     ]
   },
   {
@@ -32324,7 +32324,7 @@
     "duration": 1800,
     "range": 2,
     "npcIds": [
-      11708
+      "TOA_HET_ORB"
     ]
   },
   {
@@ -32341,7 +32341,7 @@
     "range": 3,
     "fadeInDuration": 0,
     "projectileIds": [
-      2253
+      "AKKHA_MAGIC_TRAVEL"
     ]
   },
   {
@@ -32358,8 +32358,8 @@
     "range": 3,
     "fadeInDuration": 0,
     "projectileIds": [
-      1481,
-      2266
+      "VORKATH_AREA_TRAVEL",
+      "VORKATH_AREA_TRAVEL_SMALL"
     ]
   },
   {
@@ -32377,7 +32377,7 @@
     "duration": 400,
     "range": 3,
     "objectIds": [
-      45868
+      "AKKHA_SYMBOL_GLOW_BURN"
     ]
   },
   {
@@ -32395,7 +32395,7 @@
     "duration": 400,
     "range": 3,
     "objectIds": [
-      45869
+      "AKKHA_SYMBOL_GLOW_LIGHTNING"
     ]
   },
   {
@@ -32413,7 +32413,7 @@
     "duration": 400,
     "range": 3,
     "objectIds": [
-      45870
+      "AKKHA_SYMBOL_GLOW_FREEZE"
     ]
   },
   {
@@ -32431,7 +32431,7 @@
     "duration": 400,
     "range": 3,
     "objectIds": [
-      45871
+      "AKKHA_SYMBOL_GLOW_DARKNESS"
     ]
   },
   {
@@ -32449,7 +32449,7 @@
     "duration": 600,
     "range": 5,
     "npcIds": [
-      11804
+      "AKKHA_ENRAGE_ORB"
     ]
   },
   {
@@ -32467,7 +32467,7 @@
     "duration": 300,
     "range": 3,
     "projectileIds": [
-      2181
+      "ZEBAK_MAGE_PROJANIM_SPLIT"
     ]
   },
   {
@@ -32485,7 +32485,7 @@
     "duration": 300,
     "range": 3,
     "objectIds": [
-      45525
+      "TOA_WALL_CROCODILES04"
     ]
   },
   {
@@ -32503,7 +32503,7 @@
     "duration": 600,
     "range": 3,
     "npcIds": [
-      11694
+      "TOA_MIDRAIDLOOT_TRADER"
     ]
   },
   {
@@ -32521,9 +32521,9 @@
     "duration": 600,
     "range": 2,
     "npcIds": [
-      11750,
-      11751,
-      11752
+      "TOA_WARDENS_P1_OBELISK_NPC_INACTIVE",
+      "TOA_WARDENS_P1_OBELISK_NPC",
+      "TOA_WARDENS_P2_OBELISK_NPC"
     ]
   },
   {
@@ -32541,7 +32541,7 @@
     "duration": 600,
     "range": 2,
     "npcIds": [
-      11769
+      "TOA_WARDENS_ENERGY"
     ]
   },
   {
@@ -32559,25 +32559,25 @@
     "duration": 600,
     "range": 2,
     "objectIds": [
-      45607,
-      45608,
-      45609,
-      45610,
-      45611,
-      45612,
-      45613,
-      45614,
-      45615,
-      45616,
-      45617,
-      45618,
-      45619,
-      45620,
-      45621,
-      45622,
-      45623,
-      45624,
-      45625
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_1",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_2",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_3",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_4",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_5",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_6",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_7",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_8",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_9",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_10",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_11",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_12",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_13",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_14",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_15",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_16",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_17",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_18",
+      "TOA_WARDENS_DEFAULT_CHARGING_PLATFORM_19"
     ]
   },
   {
@@ -32595,7 +32595,7 @@
     "duration": 600,
     "range": 2,
     "objectIds": [
-      45748
+      "TOA_WARDENS_PYRAMID01"
     ]
   },
   {
@@ -32613,7 +32613,7 @@
     "duration": 600,
     "range": 2,
     "objectIds": [
-      45750
+      "TOA_WARDENS_PYRAMID01_LOAD"
     ]
   },
   {
@@ -32631,7 +32631,7 @@
     "duration": 600,
     "range": 2,
     "objectIds": [
-      45749
+      "TOA_WARDENS_PYRAMID02"
     ]
   },
   {
@@ -32649,7 +32649,7 @@
     "duration": 600,
     "range": 2,
     "objectIds": [
-      45751
+      "TOA_WARDENS_PYRAMID02_LOAD"
     ]
   },
   {
@@ -32665,7 +32665,7 @@
     "duration": 600,
     "range": 2,
     "projectileIds": [
-      2237
+      "SPOTANIM_WARDENS_PHASE01_BALL01"
     ]
   },
   {
@@ -32681,7 +32681,7 @@
     "duration": 600,
     "range": 2,
     "projectileIds": [
-      2238
+      "SPOTANIM_WARDENS_PHASE01_BALL02"
     ]
   },
   {
@@ -32697,7 +32697,7 @@
     "duration": 300,
     "range": 2,
     "projectileIds": [
-      2224
+      "FX_WARDENS_BOMB01"
     ]
   },
   {
@@ -32713,7 +32713,7 @@
     "duration": 300,
     "range": 2,
     "projectileIds": [
-      2225
+      "FX_WARDENS_BOMB02"
     ]
   },
   {
@@ -32730,12 +32730,12 @@
     "duration": 300,
     "range": 2,
     "projectileIds": [
-      2239,
-      2240
+      "PROJECTILE_WARDEN_TUMEKEN_CORE",
+      "PROJECTILE_WARDEN_ELIDINIS_CORE"
     ],
     "npcIds": [
-      11770,
-      11771
+      "TOA_WARDEN_TUMEKEN_CORE",
+      "TOA_WARDEN_ELIDINIS_CORE"
     ]
   },
   {
@@ -32751,7 +32751,7 @@
     "duration": 300,
     "range": 2,
     "projectileIds": [
-      2204
+      "TOA_WARDENS_PRAYER_MELEE_TRAVEL"
     ]
   },
   {
@@ -32767,7 +32767,7 @@
     "duration": 300,
     "range": 2,
     "projectileIds": [
-      2206
+      "TOA_WARDENS_PRAYER_RANGED_TRAVEL"
     ]
   },
   {
@@ -32783,7 +32783,7 @@
     "duration": 300,
     "range": 2,
     "projectileIds": [
-      2208
+      "TOA_WARDENS_PRAYER_MAGIC_TRAVEL"
     ]
   },
   {
@@ -32800,10 +32800,10 @@
     "duration": 1800,
     "range": 3,
     "npcIds": [
-      11761,
-      11762,
-      11763,
-      11764
+      "TOA_WARDEN_ELIDINIS_PHASE3",
+      "TOA_WARDEN_TUMEKEN_PHASE3",
+      "TOA_WARDEN_ELIDINIS_PHASE3_CHARGING",
+      "TOA_WARDEN_TUMEKEN_PHASE3_CHARGING"
     ]
   },
   {
@@ -32820,10 +32820,10 @@
     "duration": 1800,
     "range": 3,
     "npcIds": [
-      11774,
-      11775,
-      11776,
-      11777
+      "TOA_WARDENS_ZEBAK",
+      "TOA_WARDENS_BABA",
+      "TOA_WARDENS_KEPHRI",
+      "TOA_WARDENS_AKKHA"
     ]
   },
   {
@@ -32840,7 +32840,7 @@
     "duration": 300,
     "range": 2,
     "npcIds": [
-      11772
+      "WARDENS_P3_ORB_BLUE"
     ]
   },
   {
@@ -32858,8 +32858,8 @@
     "range": 2,
     "fadeOutDuration": 200,
     "projectileIds": [
-      2226,
-      2227
+      "FX_WARDENS_BOMB03",
+      "FX_WARDENS_CHARGING01"
     ]
   },
   {
@@ -32876,7 +32876,7 @@
     "duration": 300,
     "range": 2,
     "npcIds": [
-      11773
+      "WARDENS_P3_ORB_RED"
     ]
   },
   {
@@ -32895,7 +32895,7 @@
     "range": 2,
     "fadeInDuration": 1200,
     "objectIds": [
-      45138
+      "TOA_TELEPORT_CRYSTAL_CONTINUE_WARDENS"
     ]
   },
   {
@@ -32913,7 +32913,7 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      44825
+      "TOA_VAULT_SARCOPHAGUS_CLOSED"
     ]
   },
   {
@@ -32947,7 +32947,7 @@
     "duration": 600,
     "range": 3,
     "objectIds": [
-      23072
+      "SUROK_TUNNEL_WALL_LAMP"
     ]
   },
   {
@@ -32965,9 +32965,9 @@
     "duration": 1550,
     "range": 50,
     "objectIds": [
-      23095,
-      23093,
-      34757
+      "SUROK_ENTRANCE_PORTAL",
+      "SUROK_EXIT_PORTAL_COMPLETE",
+      "CHAOSTEMPLE_EXIT_PORTAL"
     ]
   },
   {
@@ -32985,8 +32985,8 @@
     "duration": 1028,
     "range": 50,
     "objectIds": [
-      16691,
-      16692
+      "LUNAR_MOONCLAN_HAT_RACK",
+      "LUNAR_MOONCLAN_HAT_EMPTY"
     ]
   },
   {
@@ -33004,7 +33004,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      16702
+      "LUNAR_MOONCLAN_COOKER_SMALL"
     ]
   },
   {
@@ -33022,7 +33022,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      16703
+      "LUNAR_MOONCLAN_COOKER_WITH_KETTLE"
     ]
   },
   {
@@ -33039,7 +33039,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      16701
+      "LUNAR_MOONCLAN_LIGHT_HANGING"
     ]
   },
   {
@@ -33057,7 +33057,7 @@
     "duration": 1800,
     "range": 10,
     "objectIds": [
-      46692
+      "GHORROCK_DOOR_SHIELD01"
     ]
   },
   {
@@ -33075,7 +33075,7 @@
     "duration": 0,
     "range": 3,
     "objectIds": [
-      46647
+      "GHORROCK_WALL_CANDLE01"
     ]
   },
   {
@@ -33093,7 +33093,7 @@
     "duration": 0,
     "range": 3,
     "objectIds": [
-      46629
+      "GHORROCK_STONE01_PILLAR02"
     ]
   },
   {
@@ -33111,7 +33111,7 @@
     "duration": 0,
     "range": 3,
     "objectIds": [
-      46615
+      "SOTN_GHORROCK_BRAZIER_LIT"
     ]
   },
   {
@@ -33128,7 +33128,7 @@
     "duration": 1800,
     "range": 7,
     "objectIds": [
-      46636
+      "GHORROCK_STONE01_ALCOVE02_PLAQUE"
     ]
   },
   {
@@ -33145,7 +33145,7 @@
     "duration": 1800,
     "range": 7,
     "objectIds": [
-      46636
+      "GHORROCK_STONE01_ALCOVE02_PLAQUE"
     ]
   },
   {
@@ -33160,7 +33160,7 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      46701
+      "ANCIENT_ESSENCE_ROCK_ACTIVE"
     ]
   },
   {
@@ -33176,7 +33176,7 @@
     "duration": 300,
     "range": 2,
     "projectileIds": [
-      2327
+      "PROJECTILE_MUSPAH_ATTACK_MAGIC_01"
     ],
     "fadeInDuration": 300
   },
@@ -33192,9 +33192,9 @@
     "fadeInDuration": 100,
     "fadeOutDuration": 100,
     "npcIds": [
-      12199,
-      12200,
-      12201
+      "DUKE_EXTREMITY_CONE_1",
+      "DUKE_EXTREMITY_CONE_2",
+      "DUKE_EXTREMITY_CONE_3"
     ]
   },
   {
@@ -33212,7 +33212,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      210
+      "ICE_LIGHT"
     ]
   },
   {
@@ -33230,7 +33230,7 @@
     "duration": 600,
     "range": 10,
     "objectIds": [
-      201
+      "GNOME_LAMP2"
     ]
   },
   {
@@ -33247,7 +33247,7 @@
     "duration": 1300,
     "range": 100,
     "objectIds": [
-      21085
+      "PENG_BASE_SPINNING_LIGHT"
     ]
   },
   {
@@ -33265,7 +33265,7 @@
     "duration": 1250,
     "range": 60,
     "objectIds": [
-      726
+      "FAIRY_SPARKLE"
     ]
   },
   {
@@ -33283,8 +33283,8 @@
     "duration": 1250,
     "range": 20,
     "objectIds": [
-      12009,
-      12011
+      "FAIRY_WALL_MUSH_GREEN",
+      "FAIRY_WALL_MUSH_GREEN_VAR"
     ]
   },
   {
@@ -33302,7 +33302,7 @@
     "duration": 1250,
     "range": 20,
     "objectIds": [
-      12020
+      "FAIRY_WALL_TOP_MUSH_GREEN"
     ]
   },
   {
@@ -33320,7 +33320,7 @@
     "duration": 1250,
     "range": 20,
     "objectIds": [
-      12021
+      "FAIRY_WALL_TOP_TENTACLE"
     ]
   },
   {
@@ -33338,8 +33338,8 @@
     "duration": 1250,
     "range": 20,
     "objectIds": [
-      12010,
-      12012
+      "FAIRY_WALL_MUSH_RED",
+      "FAIRY_WALL_MUSH_RED_VAR"
     ]
   },
   {
@@ -33357,7 +33357,7 @@
     "duration": 1250,
     "range": 20,
     "objectIds": [
-      12019
+      "FAIRY_WALL_TOP_MUSH_RED"
     ]
   },
   {
@@ -33375,7 +33375,7 @@
     "duration": 5000,
     "range": 20,
     "objectIds": [
-      12124
+      "FAIRY_MUSHROOM_RAILING"
     ]
   },
   {
@@ -33393,7 +33393,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      207
+      "SKULLTORCH_GRUBBY"
     ]
   },
   {
@@ -33411,7 +33411,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      12400
+      "_100_GOBLIN_CAULDREN_STILL"
     ]
   },
   {
@@ -33429,7 +33429,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      12356
+      "HUNDRED_EXIT_PORTAL"
     ]
   },
   {
@@ -33446,7 +33446,7 @@
     "duration": 0,
     "range": 23,
     "objectIds": [
-      12934
+      "BURGH_INN_BASEMENT_TORCH"
     ]
   },
   {
@@ -33464,7 +33464,7 @@
     "duration": 0,
     "range": 24,
     "objectIds": [
-      17324
+      "QIP_DIGSITE_SWING_LANTERN"
     ]
   },
   {
@@ -33500,7 +33500,7 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      3434
+      "LANTERN_POST"
     ]
   },
   {
@@ -33518,7 +33518,7 @@
     "duration": 0,
     "range": 24,
     "objectIds": [
-      24172
+      "FAI_FALADOR_LANTERN"
     ]
   },
   {
@@ -33537,7 +33537,7 @@
     "duration": 3000,
     "range": 10,
     "objectIds": [
-      29630
+      "RC_ZMI_CRATER_LAVA_BIG"
     ]
   },
   {
@@ -33556,7 +33556,7 @@
     "duration": 3000,
     "range": 10,
     "objectIds": [
-      29629
+      "RC_ZMI_CRATER_LAVA"
     ]
   },
   {
@@ -33594,12 +33594,12 @@
     "duration": 600,
     "range": 15,
     "objectIds": [
-      49335
+      "DT2_SCAR_FIRE03"
     ]
   },
   {
     "description": "The Scar exit portal",
-    "objectIds": [ 49204 ],
+    "objectIds": [ "DT2_SCAR_RIFT" ],
     "alignment": "CENTER",
     "radius": 2500,
     "height": 256,
@@ -33628,7 +33628,7 @@
     "duration": 600,
     "range": 15,
     "objectIds": [
-      49342
+      "DT2_SCAR_PERSTENCAMP_FIRE01"
     ]
   },
   {
@@ -33645,7 +33645,7 @@
     "range": 3,
     "fadeInDuration": 0,
     "projectileIds": [
-      2489
+      "VFX_LEVIATHAN_01_PROJECTILE_MAGIC_01"
     ]
   },
   {
@@ -33662,7 +33662,7 @@
     "range": 3,
     "fadeInDuration": 0,
     "projectileIds": [
-      2487
+      "VFX_LEVIATHAN_01_PROJECTILE_RANGED_01"
     ]
   },
   {
@@ -33679,7 +33679,7 @@
     "range": 3,
     "fadeInDuration": 0,
     "projectileIds": [
-      2488
+      "VFX_LEVIATHAN_01_PROJECTILE_MELEE_01"
     ]
   },
   {
@@ -33692,7 +33692,7 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      48004
+      "LASSAR_THRONE01_DEFAULT01"
     ]
   },
   {
@@ -33710,7 +33710,7 @@
     "range": 3,
     "fadeInDuration": 0,
     "objectIds": [
-      48252
+      "DT2_LASSAR_SHADOW_BRAZIER_LIT_PERMANENTLY"
     ]
   },
   {
@@ -33726,7 +33726,7 @@
     "range": 2,
     "fadeInDuration": 0,
     "objectIds": [
-      48189
+      "LIGHT_LAMP01_LASSAR01"
     ]
   },
   {
@@ -33743,7 +33743,7 @@
     "fadeInDuration": 0,
     "visibleFromOtherPlanes": true,
     "objectIds": [
-      47945
+      "LIGHT_LAMP01_LASSAR01_SHADOW"
     ]
   },
   {
@@ -33759,7 +33759,7 @@
     "range": 3,
     "fadeInDuration": 0,
     "objectIds": [
-      48202
+      "DT2_LASSAR_TELEPORTER_ACTIVE"
     ]
   },
   {
@@ -33774,8 +33774,8 @@
     "duration": 600,
     "range": 5,
     "objectIds": [
-      48218,
-      48219
+      "DT2_LASSAR_ANIMA_PORTAL_NORMAL",
+      "DT2_LASSAR_ANIMA_PORTAL_SHADOW"
     ]
   },
   {
@@ -33790,7 +33790,7 @@
     "duration": 600,
     "range": 5,
     "npcIds": [
-      12234
+      "DT2_LASSAR_GHOST"
     ]
   },
   {
@@ -33808,7 +33808,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      11601
+      "FAI_BARBARIAN_POTTERY_OVEN"
     ]
   },
   {
@@ -33826,8 +33826,8 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      10760,
-      10766
+      "MAGICTRAINING_DUNGEONWALL_LIGHT",
+      "MAGICTRAINING_DUNGEONWALL_BONES_LIGHT"
     ]
   },
   {
@@ -33845,7 +33845,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      10720
+      "MAGICTRAINING_CANDLE_STAND"
     ]
   },
   {
@@ -33863,11 +33863,11 @@
     "duration": 1100,
     "range": 20,
     "objectIds": [
-      23673,
-      23674,
-      23675,
-      23676,
-      23677
+      "MAGICTRAINING_TELEDOOR",
+      "MAGICTRAINING_ENCHANTDOOR",
+      "MAGICTRAINING_ALCHEMDOOR",
+      "MAGICTRAINING_GRAVEDOOR",
+      "MAGICTRAINING_RETURNDOOR"
     ]
   },
   {
@@ -33885,7 +33885,7 @@
     "duration": 1100,
     "range": 20,
     "objectIds": [
-      10733
+      "MAGICTRAINING_HIDDEN_PORTAL_ENTRANCE1"
     ]
   },
   {
@@ -33903,7 +33903,7 @@
     "duration": 600,
     "range": 20,
     "objectIds": [
-      10738
+      "MAGICTRAINING_STATUE_WATER"
     ]
   },
   {
@@ -33921,10 +33921,10 @@
     "duration": 1254,
     "range": 15,
     "graphicsObjectIds": [
-      520,
-      521,
-      522,
-      523
+      "MAGICTRAINING_BONE_DROP1",
+      "MAGICTRAINING_BONE_DROP2",
+      "MAGICTRAINING_BONE_DROP3",
+      "MAGICTRAINING_BONE_DROP4"
     ]
   },
   {
@@ -33940,12 +33940,12 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      10721
+      "MAGICTRAINING_TEMPLE_DOOR"
     ]
   },
   {
     "description": "Xamphur during cutscene",
-    "npcIds": [ 10951 ],
+    "npcIds": [ "AKD_XAMPHUR_CUTSCENE" ],
     "radius": 400,
     "strength": 50,
     "height": 100,
@@ -33960,7 +33960,7 @@
   },
   {
     "description": "Xamphur during fight",
-    "npcIds": [ 10954, 10955, 10953, 10956 ],
+    "npcIds": [ "AKD_XAMPHUR_CUTSCENE_TRANSITION_B", "AKD_XAMPHUR_COMBAT", "AKD_XAMPHUR_CUTSCENE_TRANSITION_A", "AKD_XAMPHUR_COMBAT_NOHANDS" ],
     "radius": 700,
     "strength": 70,
     "height": 100,
@@ -33975,7 +33975,7 @@
   },
   {
     "description": "Xamphur phantom hands",
-    "npcIds": [ 10957, 10958 ],
+    "npcIds": [ "AKD_XAMPHUR_HAND_LEFT", "AKD_XAMPHUR_HAND_RIGHT" ],
     "radius": 300,
     "strength": 40,
     "height": 80,
@@ -33987,7 +33987,7 @@
   },
   {
     "description": "Xamphur mark of darkness",
-    "objectIds": [ 41881 ],
+    "objectIds": [ "AKD_XAMPHUR_MARK" ],
     "radius": 300,
     "strength": 50,
     "height": 40,
@@ -34013,10 +34013,10 @@
     "duration": 1550,
     "range": 20,
     "objectIds": [
-      19005,
-      20786,
-      23707,
-      23922
+      "SOS_FAM_PORTAL",
+      "SOS_WAR_PORTAL",
+      "SOS_PEST_PORTAL",
+      "SOS_DEATH_PORTAL"
     ]
   },
   {
@@ -34032,8 +34032,8 @@
     "type": "STATIC",
     "range": 20,
     "objectIds": [
-      19204,
-      19205
+      "SOS_WAR_WALL_LIGHT",
+      "SOS_WAR_WALL_LIGHT_UP"
     ]
   },
   {
@@ -34050,7 +34050,7 @@
     "type": "STATIC",
     "range": 20,
     "objectIds": [
-      19211
+      "SOS_WAR_DOOR_TOP"
     ]
   },
   {
@@ -34066,7 +34066,7 @@
     "type": "STATIC",
     "range": 20,
     "objectIds": [
-      17004
+      "SOS_FAM_WALL_LITE"
     ]
   },
   {
@@ -34083,7 +34083,7 @@
     "type": "STATIC",
     "range": 20,
     "objectIds": [
-      23651
+      "SOS_PEST_WALL_LIGHT"
     ]
   },
   {
@@ -34099,8 +34099,8 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      23653,
-      23654
+      "SOS_PEST_DOOR_FACE",
+      "SOS_PEST_DOOR_FACE_MIRR"
     ]
   },
   {
@@ -34117,7 +34117,7 @@
     "duration": 500,
     "range": 20,
     "objectIds": [
-      23716
+      "SOS_DEATH_WALL_LIGHT_GLOW"
     ]
   },
   {
@@ -34135,10 +34135,10 @@
     "duration": 1200,
     "range": 4,
     "objectIds": [
-      19000,
-      20656,
-      23709,
-      23731
+      "SOS_FAM_SACK",
+      "SOS_WAR_CHEST",
+      "SOS_PEST_CHEST",
+      "SOS_DEATH_PRAM"
     ]
   },
   {
@@ -34154,7 +34154,7 @@
     ],
     "type": "FLICKER",
     "range": 10,
-    "objectIds": [ 33311 ]
+    "objectIds": [ "MY2ARM_THRONEROOM_FIRE_NORMAL" ]
   },
   {
     "description": "Weiss Saltmine Entrance",
@@ -34176,7 +34176,7 @@
   },
   {
     "description": "Summoning circle powered - The Scar",
-    "objectIds": [ 49450 ],
+    "objectIds": [ "DT2_SCAR_MAZE_3_LINK_RITUAL_CIRCLE" ],
     "height": 200,
     "color": [
       196,
@@ -34188,7 +34188,7 @@
   },
   {
     "description": "Summoning circle - The Scar",
-    "objectIds": [ 49451 ],
+    "objectIds": [ "DT2_SCAR_MAZE_3_LINK_RITUAL_CIRCLE_INACTIVE" ],
     "height": 200,
     "color": [
       196,
@@ -34200,7 +34200,7 @@
   },
   {
     "description": "Summoning circle powered - The Scar",
-    "npcIds": [ 12359 ],
+    "npcIds": [ "DT2_SCAR_MAZE_1_RITUAL_CATALYST" ],
     "height": 200,
     "color": [
       196,
@@ -34212,7 +34212,7 @@
   },
   {
     "description": "Axon terminal powered - The Scar",
-    "objectIds": [ 49440, 49441, 49442, 49443 ],
+    "objectIds": [ "DT2_SCAR_MAZE_3_PATHING_WATER", "DT2_SCAR_MAZE_3_PATHING_FIRE", "DT2_SCAR_MAZE_3_PATHING_NATURE", "DT2_SCAR_MAZE_3_PATHING_COSMIC" ],
     "height": 200,
     "color": [
       196,
@@ -34224,7 +34224,7 @@
   },
   {
     "description": "Axon terminal - The Scar",
-    "objectIds": [ 49444 ],
+    "objectIds": [ "DT2_SCAR_MAZE_3_PATHING_INACTIVE_TERMINAL" ],
     "height": 200,
     "color": [
       196,
@@ -34236,7 +34236,7 @@
   },
   {
     "description": "Neural teleporter blue - The Scar",
-    "objectIds": [ 49413, 49414 ],
+    "objectIds": [ "DT2_SCAR_MAZE_TELEPORTER_1_1", "DT2_SCAR_MAZE_TELEPORTER_1_2" ],
     "height": 120,
     "color": [
       80,
@@ -34248,7 +34248,7 @@
   },
   {
     "description": "Neural teleporter green - The Scar",
-    "objectIds": [ 49415, 49416 ],
+    "objectIds": [ "DT2_SCAR_MAZE_TELEPORTER_2_1", "DT2_SCAR_MAZE_TELEPORTER_2_2" ],
     "height": 120,
     "color": [
       136,
@@ -34260,7 +34260,7 @@
   },
   {
     "description": "Damaged growth - light leech puzzle - The Scar",
-    "objectIds": [ 49437 ],
+    "objectIds": [ "DT2_SCAR_MAZE_LIGHT_FILLED" ],
     "height": 120,
     "color": [
       165,
@@ -34272,7 +34272,7 @@
   },
   {
     "description": "Neural gateway - The Scar",
-    "objectIds": [ 49407 ],
+    "objectIds": [ "DT2_SCAR_MAZE_2_PILLAR_ATTACKER_SPAWN" ],
     "height": 120,
     "color": [
       202,
@@ -34284,7 +34284,7 @@
   },
   {
     "description": "Ancient Vault brazier",
-    "objectIds": [ 48858 ],
+    "objectIds": [ "DT2_DESERT_VAULT_BRAZIER02" ],
     "height": 200,
     "color": [ 115, 50, 137 ],
     "strength": 30,
@@ -34306,7 +34306,7 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 25,
-    "objectIds": [ 46268 ]
+    "objectIds": [ "HW22_LANTERN_PUMPKIN01_LIT01_LARGE01" ]
   },
   {
     "description": "HALLOWEEN_PUMPKIN_SMALL",
@@ -34322,7 +34322,7 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 25,
-    "objectIds": [ 46269 ]
+    "objectIds": [ "HW22_LANTERN_PUMPKIN01_LIT01_SMALL02" ]
   },
   {
     "description": "FIRE_OF_DOMINATION",
@@ -34333,7 +34333,7 @@
     "type": "FLICKER",
     "range": 10,
     "objectIds": [
-      33318
+      "MY2ARM_THRONEROOM_FIRE_SPECIAL"
     ]
   },
   {
@@ -34345,7 +34345,7 @@
     "type": "FLICKER",
     "range": 10,
     "objectIds": [
-      33319
+      "MY2ARM_HERBPATCH_FIRE_SPECIAL"
     ]
   },
   {
@@ -34357,7 +34357,7 @@
     "type": "FLICKER",
     "range": 10,
     "objectIds": [
-      33320
+      "MY2ARM_FIRE_ETERNALLIGHT"
     ]
   },
   {
@@ -34369,7 +34369,7 @@
     "type": "FLICKER",
     "range": 10,
     "objectIds": [
-      33321
+      "MY2ARM_FIRE_UNSEASONALWARMTH"
     ]
   },
   {
@@ -34381,7 +34381,7 @@
     "type": "FLICKER",
     "range": 10,
     "objectIds": [
-      33322
+      "MY2ARM_FIRE_DEHUMIDIFICATION"
     ]
   },
   {
@@ -34398,7 +34398,7 @@
     "duration": 0,
     "range": 23,
     "objectIds": [
-      10185
+      "DAGANNOTH_CAVEWALL_TORCH_FLAMES"
     ]
   },
   {
@@ -34415,7 +34415,7 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      4587
+      "HORROR_LIGHTHOUSE_COG"
     ]
   },
   {
@@ -34431,7 +34431,7 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      4587
+      "HORROR_LIGHTHOUSE_COG"
     ]
   },
   {
@@ -34448,7 +34448,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      3474
+      "HANGINGLANTERN"
     ]
   },
   {
@@ -34484,7 +34484,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      32631
+      "SLP_POOR_STOVE"
     ]
   },
   {
@@ -34502,7 +34502,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      13053
+      "DUNGEON_CANDLE"
     ]
   },
   {
@@ -34520,7 +34520,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      9992
+      "MOURNING_CRYSTAL_LIGHT"
     ]
   },
   {
@@ -34538,7 +34538,7 @@
     "duration": 0,
     "range": 15,
     "objectIds": [
-      9799
+      "MOURNING_LIGHT_WHITE"
     ]
   },
   {
@@ -34556,7 +34556,7 @@
     "duration": 0,
     "range": 15,
     "objectIds": [
-      9801
+      "MOURNING_LIGHT_YELLOW"
     ]
   },
   {
@@ -34573,7 +34573,7 @@
     "type": "STATIC",
     "duration": 0,
     "range": 15,
-    "objectIds": [ 9803 ]
+    "objectIds": [ "MOURNING_LIGHT_CYAN" ]
   },
   {
     "description": "TEMPLE_OF_LIGHT_LIGHTBEAM_GREEN",
@@ -34589,7 +34589,7 @@
     "type": "STATIC",
     "duration": 0,
     "range": 15,
-    "objectIds": [ 9802 ]
+    "objectIds": [ "MOURNING_LIGHT_GREEN" ]
   },
   {
     "description": "TEMPLE_OF_LIGHT_LIGHTBEAM_BLUE",
@@ -34605,7 +34605,7 @@
     "type": "STATIC",
     "duration": 0,
     "range": 15,
-    "objectIds": [ 9804 ]
+    "objectIds": [ "MOURNING_LIGHT_BLUE" ]
   },
   {
     "description": "TEMPLE_OF_LIGHT_LIGHTBEAM_RED",
@@ -34621,7 +34621,7 @@
     "type": "STATIC",
     "duration": 0,
     "range": 15,
-    "objectIds": [ 9800 ]
+    "objectIds": [ "MOURNING_LIGHT_RED" ]
   },
   {
     "description": "TEMPLE_OF_LIGHT_DOOR_OPEN",
@@ -34638,7 +34638,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      9775
+      "MOURNING_DOOR_OF_LIGHT_WHITE"
     ]
   },
   {
@@ -34656,7 +34656,7 @@
     "duration": 1689,
     "range": 100,
     "objectIds": [
-      24974
+      "ABYSS_EXIT_TO_COSMIC"
     ]
   },
   {
@@ -34674,7 +34674,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      43824, 43825
+      "ABYSS_EXIT_TO_BLOOD_CHILD_TRUE", "ABYSS_EXIT_TO_BLOOD_CHILD_KOUREND"
     ]
   },
   {
@@ -34692,7 +34692,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      24971
+      "ABYSS_EXIT_TO_FIRE"
     ]
   },
   {
@@ -34710,7 +34710,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      24972
+      "ABYSS_EXIT_TO_EARTH"
     ]
   },
   {
@@ -34728,7 +34728,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      24973
+      "ABYSS_EXIT_TO_BODY"
     ]
   },
   {
@@ -34746,7 +34746,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      25379
+      "ABYSS_EXIT_TO_MIND"
     ]
   },
   {
@@ -34764,7 +34764,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      25378
+      "ABYSS_EXIT_TO_AIR"
     ]
   },
   {
@@ -34782,7 +34782,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      25377
+      "ABYSS_EXIT_TO_SOUL"
     ]
   },
   {
@@ -34800,7 +34800,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      25376
+      "ABYSS_EXIT_TO_WATER"
     ]
   },
   {
@@ -34818,7 +34818,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      25035
+      "ABYSS_EXIT_TO_DEATH"
     ]
   },
   {
@@ -34836,7 +34836,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      25034
+      "ABYSS_EXIT_TO_LAW"
     ]
   },
   {
@@ -34854,7 +34854,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      24976
+      "ABYSS_EXIT_TO_CHAOS"
     ]
   },
   {
@@ -34872,7 +34872,7 @@
     "duration": 1686,
     "range": 100,
     "objectIds": [
-      24975
+      "ABYSS_EXIT_TO_NATURE"
     ]
   },
   {
@@ -34888,7 +34888,7 @@
     ],
     "type": "STATIC",
     "objectIds": [
-      26149
+      "RCU_ABYSSAL_ENERGY_APOCALYPSE"
     ]
   },
   {
@@ -34906,9 +34906,9 @@
     "duration": 1550,
     "range": 50,
     "objectIds": [
-      34754,
-      34755,
-      34756
+      "COSMICTEMPLE_EXIT_PORTAL",
+      "LAWTEMPLE_EXIT_PORTAL",
+      "NATURETEMPLE_EXIT_PORTAL"
     ]
   },
   {
@@ -34926,7 +34926,7 @@
     "duration": 1550,
     "range": 50,
     "objectIds": [
-      34794
+      "RUNETEMPLE_STANDINGSTONE_GLOW_LAW"
     ]
   },
   {
@@ -34995,7 +34995,7 @@
   },
   {
     "description": "Defender of Varrock dungeon braziers",
-    "objectIds": [ 50170 ],
+    "objectIds": [ "ZEMO_BASE_TORCH" ],
     "height": 200,
     "alignment": "CENTER",
     "radius": 1200,
@@ -35018,12 +35018,12 @@
     "type": "FLICKER",
     "range": 30,
     "objectIds": [
-      50101
+      "DOV_DREAM_THEATER_FORGE"
     ]
   },
   {
     "description": "Defender of Varrock shield responds lightning spotanim",
-    "graphicsObjectIds": [ 2656 ],
+    "graphicsObjectIds": [ "DOV_DIMINTHEIS_RECEIVE_SHIELD_SPOTANIM" ],
     "height": 200,
     "alignment": "CENTER",
     "radius": 500,
@@ -35040,7 +35040,7 @@
     "color": [ 60, 110, 190 ],
     "type": "FLICKER",
     "range": 20,
-    "objectIds": [ 50108 ],
+    "objectIds": [ "DOV_CHAIN_LIGHTNING_1X3_LONG" ],
     "fadeInDuration": 150,
     "fadeOutDuration": 300,
     "spawnDelay": 3600,
@@ -35055,7 +35055,7 @@
     "color": [ 60, 110, 190 ],
     "type": "FLICKER",
     "range": 20,
-    "objectIds": [ 50109 ],
+    "objectIds": [ "DOV_CHAIN_LIGHTNING_2X4_ONE_LONG" ],
     "fadeInDuration": 150,
     "fadeOutDuration": 300,
     "spawnDelay": 4050,
@@ -35070,7 +35070,7 @@
     "color": [ 60, 110, 190 ],
     "type": "FLICKER",
     "range": 20,
-    "objectIds": [ 50110 ],
+    "objectIds": [ "DOV_CHAIN_LIGHTNING_2X4_TWO_LONG" ],
     "fadeInDuration": 150,
     "fadeOutDuration": 300,
     "spawnDelay": 4400,
@@ -35079,7 +35079,7 @@
   },
   {
     "description": "Imbued heart lightning spotanim",
-    "graphicsObjectIds": [ 1316 ],
+    "graphicsObjectIds": [ "IMBUED_HEART_IMPACT" ],
     "height": 200,
     "alignment": "CENTER",
     "radius": 500,
@@ -35090,7 +35090,7 @@
   },
   {
     "description": "Saturated heart lightning spotanim",
-    "graphicsObjectIds": [ 2287 ],
+    "graphicsObjectIds": [ "IMBUED_HEART_IMPACT02" ],
     "height": 200,
     "alignment": "CENTER",
     "radius": 500,
@@ -35114,7 +35114,7 @@
     "duration": 4,
     "range": 75,
     "npcIds": [
-      2054
+      "CHAOSELEMENTAL"
     ]
   },
   {
@@ -35132,7 +35132,7 @@
     "duration": 0,
     "range": 20,
     "npcIds": [
-      2054
+      "CHAOSELEMENTAL"
     ]
   },
   {
@@ -35150,7 +35150,7 @@
     "duration": 0,
     "range": 20,
     "projectileIds": [
-      554
+      "CHAOSELEMENTAL_SPOTANIM_CONFUSION_TRAVEL"
     ]
   },
   {
@@ -35168,7 +35168,7 @@
     "duration": 0,
     "range": 20,
     "projectileIds": [
-      551
+      "CHAOSELEMENTAL_SPOTANIM_MADNESS_TRAVEL"
     ]
   },
   {
@@ -35186,7 +35186,7 @@
     "duration": 0,
     "range": 100,
     "projectileIds": [
-      557
+      "CHAOSELEMENTAL_SPOTANIM_DISCORD_TRAVEL"
     ]
   },
   {
@@ -35204,7 +35204,7 @@
     "duration": 0,
     "range": 100,
     "projectileIds": [
-      557
+      "CHAOSELEMENTAL_SPOTANIM_DISCORD_TRAVEL"
     ]
   },
   {
@@ -35222,7 +35222,7 @@
     "duration": 0,
     "range": 100,
     "projectileIds": [
-      557
+      "CHAOSELEMENTAL_SPOTANIM_DISCORD_TRAVEL"
     ]
   },
   {
@@ -35240,12 +35240,12 @@
     "duration": 20,
     "range": 0,
     "npcIds": [
-      6620
+      "MINI_CHAOS_ELE"
     ]
   },
   {
     "description": "Yu'biusk portal",
-    "objectIds": [ 43119 ],
+    "objectIds": [ "LOTG_PORTAL_FLUX_THERE" ],
     "height": 400,
     "strength": 200,
     "radius": 600,
@@ -35266,7 +35266,7 @@
     "fadeInDuration": 100,
     "fadeOutDuration": 500,
     "projectileIds": [
-      2640
+      "VFX_RAT_BOSS_PROJ_MAGIC_01"
     ]
   },
   {
@@ -35284,7 +35284,7 @@
     "fadeInDuration": 100,
     "fadeOutDuration": 100,
     "projectileIds": [
-      2642
+      "VFX_RAT_BOSS_PROJ_RANGED_01"
     ]
   },
   {
@@ -35302,8 +35302,8 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      51906,
-      51907
+      "BRAZIER_VARLAMORE01_DEFAULT01_2X3",
+      "BRAZIER_VARLAMORE01_DEFAULT01_2X2"
     ]
   },
   {
@@ -35321,7 +35321,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      15253
+      "LUNAR_MINE_CAVE_TORCH"
     ]
   },
   {
@@ -35339,7 +35339,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      50698
+      "FURNACE3"
     ]
   },
   {
@@ -35357,8 +35357,8 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      52647,
-      52648
+      "FORTIS_STOVE",
+      "FORTIS_STOVE_NOOP"
     ]
   },
   {
@@ -35405,7 +35405,7 @@
     "type": "FLICKER",
     "range": 15,
     "objectIds": [
-      51578
+      "BRAZIER_IMCANDO01_RALOS01"
     ],
     "visibleFromOtherPlanes": true
   },
@@ -35423,8 +35423,8 @@
     "type": "FLICKER",
     "range": 10,
     "objectIds": [
-      47446,
-      47447
+      "DECO_CANDLES01_RED",
+      "DECO_CANDLES02_RED"
     ],
     "visibleFromOtherPlanes": true
   },
@@ -35441,7 +35441,7 @@
     "type": "FLICKER",
     "range": 7.5,
     "objectIds": [
-      51009
+      "DUNGEONKIT_IMCANDO02_STATUE02"
     ]
   },
   {
@@ -35496,7 +35496,7 @@
   },
   {
     "description": "ANTECHAMBER_ORANGE_BRAZIERS",
-    "objectIds": [ 51342 ],
+    "objectIds": [ "BRAZIER_DUNGEON01_PMOON01" ],
     "color": "#e58500",
     "strength": 20,
     "radius": 1000,
@@ -35504,7 +35504,7 @@
   },
   {
     "description": "ANTECHAMBER_BLOOD_MOON_BRAZIERS",
-    "objectIds": [ 51343 ],
+    "objectIds": [ "BRAZIER_DUNGEON01_PMOON02" ],
     "color": "#df002e",
     "strength": 10,
     "radius": 1000,
@@ -35512,7 +35512,7 @@
   },
   {
     "description": "ANTECHAMBER_BLUE_MOON_BRAZIERS",
-    "objectIds": [ 51344 ],
+    "objectIds": [ "BRAZIER_DUNGEON01_PMOON03" ],
     "color": "#3571a7",
     "strength": 25,
     "radius": 1000,
@@ -35520,7 +35520,7 @@
   },
   {
     "description": "Earthbound Cavern - Glowing Mushrooms",
-    "objectIds": [ 36220 ],
+    "objectIds": [ "PRIF_MINE_MUSHROOM_1" ],
     "height": 155,
     "color": "#00e4ff",
     "strength": 5.5,
@@ -35528,7 +35528,7 @@
   },
   {
     "description": "ANTECHAMBER_ECLIPSE_MOON_BRAZIERS",
-    "objectIds": [ 51345 ],
+    "objectIds": [ "BRAZIER_DUNGEON01_PMOON04" ],
     "color": "#ffa41b",
     "strength": 3.5,
     "radius": 1000,
@@ -35536,7 +35536,7 @@
   },
   {
     "description": "ANTECHAMBER_ECLIPSE_MOON_BRAZIERS",
-    "objectIds": [ 51345 ],
+    "objectIds": [ "BRAZIER_DUNGEON01_PMOON04" ],
     "color": "#ffa41b",
     "strength": 250,
     "radius": 100,
@@ -35544,7 +35544,7 @@
   },
   {
     "description": "SULPHUR_NAGA",
-    "npcIds": [ 13033 ],
+    "npcIds": [ "PMOON_SULPHUR_NAGUA" ],
     "color": "#cd7c00",
     "strength": 20,
     "radius": 600,
@@ -35552,7 +35552,7 @@
   },
   {
     "description": "PERILOUS_MOONS_COOKING_STOVE",
-    "objectIds": [ 51362 ],
+    "objectIds": [ "PMOON_RANGE" ],
     "color": "#e58500",
     "strength": 30,
     "radius": 400,
@@ -35560,7 +35560,7 @@
   },
   {
     "description": "PERILOUS_MOONS_SURFACE_OPENING_VINES",
-    "objectIds": [ 51441 ],
+    "objectIds": [ "LIGHT_GODRAY02_SMALL01_MOONLIGHT01" ],
     "radius": 1300,
     "strength": 25,
     "color": "#ffffff",
@@ -35581,12 +35581,12 @@
     "duration": 0,
     "range": 30,
     "objectIds": [
-      51496
+      "CAM_TORUM_SACRED_FORGE"
     ]
   },
   {
     "description": "EYATLALLI",
-    "npcIds": [ 12869, 12870 ],
+    "npcIds": [ "PMOON_EYATLALLI_VIS", "PMOON_EYATLALLI_VIS_POSTQUEST" ],
     "color": "#00c7c1",
     "strength": 25,
     "radius": 700,
@@ -35594,7 +35594,7 @@
   },
   {
     "description": "EYATLALLI_RIGHT_HAND",
-    "npcIds": [ 12869, 12870 ],
+    "npcIds": [ "PMOON_EYATLALLI_VIS", "PMOON_EYATLALLI_VIS_POSTQUEST" ],
     "color": "#00c7c1",
     "strength": 25,
     "radius": 250,
@@ -35602,7 +35602,7 @@
   },
   {
     "description": "EYATLALLI_LEFT_HAND",
-    "npcIds": [ 12869, 12870 ],
+    "npcIds": [ "PMOON_EYATLALLI_VIS", "PMOON_EYATLALLI_VIS_POSTQUEST" ],
     "color": "#00c7c1",
     "strength": 15,
     "radius": 250,
@@ -35610,7 +35610,7 @@
   },
   {
     "description": "THE_BLUE_MOON_BRAZIERS",
-    "objectIds": [ 52992, 52993 ],
+    "objectIds": [ "PMOON_BOSS_BRAZIER_LEFT", "PMOON_BOSS_BRAZIER_RIGHT" ],
     "color": "#3571a7",
     "strength": 25,
     "radius": 1000,
@@ -35618,7 +35618,7 @@
   },
   {
     "description": "ECLIPSE_MOON",
-    "npcIds": [ 13012, 13019 ],
+    "npcIds": [ "PMOON_BOSS_ECLIPSE_MOON_VIS", "PMOON_BOSS_ECLIPSE_CLONE" ],
     "color": "#cd7c00",
     "strength": 50,
     "radius": 1200,
@@ -35627,7 +35627,7 @@
   },
   {
     "description": "BLOOD_MOON",
-    "npcIds": [ 13011 ],
+    "npcIds": [ "PMOON_BOSS_BLOOD_MOON_VIS" ],
     "color": "#df002e",
     "strength": 10,
     "radius": 1200,
@@ -35637,7 +35637,7 @@
   },
   {
     "description": "BLUE_MOON",
-    "npcIds": [ 13013 ],
+    "npcIds": [ "PMOON_BOSS_BLUE_MOON_VIS" ],
     "color": "#3571a7",
     "strength": 20,
     "radius": 1200,
@@ -35647,7 +35647,7 @@
   },
   {
     "description": "BLUE_MOON_ARENA_BURNING_BRAZIERS",
-    "objectIds": [ 51052 ],
+    "objectIds": [ "PMOON_BOSS_BRAZIER_LIT" ],
     "color": "#3571a7",
     "strength": 25,
     "radius": 1000,
@@ -35657,7 +35657,7 @@
   },
   {
     "description": "BLUE_MOON_ARENA_BURNING_LINE",
-    "objectIds": [ 51053 ],
+    "objectIds": [ "PMOON_BOSS_BLUE_FIRE" ],
     "color": "#3571a7",
     "strength": 25,
     "radius": 220,
@@ -35667,7 +35667,7 @@
   },
   {
     "description": "BLOOD_MOON_ARENA_BURNING_LINE",
-    "objectIds": [ 51054 ],
+    "objectIds": [ "PMOON_BOSS_BLOOD_FIRE" ],
     "color": "#6f2375",
     "strength": 15,
     "radius": 250,
@@ -35677,9 +35677,9 @@
   },
   {
     "description": "CURRENT_MOON_PHASE",
-    "npcIds": [ 13015 ],
+    "npcIds": [ "PMOON_BOSS_THREAT_CIRCLE" ],
     "objectIds": [
-      51042
+      "PMOON_BOSS_THREAT_CIRCLE"
     ],
     "color": "#00c7c1",
     "strength": 25,
@@ -35689,7 +35689,7 @@
   },
   {
     "description": "SMALL_MOON_PHASE",
-    "objectIds": [ 51041 ],
+    "objectIds": [ "PMOON_BOSS_SMALL_THREAT_CIRCLE" ],
     "color": "#00c7c1",
     "strength": 25,
     "radius": 128,
@@ -35711,10 +35711,10 @@
     "duration": 0,
     "range": 0,
     "objectIds": [
-      46327,
-      46330,
-      46333,
-      46336
+      "TGOD_GARDEN_1_EXIT",
+      "TGOD_GARDEN_2_EXIT",
+      "TGOD_GARDEN_3_EXIT",
+      "TGOD_GARDEN_4_EXIT"
     ]
   },
   {
@@ -35726,7 +35726,7 @@
     "range": 13,
     "offset": [ 0, 406, 0 ],
     "objectIds": [
-      51731
+      "HG_LANTERN_HANGING_LARGE01"
     ]
   },
   {
@@ -35738,7 +35738,7 @@
     "type": "FLICKER",
     "range": 13,
     "objectIds": [
-      19037
+      "CHINCHOMPA_JUNGLE_CAVE_EXIT"
     ]
   },
   {
@@ -35756,7 +35756,7 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      9736
+      "NEWBIERANGE"
     ]
   },
   {
@@ -35774,13 +35774,13 @@
     "duration": 1000,
     "range": 12,
     "objectIds": [
-      42819,
-      42820
+      "GIM_PORTAL",
+      "GIM_PORTAL_LUMBRIDGE_PORTAL"
     ]
   },
   {
     "description": "Easter event 2024 brazier",
-    "objectIds": [ 53050 ],
+    "objectIds": [ "EASTER24_BRAZIER_LIT" ],
     "radius": 500,
     "strength": 20,
     "color": "#dc5600",
@@ -35798,7 +35798,7 @@
     "range": 15,
     "offset": [ 0, 52, 0 ],
     "objectIds": [
-      51728
+      "HG_COOKING_FIRE_TRIVET"
     ]
   },
   {
@@ -35816,7 +35816,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      2501
+      "FAI_VARROCK_PRETTY_OILLAMP"
     ]
   },
   {
@@ -35834,12 +35834,12 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      15229
+      "ROYAL_COAL_LIFT_ENGINE_PLATFORM_ENGINE_ON"
     ]
   },
   {
     "description": "Troll Stronghold Window and Exit Door",
-    "objectIds": [ 3770, 3774 ],
+    "objectIds": [ "TROLL_STRONGHOLD_WINDOW", "TROLL_STRONGHOLD_TOP_EXIT_MID" ],
     "radius": 450,
     "areas": [ "TROLL_STRONGHOLD" ],
     "strength": 10,
@@ -35848,7 +35848,7 @@
   },
   {
     "description": "Icy Basalt Teleport",
-    "graphicsObjectIds": [ 1628 ],
+    "graphicsObjectIds": [ "MY2ARM_FLAME_TELEPORT_WEISS" ],
     "radius": 250,
     "strength": 10,
     "color": [ 0, 255, 255 ],
@@ -35859,7 +35859,7 @@
   },
   {
     "description": "Stony Basalt Teleport",
-    "graphicsObjectIds": [ 1617 ],
+    "graphicsObjectIds": [ "MY2ARM_FLAME_TELEPORT_SPOT" ],
     "radius": 250,
     "strength": 10,
     "color": [ 0, 255, 50 ],
@@ -35870,7 +35870,7 @@
   },
   {
     "description": "Standard Spellbook Teleport",
-    "graphicsObjectIds": [ 111 ],
+    "graphicsObjectIds": [ "TELEPORT_CASTING" ],
     "radius": 350,
     "strength": 12,
     "color": [ 205, 0, 205 ],
@@ -35926,8 +35926,8 @@
     "type": "FLICKER",
     "duration": 10,
     "range": 20,
-    "objectIds": [ 14825 ],
-    "animationIds": [ 3944 ],
+    "objectIds": [ "WILDERNESS_PORTAL_STONE_GLOWING" ],
+    "animationIds": [ "WILDERNESS_PORTAL_STONE_GLOW" ],
     "fadeInDuration": 80,
     "fadeOutDuration": 80
   },
@@ -35945,7 +35945,7 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 20,
-    "objectIds": [ 14008 ],
+    "objectIds": [ "RAG_POTBOILER_ONFIRE" ],
     "fadeInDuration": 50,
     "fadeOutDuration": 100
   },
@@ -35963,7 +35963,7 @@
     "type": "FLICKER",
     "duration": 3,
     "range": 35,
-    "projectileIds": [ 1737 ],
+    "projectileIds": [ "JORMUNGAND_MAGIC_TRAVEL" ],
     "fadeInDuration": 900,
     "fadeOutDuration": 300
   },
@@ -35973,7 +35973,7 @@
     "radius": 215,
     "strength": 11,
     "color": [ 220, 0, 255 ],
-    "projectileIds": [ 1735 ],
+    "projectileIds": [ "BASILISK_KNIGHT_MAGIC_TRAVEL" ],
     "fadeInDuration": 350,
     "spawnDelay": 750,
     "fadeOutDuration": 600
@@ -35981,10 +35981,10 @@
   {
     "description": "Venenatis, Spindel, Artio, Callisto and Escape Caves exit cave",
     "objectIds": [
-      46999,
-      47000,
-      47122,
-      47147
+      "WILD_VENANATIS_EXIT_NOOP",
+      "WILD_VENANATIS_EXIT",
+      "WILD_CALLISTO_EXIT01",
+      "WILD_BOSS_ESCAPE_CAVE_EXIT01"
     ],
     "radius": 500,
     "strength": 10,
@@ -35994,7 +35994,7 @@
   {
     "description": "Vet'ion/Calvar'ion Exit Door",
     "objectIds": [
-      46925
+      "WILD_VETION_EXIT01"
     ],
     "radius": 450,
     "strength": 10,
@@ -36004,7 +36004,7 @@
   {
     "description": "Vet'ion/Calvar'ion Ceiling Light",
     "objectIds": [
-      46949
+      "LIGHT_GODRAY02_LARGE01"
     ],
     "radius": 1350,
     "strength": 10,
@@ -36025,7 +36025,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      46993
+      "WILD_VETION_CANDLES01"
     ]
   },
   {
@@ -36042,7 +36042,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      46994
+      "WILD_VETION_CANDLES02"
     ]
   },
   {
@@ -36059,9 +36059,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      43108,
-      46910,
-      46911
+      "WILD_VETION_COFFIN01",
+      "WILD_VETION_COFFIN02",
+      "WILD_VETION_COFFIN03"
     ]
   },
   {
@@ -36078,9 +36078,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      43108,
-      46910,
-      46911
+      "WILD_VETION_COFFIN01",
+      "WILD_VETION_COFFIN02",
+      "WILD_VETION_COFFIN03"
     ]
   },
   {
@@ -36097,9 +36097,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      43108,
-      46910,
-      46911
+      "WILD_VETION_COFFIN01",
+      "WILD_VETION_COFFIN02",
+      "WILD_VETION_COFFIN03"
     ]
   },
   {
@@ -36116,9 +36116,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      43108,
-      46910,
-      46911
+      "WILD_VETION_COFFIN01",
+      "WILD_VETION_COFFIN02",
+      "WILD_VETION_COFFIN03"
     ]
   },
   {
@@ -36135,9 +36135,9 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      43108,
-      46910,
-      46911
+      "WILD_VETION_COFFIN01",
+      "WILD_VETION_COFFIN02",
+      "WILD_VETION_COFFIN03"
     ]
   },
   {
@@ -36154,7 +36154,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      43108
+      "WILD_VETION_COFFIN01"
     ],
     "fadeOutDuration": 50,
     "fadeInDuration": 50
@@ -36173,7 +36173,7 @@
     "duration": 0,
     "range": 10,
     "objectIds": [
-      46910
+      "WILD_VETION_COFFIN02"
     ],
     "fadeOutDuration": 50,
     "fadeInDuration": 50
@@ -36191,8 +36191,8 @@
     "type": "STATIC",
     "duration": 0,
     "range": 10,
-    "npcIds": [ 6611, 11993 ],
-    "animationIds": [ 9975 ],
+    "npcIds": [ "VETION", "VETION_SINGLE" ],
+    "animationIds": [ "NPC_VETION_DEFEND_SHIELD_01" ],
     "fadeOutDuration": 250,
     "fadeInDuration": 500
   },
@@ -36209,8 +36209,8 @@
     "type": "STATIC",
     "duration": 0,
     "range": 10,
-    "npcIds": [ 11994 ],
-    "animationIds": [ -1, 9969, 9972, 9974, 9976 ],
+    "npcIds": [ "VETION_2_SINGLE" ],
+    "animationIds": [ "SWARM_ATTACK", "NPC_VETION_ATTACK_MAGIC_01", "NPC_VETION_ATTACK_MELEE_02", "NPC_VETION_DEFEND_PARRY_02", "NPC_VETION_DEFEND_SHIELD_02" ],
     "fadeOutDuration": 1500
   },
   {
@@ -36226,15 +36226,15 @@
     "type": "STATIC",
     "duration": 0,
     "range": 10,
-    "npcIds": [ 12108 ],
-    "animationIds": [ -1, 6578, 6579 ],
+    "npcIds": [ "VETION_HELLHOUND_SNR_SINGLES" ],
+    "animationIds": [ "SWARM_ATTACK", "DOG_UPDATE_SKELETON_HELLHOUND_DEFEND", "DOG_UPDATE_SKELETON_HELLHOUND_ATTACK" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 1500
   },
   {
     "description": "Wilderness - Escape Caves - Rope Light",
     "objectIds": [
-      47150
+      "WILD_BOSS_ESCAPE_CAVE_EXIT03_OVERHEAD"
     ],
     "radius": 550,
     "strength": 15,
@@ -36244,7 +36244,7 @@
   {
     "description": "Tutorial Island - The Node - Furnace - 1",
     "objectIds": [
-      42824
+      "GIM_FURNACE"
     ],
     "offset": [ 0, 80, -30 ],
     "radius": 150,
@@ -36261,7 +36261,7 @@
   {
     "description": "Tutorial Island - The Node - Furnace - 2",
     "objectIds": [
-      42824
+      "GIM_FURNACE"
     ],
     "offset": [ 0, 80, -90 ],
     "radius": 250,
@@ -36290,7 +36290,7 @@
     "type": "STATIC",
     "duration": 4500,
     "range": 10,
-    "objectIds": [ 34705 ]
+    "objectIds": [ "KEBOS_FARMING_GUILD_HESPORI_GROWN" ]
   },
   {
     "description": "Hespori Combat Flower - Open - Wide",
@@ -36309,8 +36309,8 @@
     "type": "PULSE",
     "duration": 2500,
     "range": 15,
-    "npcIds": [ 8584 ],
-    "animationIds": [ -1, 8229 ]
+    "npcIds": [ "HESPORI_HEALER_ACTIVE" ],
+    "animationIds": [ "SWARM_ATTACK", "HESPORI_HEALER_DEAD_TO_ALIVE" ]
   },
   {
     "description": "Hespori Combat Flower - Open - Short",
@@ -36329,8 +36329,8 @@
     "type": "PULSE",
     "duration": 2500,
     "range": 15,
-    "npcIds": [ 8584 ],
-    "animationIds": [ -1, 8229 ]
+    "npcIds": [ "HESPORI_HEALER_ACTIVE" ],
+    "animationIds": [ "SWARM_ATTACK", "HESPORI_HEALER_DEAD_TO_ALIVE" ]
   },
   {
     "description": "Hespori Magic Attack",
@@ -36348,7 +36348,7 @@
     "fadeInDuration": 1000,
     "fadeOutDuration": 250,
     "projectileIds": [
-      1640
+      "HESPORI_MAGIC_PROJ"
     ]
   },
   {
@@ -36365,14 +36365,14 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      16812
+      "LUNAR_MOONCLAN_ANIM_LOC_KETTLE"
     ]
   },
   {
     "description": "Grotesque Guardians Dawn Ranged Attack",
     "projectileIds": [
-      1437,
-      1444
+      "GARGBOSS_HEALING_SPHERE_SMALL",
+      "GARGBOSS_STANDARD_RANGED_PROJECTILE"
     ],
     "offset": [ 0, 0, 0 ],
     "radius": 210,
@@ -36392,7 +36392,7 @@
   {
     "description": "Grotesque Guardians Dawn Freeze",
     "projectileIds": [
-      1445
+      "GARGBOSS_STUN_RANGED_PROJECTILE"
     ],
     "offset": [ 0, -20, 0 ],
     "radius": 195,
@@ -36412,7 +36412,7 @@
   {
     "description": "Grotesque Guardians Flames",
     "graphicsObjectIds": [
-      1434
+      "GG_DUSK_LIGHTNING_ENRAGED"
     ],
     "offset": [ 0, 10, 0 ],
     "radius": 175,
@@ -36433,7 +36433,7 @@
   {
     "description": "Grotesque Guardians Dusk Final Phase",
     "npcIds": [
-      7888
+      "GARGBOSS_DUSK_PHASE4"
     ],
     "offset": [ 0, 50, 0 ],
     "radius": 700,
@@ -36448,9 +36448,9 @@
   {
     "description": "Grotesque Guardians Dusk Heal Orb",
     "objectIds": [
-      31678,
-      31679,
-      31680
+      "GARGBOSS_HEALSPHERE_SMALL",
+      "GARGBOSS_HEALSPHERE_MED",
+      "GARGBOSS_HEALSPHERE_LARGE"
     ],
     "offset": [ 0, 10, 0 ],
     "radius": 200,
@@ -36479,10 +36479,10 @@
     "duration": 30,
     "range": 10,
     "objectIds": [
-      3493,
-      3494,
-      3495,
-      3496
+      "PRIESTPERIL_GRAVE_BASE1",
+      "PRIESTPERIL_GRAVE_BASE2",
+      "PRIESTPERIL_GRAVE_BASE3",
+      "PRIESTPERIL_GRAVE_BASE4"
     ]
   },
   {
@@ -36500,9 +36500,9 @@
     "duration": 30,
     "range": 10,
     "objectIds": [
-      3497,
-      3498,
-      3499
+      "PRIESTPERIL_GRAVE_BASE5",
+      "PRIESTPERIL_GRAVE_BASE6",
+      "PRIESTPERIL_GRAVE_BASE7"
     ]
   },
   {
@@ -36519,7 +36519,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      18536
+      "ELEM1_QIP_LANTERN_LIT"
     ]
   },
   {
@@ -36536,8 +36536,8 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      4932,
-      4933
+      "GLOWING_MUSHROOM",
+      "GLOWING_MUSHROOM2"
     ]
   },
   {
@@ -36554,9 +36554,9 @@
     "duration": 0,
     "range": 5,
     "objectIds": [
-      4926,
-      4927,
-      4928
+      "CRYSTALCORNER",
+      "CRYSTALEDGING",
+      "LARGECRYSTALS"
     ]
   },
   {
@@ -36573,7 +36573,7 @@
     "duration": 600,
     "range": 15,
     "objectIds": [
-      55200
+      "HUEY_LOBBY_COOKINGFIRE"
     ]
   },
   {
@@ -36592,9 +36592,9 @@
     "duration": 600,
     "range": 15,
     "objectIds": [
-      55210,
-      55218,
-      55226
+      "HUEY_PRAYER_PILLAR_MAGIC_BRAZIER_ON",
+      "HUEY_PRAYER_PILLAR_RANGED_BRAZIER_ON",
+      "HUEY_PRAYER_PILLAR_MELEE_BRAZIER_ON"
     ]
   },
   {
@@ -36612,7 +36612,7 @@
     "fadeOutDuration": 300,
     "duration": 600,
     "range": 15,
-    "projectileIds": [ 2969 ]
+    "projectileIds": [ "VFX_HUEY_ATTACK_MELEE_PROJANIM_01" ]
   },
   {
     "description": "Hueycoatl Range Projectile",
@@ -36629,7 +36629,7 @@
     "fadeOutDuration": 300,
     "duration": 600,
     "range": 15,
-    "projectileIds": [ 2972 ]
+    "projectileIds": [ "VFX_HUEY_ATTACK_RANGED_PROJANIM_01" ]
   },
   {
     "description": "Hueycoatl Mage Projectile",
@@ -36646,7 +36646,7 @@
     "fadeOutDuration": 300,
     "duration": 600,
     "range": 15,
-    "projectileIds": [ 2975 ]
+    "projectileIds": [ "VFX_HUEY_ATTACK_MAGIC_PROJANIM_01" ]
   },
   {
     "description": "Hueycoatl Ground Attack",
@@ -36665,11 +36665,11 @@
     "fadeOutDuration": 200,
     "duration": 600,
     "range": 15,
-    "graphicsObjectIds": [ 3001 ]
+    "graphicsObjectIds": [ "VFX_HUEYCOATL_PRAYER_02" ]
   },
   {
     "description": "Asgarnia Ice Dungeon Ladder",
-    "objectIds": [ 17385 ],
+    "objectIds": [ "LADDER_FROM_CELLAR" ],
     "height": 360,
     "radius": 900,
     "strength": 10,
@@ -36810,7 +36810,7 @@
     "duration": 0,
     "range": 20,
     "objectIds": [
-      56001
+      "VFX_BRANDA_QUEEN_LOC01_IDLE01"
     ]
   },
   {
@@ -36826,7 +36826,7 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 20,
-    "npcIds": [ 12596 ],
+    "npcIds": [ "RT_FIRE_QUEEN" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 400
   },
@@ -36843,7 +36843,7 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 20,
-    "npcIds": [ 12596 ],
+    "npcIds": [ "RT_FIRE_QUEEN" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 400
   },
@@ -36860,7 +36860,7 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 20,
-    "npcIds": [ 12596 ],
+    "npcIds": [ "RT_FIRE_QUEEN" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 400
   },
@@ -36877,8 +36877,8 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 20,
-    "npcIds": [ 14148 ],
-    "animationIds": [ 11992 ],
+    "npcIds": [ "RT_FIRE_QUEEN_INACTIVE" ],
+    "animationIds": [ "FIRE_GIANT_BRANDA_QUEEN_DEATH01" ],
     "fadeInDuration": 400,
     "fixedDespawnTime": true,
     "despawnDelay": 3100,
@@ -36895,7 +36895,7 @@
       255
     ],
     "type": "STATIC",
-    "npcIds": [ 14147 ],
+    "npcIds": [ "RT_ICE_KING" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 400
   },
@@ -36910,7 +36910,7 @@
       255
     ],
     "type": "STATIC",
-    "npcIds": [ 14147 ],
+    "npcIds": [ "RT_ICE_KING" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 400
   },
@@ -36925,7 +36925,7 @@
       255
     ],
     "type": "STATIC",
-    "npcIds": [ 14147 ],
+    "npcIds": [ "RT_ICE_KING" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 400
   },
@@ -36942,8 +36942,8 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 20,
-    "npcIds": [ 14150 ],
-    "animationIds": [ -1, 11947, 11956 ],
+    "npcIds": [ "RT_SUMMON_ELEMENTAL_FIRE" ],
+    "animationIds": [ "SWARM_ATTACK", "FIRE_MINION_ATTACK01", "FIRE_MINION_SPAWN01" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 200
   },
@@ -36958,8 +36958,8 @@
       255
     ],
     "type": "STATIC",
-    "npcIds": [ 14151 ],
-    "animationIds": [ -1, 11950, 11954 ],
+    "npcIds": [ "RT_SUMMON_ELEMENTAL_ICE" ],
+    "animationIds": [ "SWARM_ATTACK", "ICE_MINION_ATTACK01", "ICE_MINION_SPAWN01" ],
     "fadeInDuration": 100,
     "fadeOutDuration": 200
   },
@@ -36974,7 +36974,7 @@
       255
     ],
     "type": "STATIC",
-    "graphicsObjectIds": [ 3226 ],
+    "graphicsObjectIds": [ "VFX_HUMAN_TELEPORT_GIANTSOUL_AMULET_01" ],
     "fixedDespawnTime": true,
     "despawnDelay": 1300,
     "fadeInDuration": 100,
@@ -36993,7 +36993,7 @@
     "type": "FLICKER",
     "duration": 0,
     "range": 20,
-    "graphicsObjectIds": [ 3226 ],
+    "graphicsObjectIds": [ "VFX_HUMAN_TELEPORT_GIANTSOUL_AMULET_01" ],
     "fixedDespawnTime": true,
     "despawnDelay": 1300,
     "fadeInDuration": 100,

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -3,1081 +3,1081 @@
     "description": "Remove fake shadows/baked lighting",
     "hideVanillaShadows": true,
     "npcIds": [
-      10,
-      85,
-      86,
-      87,
-      88,
-      89,
-      90,
-      91,
-      92,
-      93,
-      94,
-      95,
-      96,
-      97,
-      98,
-      99,
-      137,
-      139,
-      142,
-      154,
-      239,
-      240,
-      241,
-      242,
-      243,
-      244,
-      245,
-      246,
-      247,
-      248,
-      249,
-      250,
-      251,
-      252,
-      253,
-      254,
-      255,
-      256,
-      257,
-      258,
-      259,
-      260,
-      261,
-      262,
-      263,
-      264,
-      265,
-      266,
-      267,
-      268,
-      269,
-      270,
-      271,
-      272,
-      273,
-      274,
-      275,
-      281,
-      284,
-      285,
-      286,
-      313,
-      326,
-      327,
-      404,
-      412,
-      413,
-      414,
-      423,
-      433,
-      434,
-      435,
-      436,
-      470,
-      472,
-      473,
-      474,
-      498,
-      499,
-      505,
-      506,
-      507,
-      509,
-      762,
-      763,
-      764,
-      817,
-      852,
-      853,
-      854,
-      855,
-      891,
-      920,
-      948,
-      1039,
-      1060,
-      1061,
-      1062,
-      1120,
-      1161,
-      1362,
-      1364,
-      1366,
-      1367,
-      1368,
-      1543,
-      1554,
-      1555,
-      1609,
-      1625,
-      1632,
-      1635,
-      1636,
-      1637,
-      1638,
-      1640,
-      1641,
-      1642,
-      1643,
-      1644,
-      1645,
-      1646,
-      1647,
-      1648,
-      1650,
-      1651,
-      1652,
-      1653,
-      1654,
-      1668,
-      1680,
-      1681,
-      1682,
-      1689,
-      1690,
-      1691,
-      1692,
-      1693,
-      1786,
-      1801,
-      1802,
-      1803,
-      1804,
-      1805,
-      1806,
-      1840,
-      1841,
-      1842,
-      1843,
-      1844,
-      1845,
-      1847,
-      1848,
-      1849,
-      1850,
-      1851,
-      1871,
-      1872,
-      2005,
-      2006,
-      2007,
-      2008,
-      2018,
-      2025,
-      2026,
-      2027,
-      2028,
-      2029,
-      2030,
-      2031,
-      2032,
-      2048,
-      2049,
-      2050,
-      2051,
-      2052,
-      2054,
-      2055,
-      2085,
-      2086,
-      2087,
-      2088,
-      2089,
-      2090,
-      2091,
-      2092,
-      2093,
-      2097,
-      2098,
-      2099,
-      2100,
-      2101,
-      2102,
-      2103,
-      2136,
-      2137,
-      2138,
-      2139,
-      2140,
-      2141,
-      2142,
-      2143,
-      2144,
-      2189,
-      2190,
-      2205,
-      2206,
-      2215,
-      2235,
-      2236,
-      2237,
-      2238,
-      2239,
-      2240,
-      2242,
-      2243,
-      2244,
-      2463,
-      2464,
-      2465,
-      2466,
-      2467,
-      2468,
-      2510,
-      2511,
-      2512,
-      2527,
-      2528,
-      2529,
-      2530,
-      2531,
-      2532,
-      2533,
-      2534,
-      2583,
-      2642,
-      2644,
-      2827,
-      2829,
-      2834,
-      2837,
-      2838,
-      2839,
-      2849,
-      2856,
-      2857,
-      2858,
-      2859,
-      2860,
-      2861,
-      2862,
-      2863,
-      2864,
-      2865,
-      2866,
-      2867,
-      2868,
-      2869,
-      2916,
-      2917,
-      2918,
-      2919,
-      2956,
-      2957,
-      2958,
-      2959,
-      2960,
-      2961,
-      2962,
-      2963,
-      3092,
-      3116,
-      3117,
-      3129,
-      3130,
-      3131,
-      3132,
-      3139,
-      3162,
-      3163,
-      3164,
-      3165,
-      3166,
-      3167,
-      3168,
-      3169,
-      3170,
-      3171,
-      3172,
-      3173,
-      3174,
-      3175,
-      3176,
-      3177,
-      3178,
-      3179,
-      3180,
-      3181,
-      3182,
-      3183,
-      3201,
-      3202,
-      3204,
-      3291,
-      3313,
-      3314,
-      3315,
-      3357,
-      3423,
-      3424,
-      3425,
-      3472,
-      3474,
-      3518,
-      3588,
-      3589,
-      3590,
-      3607,
-      3608,
-      3609,
-      3616,
-      3617,
-      3625,
-      3626,
-      3627,
-      3713,
-      3714,
-      3715,
-      3716,
-      3717,
-      3718,
-      3719,
-      3720,
-      3725,
-      3726,
-      3727,
-      3728,
-      3729,
-      3730,
-      3731,
-      3732,
-      3835,
-      3837,
-      3838,
-      3839,
-      3840,
-      3841,
-      3842,
-      3843,
-      3844,
-      3850,
-      3851,
-      3852,
-      3904,
-      3905,
-      3906,
-      3907,
-      3908,
-      3909,
-      3910,
-      3911,
-      3968,
-      3969,
-      3970,
-      3971,
-      3975,
-      3976,
-      3977,
-      3978,
-      3979,
-      3998,
-      4053,
-      4289,
-      4290,
-      4385,
-      4504,
-      4534,
-      4535,
-      4562,
-      4674,
-      4688,
-      4689,
-      4690,
-      4692,
-      4734,
-      4735,
-      4738,
-      4796,
-      4797,
-      4798,
-      4820,
-      4821,
-      4881,
-      5194,
-      5240,
-      5241,
-      5341,
-      5352,
-      5355,
-      5370,
-      5371,
-      5548,
-      5549,
-      5550,
-      5551,
-      5552,
-      5590,
-      5597,
-      5631,
-      5632,
-      5633,
-      5735,
-      5736,
-      5737,
-      5757,
-      5758,
-      5759,
-      5760,
-      5761,
-      5762,
-      5763,
-      5764,
-      5765,
-      5775,
-      5796,
-      5797,
-      5798,
-      5799,
-      5800,
-      5801,
-      5802,
-      5803,
-      5804,
-      5805,
-      5806,
-      5807,
-      5835,
-      5836,
-      5837,
-      5838,
-      5839,
-      5867,
-      5868,
-      5869,
-      5872,
-      5873,
-      5874,
-      5875,
-      5876,
-      5877,
-      5878,
-      5879,
-      5880,
-      5881,
-      5882,
-      6118,
-      6120,
-      6298,
-      6309,
-      6323,
-      6324,
-      6325,
-      6335,
-      6339,
-      6349,
-      6351,
-      6359,
-      6370,
-      6384,
-      6385,
-      6386,
-      6396,
-      6400,
-      6492,
-      6493,
-      6494,
-      6495,
-      6502,
-      6503,
-      6505,
-      6587,
-      6588,
-      6593,
-      6594,
-      6609,
-      6631,
-      6632,
-      6633,
-      6634,
-      6636,
-      6639,
-      6642,
-      6643,
-      6644,
-      6646,
-      6647,
-      6652,
-      6655,
-      6674,
-      6689,
-      6696,
-      6716,
-      6723,
-      6738,
-      6762,
-      6795,
-      6824,
-      7023,
-      7024,
-      7027,
-      7036,
-      7037,
-      7039,
-      7061,
-      7063,
-      7101,
-      7102,
-      7103,
-      7233,
-      7234,
-      7242,
-      7243,
-      7244,
-      7245,
-      7246,
-      7247,
-      7248,
-      7249,
-      7253,
-      7254,
-      7255,
-      7258,
-      7261,
-      7262,
-      7263,
-      7264,
-      7270,
-      7271,
-      7272,
-      7273,
-      7274,
-      7275,
-      7287,
-      7302,
-      7332,
-      7333,
-      7391,
-      7394,
-      7397,
-      7398,
-      7401,
-      7402,
-      7403,
-      7404,
-      7405,
-      7406,
-      7409,
-      7410,
-      7411,
-      7416,
-      7513,
-      7576,
-      7577,
-      7578,
-      7579,
-      7649,
-      7656,
-      7657,
-      7664,
-      7668,
-      7748,
-      7750,
-      7792,
-      7793,
-      7794,
-      7795,
-      7859,
-      7861,
-      7862,
-      7863,
-      7865,
-      7866,
-      7867,
-      7868,
-      7869,
-      7870,
-      7871,
-      7872,
-      7873,
-      7874,
-      7875,
-      7876,
-      7878,
-      7879,
-      7880,
-      7932,
-      7936,
-      7938,
-      7940,
-      7955,
-      8015,
-      8016,
-      8017,
-      8018,
-      8027,
-      8030,
-      8031,
-      8033,
-      8049,
-      8065,
-      8066,
-      8073,
-      8074,
-      8075,
-      8076,
-      8077,
-      8078,
-      8079,
-      8080,
-      8081,
-      8082,
-      8083,
-      8084,
-      8085,
-      8086,
-      8087,
-      8088,
-      8089,
-      8090,
-      8091,
-      8092,
-      8093,
-      8158,
-      8166,
-      8174,
-      8195,
-      8234,
-      8344,
-      8347,
-      8350,
-      8353,
-      8356,
-      8359,
-      8366,
-      8367,
-      8383,
-      8384,
-      8385,
-      8386,
-      8389,
-      8424,
-      8425,
-      8426,
-      8428,
-      8429,
-      8430,
-      8431,
-      8434,
-      8435,
-      8438,
-      8439,
-      8440,
-      8442,
-      8444,
-      8445,
-      8446,
-      8447,
-      8448,
-      8449,
-      8450,
-      8451,
-      8452,
-      8453,
-      8454,
-      8455,
-      8456,
-      8459,
-      8460,
-      8463,
-      8464,
-      8467,
-      8470,
-      8471,
-      8472,
-      8473,
-      8482,
-      8483,
-      8488,
-      8489,
-      8490,
-      8492,
-      8494,
-      8495,
-      8504,
-      8505,
-      8512,
-      8513,
-      8517,
-      8519,
-      8520,
-      8539,
-      8540,
-      8548,
-      8549,
-      8550,
-      8551,
-      8552,
-      8553,
-      8554,
-      8555,
-      8556,
-      8557,
-      8558,
-      8559,
-      8560,
-      8561,
-      8605,
-      8606,
-      8607,
-      8608,
-      8609,
-      8614,
-      8615,
-      8616,
-      8620,
-      8621,
-      8623,
-      8697,
-      8699,
-      8713,
-      8714,
-      8715,
-      8729,
-      8729,
-      8730,
-      8730,
-      8731,
-      8736,
-      8737,
-      8737,
-      8738,
-      8738,
-      8739,
-      8741,
-      8742,
-      8743,
-      8744,
-      8745,
-      8746,
-      8747,
-      8748,
-      8749,
-      8750,
-      8751,
-      8752,
-      8753,
-      8754,
-      8755,
-      8756,
-      8757,
-      8775,
-      8776,
-      8777,
-      8778,
-      8779,
-      8780,
-      8781,
-      8782,
-      8783,
-      8784,
-      8994,
-      8995,
-      8996,
-      9024,
-      9025,
-      9026,
-      9027,
-      9028,
-      9029,
-      9030,
-      9031,
-      9032,
-      9033,
-      9034,
-      9038,
-      9039,
-      9040,
-      9041,
-      9042,
-      9043,
-      9044,
-      9045,
-      9046,
-      9047,
-      9048,
-      9049,
-      9050,
-      9194,
-      9199,
-      9258,
-      9293,
-      9294,
-      9295,
-      9296,
-      9297,
-      9454,
-      9455,
-      9457,
-      9465,
-      9466,
-      9467,
-      9483,
-      9647,
-      9648,
-      9649,
-      9650,
-      9651,
-      9652,
-      9653,
-      9654,
-      9655,
-      9656,
-      9672,
-      9673,
-      9674,
-      10374,
-      10375,
-      10376,
-      10402,
-      10474,
-      10475,
-      10492,
-      10493,
-      10506,
-      10523,
-      10524,
-      10525,
-      10526,
-      10534,
-      10535,
-      10536,
-      10537,
-      10538,
-      10541,
-      10544,
-      10545,
-      10654,
-      10665,
-      10666,
-      10689,
-      10690,
-      10691,
-      10692,
-      10693,
-      10694,
-      10695,
-      10696,
-      10762,
-      10765,
-      10776,
-      10779,
-      10782,
-      10785,
-      10788,
-      10793,
-      10796,
-      10799,
-      10802,
-      10805,
-      10809,
-      10812,
-      10813,
-      10820,
-      10821,
-      10828,
-      10829,
-      10843,
-      10844,
-      10845,
-      10846,
-      10860,
-      10861,
-      10862,
-      10863,
-      10866,
-      10869,
-      10871,
-      10874,
-      10888,
-      10951,
-      10953,
-      10954,
-      10955,
-      10956,
-      10961,
-      10962,
-      11157,
-      11158,
-      11159,
-      11160,
-      11179,
-      11184,
-      11188,
-      11191,
-      11195,
-      11237,
-      11238,
-      11297,
-      11467,
-      11468,
-      11469,
-      11470,
-      11472,
-      12617
+      "SLAYER_NECHRYAEL_SPAWN",
+      "GHOST",
+      "GHOST2",
+      "GHOST3",
+      "GHOST4",
+      "GHOST5",
+      "GHOST6",
+      "GHOST7",
+      "GHOST8",
+      "GHOST_UNAGGRESSIVE",
+      "GHOST2_UNAGGRESSIVE",
+      "GHOST3_UNAGGRESSIVE",
+      "GHOST4_UNAGGRESSIVE",
+      "GHOST5_UNAGGRESSIVE",
+      "GHOST6_UNAGGRESSIVE",
+      "GHOST7_UNAGGRESSIVE",
+      "POH_BABYREDDRAGON",
+      "POH_STEEL_DRAGON",
+      "POH_DEMON",
+      "POH_TREASURE_HUNT_FAIRY",
+      "KING_DRAGON",
+      "BLACK_DEMON_STRONGHOLDCAVE_1",
+      "BABYBLUEDRAGON",
+      "BABYBLUEDRAGON2",
+      "BABYBLUEDRAGON3",
+      "BABYREDDRAGON",
+      "BABYREDDRAGON2",
+      "BABYREDDRAGON3",
+      "RED_DRAGON",
+      "RED_DRAGON2",
+      "RED_DRAGON3",
+      "RED_DRAGON4",
+      "RED_DRAGON5",
+      "BLACK_DRAGON",
+      "BLACK_DRAGON2",
+      "BLACK_DRAGON3",
+      "BLACK_DRAGON4",
+      "BLACK_DRAGON5",
+      "BLACK_DRAGON_STRONGHOLDCAVE_1",
+      "BLACK_DRAGON_STRONGHOLDCAVE_2",
+      "BLACK_DRAGON_STRONGHOLDCAVE_3",
+      "GREEN_DRAGON",
+      "GREEN_DRAGON2",
+      "GREEN_DRAGON3",
+      "GREEN_DRAGON4",
+      "GREEN_DRAGON5",
+      "BLUE_DRAGON",
+      "BLUE_DRAGON2",
+      "BLUE_DRAGON3",
+      "BLUE_DRAGON4",
+      "BLUE_DRAGON5",
+      "BRONZE_DRAGON",
+      "BRONZE_DRAGON_STRONGHOLDCAVE",
+      "IRON_DRAGON",
+      "IRON_DRAGON_STRONGHOLDCAVE",
+      "STEEL_DRAGON",
+      "STEEL_DRAGON_STRONGHOLDCAVE",
+      "SEABIRD1",
+      "GULL1",
+      "GULL2",
+      "_0_45_48_SEABIRD1",
+      "TEST_SILLYRAT",
+      "MACRO_GENI",
+      "MACRO_GENI_UNDERWATER",
+      "SLAYER_MASTER_4",
+      "SLAYER_GARGOYLE_1",
+      "SLAYER_GARGOYLE_DEAD",
+      "SLAYER_BANSHEE_1",
+      "SLAYER_DUSTDEVIL",
+      "SLAYER_PYREFIEND_1",
+      "SLAYER_PYREFIEND_2",
+      "SLAYER_PYREFIEND_3",
+      "SLAYER_PYREFIEND_4",
+      "SLAYER_KILLERWATT_BALL",
+      "GHOST8_UNAGGRESSIVE",
+      "HOUSE_GHOST",
+      "HOUSE_GHOST2",
+      "SMOKE_DEVIL",
+      "SMOKE_DEVIL_BOSS",
+      "HOUSE_GHOST3",
+      "HOUSE_GHOST4",
+      "HOUSE_GHOST5",
+      "DEATHWING",
+      "MYARM_BABY_ROC",
+      "MYARM_GIANT_ROC",
+      "MYARM_GIANT_ROC_SHADOW",
+      "DRAGONSLAYER_ELVARG_CUTSCENE",
+      "PENG_ICELORD_WARRIOR01",
+      "PENG_ICELORD_WARRIOR02",
+      "PENG_ICELORD_WARRIOR03",
+      "PENG_ICELORD_WARRIOR04",
+      "ROVING_MOSSGIANT",
+      "AGRITH_NONCOMBAT_GHOST",
+      "ICS_LITTLE_SPECTRE_VIS",
+      "HARMLESS_ISLAND_ALBINO_BAT",
+      "SOULBANE_ANGER_BEAR",
+      "SOULBANE_ANGER_UNICORN",
+      "SOULBANE_ANGER_RAT",
+      "NZONE_HOST",
+      "FAIRY_QUEEN",
+      "SLAGILITH",
+      "SLAGILITH_BIRTH",
+      "ELEMENTAL_EARTH",
+      "ELEM1_QIP_EARTH_ELEMENTAL_ROCK_VERSION",
+      "ELEM1_QIP_EARTH_ELEMENTAL_ROCK_VERSION_ROCK",
+      "SLAYER_CAVE_GARGOYLE",
+      "SEAGULL_47_49_1",
+      "SEAGULL_47_49_2",
+      "KOLDEMON",
+      "GROWNCAT_HELL",
+      "LAZYCAT_HELL",
+      "II_IMPLING_TYPE_1",
+      "II_IMPLING_TYPE_2",
+      "II_IMPLING_TYPE_3",
+      "II_IMPLING_TYPE_4",
+      "II_IMPLING_TYPE_6",
+      "II_IMPLING_TYPE_7",
+      "II_IMPLING_TYPE_8",
+      "II_IMPLING_TYPE_9",
+      "II_IMPLING_TYPE_10",
+      "II_IMPLING_TYPE_1_MAZE",
+      "II_IMPLING_TYPE_2_MAZE",
+      "II_IMPLING_TYPE_3_MAZE",
+      "II_IMPLING_TYPE_4_MAZE",
+      "II_IMPLING_TYPE_6_MAZE",
+      "II_IMPLING_TYPE_7_MAZE",
+      "II_IMPLING_TYPE_8_MAZE",
+      "II_IMPLING_TYPE_9_MAZE",
+      "II_IMPLING_TYPE_10_MAZE",
+      "BARBASSAULT_PEN_RANGER_TUTOR",
+      "BARROWS_GIANTRAT",
+      "BARROWS_GIANTRAT2",
+      "BARROWS_GIANTRAT3",
+      "PEST_SPLATTER_1",
+      "PEST_SPLATTER_2",
+      "PEST_SPLATTER_3",
+      "PEST_SPLATTER_4",
+      "PEST_SPLATTER_5",
+      "UNATTACKABLE_GHOST",
+      "_100_OSMAN_SUMMER_ELEMENTAL_1",
+      "_100_OSMAN_SUMMER_ELEMENTAL_2",
+      "_100_OSMAN_SUMMER_ELEMENTAL_3",
+      "_100_OSMAN_SUMMER_ELEMENTAL_4",
+      "_100_OSMAN_SUMMER_ELEMENTAL_5",
+      "_100_OSMAN_SUMMER_ELEMENTAL_6",
+      "FAIRY_GODFATHER2",
+      "FAIRY_NUFF2",
+      "FAIRY_QUEEN2",
+      "FAIRY2_CENTAUR_MALE",
+      "FAIRY2_CENTAUR_FEMALE",
+      "FAIRY2_STAG",
+      "FAIRY2_ADVISOR",
+      "FAIRY2_BANDAGES",
+      "FAIRY2_BROKEN_LEG",
+      "FAIRY2_SLING_ARM",
+      "FAIRY2_NO_ARM",
+      "CHICKENQUEST_BABY_BLACK_DRAGON",
+      "BABY_BLACK_DRAGON_STRONGHOLDCAVE",
+      "LESSER_DEMON",
+      "LESSER_DEMON2",
+      "LESSER_DEMON3",
+      "LESSER_DEMON4",
+      "LESSER_DEMON5",
+      "GREATER_DEMON",
+      "GREATER_DEMON2",
+      "GREATER_DEMON3",
+      "GREATER_DEMON4",
+      "GREATER_DEMON5",
+      "GREATER_DEMON_STRONGHOLDCAVE_1",
+      "GREATER_DEMON_STRONGHOLDCAVE_2",
+      "GREATER_DEMON_STRONGHOLDCAVE_3",
+      "BLACK_DEMON",
+      "BLACK_DEMON2",
+      "BLACK_DEMON3",
+      "BLACK_DEMON4",
+      "BLACK_DEMON5",
+      "CHAOSELEMENTAL",
+      "CHAOS_ELEMENTAL_PET",
+      "ICEGIANT",
+      "ICEGIANT2",
+      "ICEGIANT3",
+      "ICEGIANT_LOW_WANDERRANGE",
+      "ICEGIANT_LOW_WANDERRANGE2",
+      "MOSSGIANT",
+      "MOSSGIANT2",
+      "MOSSGIANT3",
+      "MOSSGIANT4",
+      "CYCLOPS",
+      "GIANT",
+      "GIANT2",
+      "GIANT3",
+      "GIANT4",
+      "GIANT5",
+      "GIANT6",
+      "WARGUILD_CYCLOPS_PET",
+      "WARGUILD_CYCLOPS1_HIGH",
+      "WARGUILD_CYCLOPS2_HIGH",
+      "WARGUILD_CYCLOPS3_HIGH",
+      "WARGUILD_CYCLOPS4_HIGH",
+      "WARGUILD_CYCLOPS5_HIGH",
+      "WARGUILD_CYCLOPS6_HIGH",
+      "POH_MENAGERIE_SARACHNISPET",
+      "SARACHNISPET",
+      "TZHAAR_FIGHTPIT_SWARM_1A",
+      "TZHAAR_FIGHTPIT_SWARM_1B",
+      "GODWARS_SARADOMIN_AVATAR",
+      "GODWARS_SARADOMIN_UNICORN",
+      "GODWARS_BANDOS_AVATAR",
+      "GODWARS_ANCIENT_CYCLOPS",
+      "GODWARS_ANCIENT_CYCLOPS2",
+      "GODWARS_ANCIENT_ORK1",
+      "GODWARS_ANCIENT_ORK2",
+      "GODWARS_ANCIENT_ORK3",
+      "GODWARS_ANCIENT_ORK4",
+      "GODWARS_SPIRITUAL_BANDOS_RANGER",
+      "GODWARS_SPIRITUAL_BANDOS_WARRIOR",
+      "GODWARS_SPIRITUAL_BANDOS_MAGE",
+      "WARGUILD_CYCLOPS1",
+      "WARGUILD_CYCLOPS2",
+      "WARGUILD_CYCLOPS3",
+      "WARGUILD_CYCLOPS4",
+      "WARGUILD_CYCLOPS5",
+      "WARGUILD_CYCLOPS6",
+      "SOS_FAM_GIANTRAT",
+      "SOS_FAM_GIANTRAT2",
+      "SOS_FAM_GIANTRAT3",
+      "SOS_DEATH_GHOST",
+      "SOS_DEATH_GHOST_B",
+      "SOS_DEATH_GHOST_C",
+      "SOS_DEATH_GHOST_D",
+      "SOS_DEATH_GHOST2",
+      "SOS_DEATH_GHOST2_B",
+      "SOS_DEATH_GHOST2_C",
+      "SOS_DEATH_GHOST2_D",
+      "RCU_ZAMMY_MAGE2",
+      "TWOCATS_KBD_CUTSCENE",
+      "TWOCATS_CARPET_CATS",
+      "SMALL_BAT",
+      "FAIRY",
+      "BAT",
+      "UNICORN",
+      "BROWNBEAR",
+      "DARKBEAR",
+      "BLACK_UNICORN",
+      "GIANTRAT",
+      "GIANTRAT2",
+      "GIANTRAT3",
+      "GIANTRAT_GREY",
+      "GIANTRAT_GREY2",
+      "GIANTRAT_GREY3",
+      "GIANTRAT1",
+      "GIANTRAT1_2",
+      "GIANTRAT1_3",
+      "DUNGEON_RAT",
+      "DUNGEON_RAT2",
+      "DUNGEON_RAT3",
+      "GENERALSHOPKEEPER8",
+      "GENERALASSISTANT8",
+      "BRUT_WATERFIEND",
+      "WATERFIEND_STRONGHOLDCAVE",
+      "BRUT_GREEN_DRAGON",
+      "BRUT_MITHRIL_DRAGON",
+      "_100_OSMAN_SPRING_ELEMENTAL_1",
+      "_100_OSMAN_SPRING_ELEMENTAL_2",
+      "_100_OSMAN_SPRING_ELEMENTAL_3",
+      "_100_OSMAN_SPRING_ELEMENTAL_4",
+      "_100_OSMAN_SPRING_ELEMENTAL_5",
+      "_100_OSMAN_SPRING_ELEMENTAL_6",
+      "_100_OSMAN_SPRING_ELEMENTAL_7",
+      "_100_OSMAN_SPRING_ELEMENTAL_8",
+      "FAIRY_BANKER",
+      "TZHAAR_FIGHTCAVE_SWARM_1A",
+      "TZHAAR_FIGHTCAVE_SWARM_1B",
+      "GODWARS_ZAMORAK_AVATAR",
+      "GODWARS_ANCIENT_GREATER_DEMON",
+      "GODWARS_ANCIENT_LESSER_DEMON",
+      "GODWARS_ANCIENT_BLACK_DEMON",
+      "GODWARS_PYREFIEND_1",
+      "GODWARS_ARMADYL_AVATAR",
+      "GODWARS_ARMADYL_BODYGUARD_SKREE",
+      "GODWARS_ARMADYL_BODYGUARD_GEERIN",
+      "GODWARS_ARMADYL_BODYGUARD_KILISA",
+      "GODWARS_SPIRITUAL_ARMADYL_WARRIOR",
+      "GODWARS_SPIRITUAL_ARMADYL_RANGER",
+      "GODWARS_SPIRITUAL_ARMADYL_MAGE",
+      "GODWARS_ARMADYL_MALE_ARMOR01_BLUE",
+      "GODWARS_ARMADYL_MALE_ARMOR01_GREEN",
+      "GODWARS_ARMADYL_MALE_ARMOR01_RED",
+      "GODWARS_ARMADYL_MALE_ARMOR02_BLUE",
+      "GODWARS_ARMADYL_MALE_ARMOR02_GREEN",
+      "GODWARS_ARMADYL_MALE_ARMOR02_RED",
+      "GODWARS_ARMADYL_MALE_ARMOR03_GREEN",
+      "GODWARS_ARMADYL_MALE_ARMOR03_RED",
+      "GODWARS_ARMADYL_FEMALE_ARMOR01_BLUE",
+      "GODWARS_ARMADYL_FEMALE_ARMOR01_GREEN",
+      "GODWARS_ARMADYL_FEMALE_ARMOR01_RED",
+      "GODWARS_ARMADYL_FEMALE_ARMOR02_BLUE",
+      "GODWARS_ARMADYL_FEMALE_ARMOR02_GREEN",
+      "GODWARS_ARMADYL_FEMALE_ARMOR02_RED",
+      "GODWARS_ARMADYL_FEMALE_ARMOR03_BLUE",
+      "JAKUT",
+      "FAIRY_LUNDERWIN",
+      "FAIRY_LADDER_ATTENDANT",
+      "POSTIE_PETE",
+      "NEWBIEGIANTRAT",
+      "NEWBIEGIANTRAT2",
+      "NEWBIEGIANTRAT3",
+      "CHAMPIONS_LESSERDEMON",
+      "REGICIDE_DARKBEAR",
+      "REGICIDE_DARKBEAR_CUB1",
+      "REGICIDE_DARKBEAR_CUB2",
+      "DREAM_BIRDS_EYE_JACK",
+      "DREAM_EVERLASTING",
+      "THRANTAX",
+      "TOL_HOMONCULUS_NOCAGE",
+      "TOL_HOMONCULUS",
+      "TOL_HOMONCULUS_CAGE_BROKEN",
+      "CLOCKTOWER_RAT",
+      "CLOCKTOWER_RAT2",
+      "CLOCKTOWER_RAT3",
+      "HAUNTEDMINE_BOSS_GHOST",
+      "HAUNTEDMINE_BOSS_GHOST_FADED",
+      "HAUNTEDMINE_SUPRISE_GHOST",
+      "HAUNTEDMINE_SUPRISE_GHOST_HIDDEN",
+      "HAUNTEDMINE_CHEEKY_GHOST",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_FEMALE_1",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_FEMALE_2",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_FEMALE_3",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_FEMALE_4",
+      "SANG_MYQ3_FEMALE_FLYING_VYREWATCH_1",
+      "SANG_MYQ3_FEMALE_FLYING_VYREWATCH_2",
+      "SANG_MYQ3_FEMALE_FLYING_VYREWATCH_3",
+      "SANG_MYQ3_FEMALE_FLYING_VYREWATCH_4",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_MALE_1",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_MALE_2",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_MALE_3",
+      "MYREQUE_PT3_TAKEOFF_VYREWATCH_MALE_4",
+      "SANG_MYQ3_MALE_FLYING_VYREWATCH_1",
+      "SANG_MYQ3_MALE_FLYING_VYREWATCH_2",
+      "SANG_MYQ3_MALE_FLYING_VYREWATCH_3",
+      "SANG_MYQ3_MALE_FLYING_VYREWATCH_4",
+      "LUNAR_ONEIROMANCER",
+      "LUNAR_MOONCLAN_BABA_YAGA",
+      "LUNAR_MOONCLAN_MONK1",
+      "LUNAR_MOONCLAN_MONK2",
+      "LUNAR_MOONCLAN_MONK3",
+      "LUNAR_MOONCLAN_MONK4",
+      "LUNAR_MOONCLAN_MONK5",
+      "LUNAR_MOONCLAN_MONK_MAN",
+      "LUNAR_MOONCLAN_GUARD",
+      "LUNAR_MOONCLAN_MONK_WATERING",
+      "LUNAR_MOSSGIANT",
+      "LUNAR_MOSSGIANT2",
+      "VIKING_SEAGULL",
+      "VIKING_SEAGULL2",
+      "VIKING_SEAGULL3",
+      "VIKING_SEAGULL4",
+      "BROWNBEAR_CUB_1",
+      "BROWNBEAR_CUB_2",
+      "UNICORN_FOAL_1",
+      "BLACK_UNICORN_FOAL",
+      "ECHNED_ZEKIN",
+      "DRAGONSLAYER_GIANTRAT_1_KEY",
+      "DRAGONSLAYER_GIANTRAT_2",
+      "DRAGONSLAYER_GIANTRAT_3",
+      "DRAGONSLAYER_GHOST_1_KEY",
+      "DRAGONSLAYER_GHOST_2",
+      "DRAGONSLAYER_GHOST_3",
+      "DRAGONSLAYER_GHOST_4",
+      "DRAGONSLAYER_GHOST_5",
+      "SHAPESHIFTERBEAR",
+      "FEVER_SEAGULL",
+      "SEAGULL_DRAYNOR1",
+      "SEAGULL_DRAYNOR2",
+      "WATCHTOWER_CUTSCENE_BLUE_DRAGON",
+      "OLAF2_GIANT_BAT",
+      "BLESSED_GIANTRAT",
+      "BLESSED_GIANTRAT2",
+      "NON_COMBAT_BAT",
+      "TOURTRAP_QIP_CART_CAMEL",
+      "SOULBANE_UNICORN",
+      "SOULBANE_RAT",
+      "SOULBANE_RAT2",
+      "SOULBANE_BEAR",
+      "THURGOS_SEAGULL",
+      "THURGOS_SEAGULL2",
+      "ELID_GENIE",
+      "SLUG2_THE_SLUG_QUEEN",
+      "SLUG2_THE_SLUG_PRINCE",
+      "SLUG2_PRINCE_NONCOMBAT",
+      "HUNDRED_PIRATE_GIANT_MUDSKIPPER",
+      "HUNDRED_PIRATE_GIANT_MUDSKIPPER_2",
+      "HUNDRED_MINION2",
+      "BABYGREENDRAGON1",
+      "MM_JUNGLE_BIRD_GREEN",
+      "MM_JUNGLE_BIRD_BLUE",
+      "ZADIMUS_GHOST",
+      "ZQZOMBIEQUEEN",
+      "ZQ_MAINZOMBIE3",
+      "ZAMORAKGHOST",
+      "SPIRIT_OF_SCORPIUS",
+      "MULTICOLOURED_BIRD",
+      "HUNTING_BIRD_JUNGLE",
+      "HUNTING_BIRD_POLAR",
+      "HUNTING_BIRD_DESERT",
+      "HUNTING_BIRD_WOODLAND",
+      "WILEYCAT_HELL",
+      "KITTENPET_HELL",
+      "TEMPLETREK_SHADE_1",
+      "TEMPLETREK_SHADE_2",
+      "TEMPLETREK_SHADE_3",
+      "II_IMMENIZZ",
+      "II_FAIRY",
+      "II_LOST_IMPLING",
+      "BARBASSAULT_PEN_RANGER_LV1",
+      "BARBASSAULT_PEN_RANGER_LV2",
+      "BARBASSAULT_PEN_RANGER_LV3",
+      "BARBASSAULT_PEN_RANGER_LV4",
+      "BARBASSAULT_PEN_RANGER_LV5",
+      "BARBASSAULT_PEN_RANGER_LV6",
+      "BARBASSAULT_PEN_RANGER_LV7",
+      "BARBASSAULT_PEN_RANGER_LV8",
+      "BARBASSAULT_PEN_RANGER_LV9",
+      "BARBASSAULT_PEN_QUEEN_NEW",
+      "_100_OSMAN_WINTER_ELEMENTAL_1",
+      "_100_OSMAN_WINTER_ELEMENTAL_2",
+      "_100_OSMAN_WINTER_ELEMENTAL_3",
+      "_100_OSMAN_WINTER_ELEMENTAL_4",
+      "_100_OSMAN_WINTER_ELEMENTAL_5",
+      "_100_OSMAN_WINTER_ELEMENTAL_6",
+      "_100_OSMAN_AUTUMN_ELEMENTAL_1",
+      "_100_OSMAN_AUTUMN_ELEMENTAL_2",
+      "_100_OSMAN_AUTUMN_ELEMENTAL_3",
+      "_100_OSMAN_AUTUMN_ELEMENTAL_4",
+      "_100_OSMAN_AUTUMN_ELEMENTAL_5",
+      "_100_OSMAN_AUTUMN_ELEMENTAL_6",
+      "FAIRY_COORDINATOR",
+      "FAIRY_NUFF",
+      "FAIRY_GODFATHER",
+      "FAIRY_HENCHMAN1",
+      "FAIRY_HENCHMAN2",
+      "CERBERUS_SPECTRE_RANGED",
+      "CERBERUS_SPECTRE_MAGIC",
+      "CERBERUS_SPECTRE_MELEE",
+      "BABYGREENDRAGON2",
+      "BABYGREENDRAGON3",
+      "BLACK_DEMON_STRONGHOLDCAVE_2",
+      "BLACK_DEMON_STRONGHOLDCAVE_3",
+      "BLACK_DEMON_STRONGHOLDCAVE_4",
+      "BLACK_DEMON_STRONGHOLDCAVE_5",
+      "BLUE_DRAGON_STRONGHOLDCAVE_1",
+      "BLUE_DRAGON_STRONGHOLDCAVE_2",
+      "BLUE_DRAGON_STRONGHOLDCAVE_3",
+      "BLUE_DRAGON_STRONGHOLDCAVE_4",
+      "BLUE_DRAGON_STRONGHOLDCAVE_5",
+      "NZONE_ELVARG_HARD",
+      "NZONE_DREAM_EVERLASTING_HARD",
+      "NZONE_HAUNTEDMINE_BOSS_GHOST_HARD",
+      "NZONE_HUNDRED_MINION2_HARD",
+      "NZONE_MYARM_GIANT_ROC_HARD",
+      "NZONE_SLAGILITH_HARD",
+      "NZONE_ROVING_MOSSGIANT_HARD",
+      "NZONE_SHAPESHIFTERBEAR_HARD",
+      "NZONE_ZQ_MAINZOMBIE3_HARD",
+      "NZONE_ELVARG_NORMAL",
+      "NZONE_DREAM_EVERLASTING_NORMAL",
+      "NZONE_HAUNTEDMINE_BOSS_GHOST_NORMAL",
+      "NZONE_HUNDRED_MINION2_NORMAL",
+      "NZONE_MYARM_GIANT_ROC_NORMAL",
+      "NZONE_SLAGILITH_NORMAL",
+      "NZONE_ROVING_MOSSGIANT_NORMAL",
+      "NZONE_SHAPESHIFTERBEAR_NORMAL",
+      "NZONE_ZQ_MAINZOMBIE3_NORMAL",
+      "CLANCUP_GODWARS_ARMADYL_AVATAR",
+      "CLANCUP_GODWARS_SARADOMIN_AVATAR",
+      "CLANCUP_GODWARS_BANDOS_AVATAR",
+      "CLANCUP_GODWARS_ZAMORAK_AVATAR",
+      "CLANCUP_KING_DRAGON",
+      "CLANCUP_CALLISTO",
+      "CLANCUP_CHAOSELEMENTAL",
+      "ELITE_NPC_1",
+      "ELITE_NPC_2",
+      "LAVA_DRAGON",
+      "WILDERNESS_ENT",
+      "CALLISTO",
+      "ARMADYL_PET",
+      "BANDOS_PET",
+      "SARADOMIN_PET",
+      "ZAMORAK_PET",
+      "KBD_PET",
+      "SMOKE_PET",
+      "POH_PENANCE_PET",
+      "POH_ARMADYL_PET",
+      "POH_BANDOS_PET",
+      "POH_SARADOMIN_PET",
+      "POH_ZAMORAK_PET",
+      "POH_KBD_PET",
+      "POH_SMOKE_PET",
+      "PENANCE_PET",
+      "POH_LAZYCAT_HELL",
+      "POH_WILEYCAT_HELL",
+      "SUPERIOR_NECHRYAEL_MELEE_SPAWN",
+      "SUPERIOR_NECHRYAEL_RANGED_SPAWN",
+      "GRAB_POSTMAN",
+      "SLAYER_PYREBEAST_1",
+      "SLAYER_PYREBEAST_2",
+      "BAT_UNAGGRESSIVE",
+      "ARCEUUS_REANIMATED_BEAR",
+      "ARCEUUS_REANIMATED_UNICORN",
+      "ARCEUUS_REANIMATED_GIANT",
+      "ARCEUUS_REANIMATED_DEMON",
+      "ARCEUUS_REANIMATED_AVIANSIE",
+      "ARCEUUS_REANIMATED_DRAGON",
+      "ARCEUUS_PETBAT",
+      "COB_THE_BAT",
+      "MM2_DEMON_GLOUGH",
+      "MM2_DEMON_GLOUGH_NOMOVE",
+      "MM2_DEMON_GLOUGH_CUTSCENE",
+      "II_IMPLING_TYPE_11",
+      "WCGUILD_ENT",
+      "KOUREND_BLACK_DEMON_1",
+      "KOUREND_BLACK_DEMON_2",
+      "KOUREND_GREATER_DEMON1",
+      "KOUREND_GREATER_DEMON2",
+      "KOUREND_GREATER_DEMON3",
+      "KOUREND_LESSER_DEMON1",
+      "KOUREND_LESSER_DEMON2",
+      "KOUREND_DUSTDEVIL",
+      "KOUREND_BRONZE_DRAGON",
+      "KOUREND_IRON_DRAGON",
+      "KOUREND_STEEL_DRAGON",
+      "KOUREND_SHADE",
+      "KOUREND_HILLGIANT",
+      "KOUREND_MOSSGIANT",
+      "KOUREND_GHOST1",
+      "KOUREND_GHOST2",
+      "KOUREND_CYCLOPS1",
+      "KOUREND_CYCLOPS2",
+      "KOUREND_BANSHEE",
+      "KOUREND_BLUE_DRAGON",
+      "KOUREND_RED_DRAGON",
+      "KOUREND_BLACK_DRAGON",
+      "CATA_BOSS_MINION",
+      "II_IMPLING_TYPE_11_MAZE",
+      "FAIRY2_REPAIR_1OP",
+      "FAIRY2_REPAIR_2OPS",
+      "SUPERIOR_KOUREND_BANSHEE",
+      "SUPERIOR_PYREFIEND",
+      "SUPERIOR_BLOODVELD",
+      "SUPERIOR_KOUREND_BLOODVELD",
+      "SUPERIOR_CAVE_HORROR",
+      "SUPERIOR_ABBERANT_SPECTRE",
+      "SUPERIOR_KOUREND_SPECTRE",
+      "SUPERIOR_DUSTDEVIL",
+      "SUPERIOR_KURASK",
+      "SUPERIOR_SMOKE_DEVIL",
+      "SUPERIOR_DARK_BEAST",
+      "SUPERIOR_ABYSSAL_DEMON",
+      "SUPERIOR_NECHRYAEL",
+      "HILLGIANT_BOSS",
+      "MA2_BOSS_GUTHIX_SPAWNING",
+      "RAIDS_LASERCRABS_CRAB_GREY",
+      "RAIDS_LASERCRABS_CRAB_RED",
+      "RAIDS_LASERCRABS_CRAB_GREEN",
+      "RAIDS_LASERCRABS_CRAB_BLUE",
+      "SUPERIOR_NECHRYAEL_MAGIC_SPAWN",
+      "LESSER_DEMON_SLAYERCAVE_1",
+      "LESSER_DEMON_SLAYERCAVE_2",
+      "LESSER_DEMON_SLAYERCAVE_3",
+      "VOICE_OF_YAMA",
+      "FAIRY_CHILD",
+      "WILDWARS_BOSS_ARMOUR",
+      "WYVERN_LONG_TAILED",
+      "WYVERN_TALONED",
+      "WYVERN_SPITTING",
+      "ANCIENT_WYVERN",
+      "MA2_BOSS_GUTHIX",
+      "WILD_CAVE_BLACK_DRAGON",
+      "WILD_CAVE_BLACK_DRAGON2",
+      "WILD_CAVE_BLACK_DRAGON3",
+      "WILD_CAVE_LESSER_DEMON",
+      "WILD_CAVE_LESSER_DEMON2",
+      "WILD_CAVE_LESSER_DEMON3",
+      "WILD_CAVE_GREEN_DRAGON",
+      "WILD_CAVE_GREEN_DRAGON2",
+      "WILD_CAVE_GREEN_DRAGON3",
+      "WILD_CAVE_GREATER_DEMON",
+      "WILD_CAVE_GREATER_DEMON2",
+      "WILD_CAVE_GREATER_DEMON3",
+      "WILD_CAVE_BLACK_DEMON",
+      "WILD_CAVE_BLACK_DEMON2",
+      "WILD_CAVE_BLACK_DEMON3",
+      "WILD_CAVE_ICEGIANT",
+      "WILD_CAVE_ICEGIANT2",
+      "WILD_CAVE_ICEGIANT3",
+      "WILD_CAVE_PYREFIEND",
+      "WILD_CAVE_DEMON",
+      "WILD_CAVE_DARKBEAST",
+      "WILD_CAVE_DRAGON",
+      "BABY_BLACK_DRAGON_NOHUNT",
+      "DEADMAN_FINAL_MOSSGIANT",
+      "DEADMAN_FINAL_MOSSGIANT2",
+      "DEADMAN_FINAL_MOSSGIANT3",
+      "DEADMAN_FINAL_MOSSGIANT4",
+      "POH_RUNE_DRAGON",
+      "ADAMANT_DRAGON",
+      "RUNE_DRAGON",
+      "ELVARG_ALIVE",
+      "DS2_MEETING_ONEIROMANCER",
+      "DS2_GOLEM_RANGED",
+      "DS2_GOLEM_MAGIC",
+      "DS2_GREEN_DRAGON_FLYING",
+      "DS2_BLUE_DRAGON_FLYING",
+      "DS2_RED_DRAGON_FLYING",
+      "DS2_GREEN_DRAGON_CUTSCENE_FLYING",
+      "DS2_BLUE_DRAGON_CUTSCENE_FLYING",
+      "DS2_RED_DRAGON_CUTSCENE_FLYING",
+      "DS2_RED_DRAGON",
+      "DS2_IRON_DRAGON",
+      "DS2_BRUT_GREEN_DRAGON",
+      "DS2_GREEN_DRAGON",
+      "DS2_BLUE_DRAGON",
+      "DS2_BLACK_DRAGON_CUTSCENE",
+      "DS2_BLACK_DRAGON",
+      "DS2_STEEL_DRAGON",
+      "DS2_BRUT_RED_DRAGON",
+      "DS2_MITHRIL_DRAGON_CUTSCENE",
+      "DS2_MITHRIL_DRAGON",
+      "DS2_ADAMANT_DRAGON",
+      "DS2_RUNE_DRAGON",
+      "DS2_BRUT_BLACK_DRAGON_CUTSCENE",
+      "DS2_BRUT_BLACK_DRAGON",
+      "DS2_BATTLE_ONEIROMANCER",
+      "DS2_BATTLE_ONEIROMANCER_FINAL",
+      "DS2_CUTSCENE_ONEIROMANCER",
+      "GB_MOSSGIANT",
+      "MORYTANIA_WANDERING_GHOST",
+      "TOB_NYLOCAS_INCOMING_MAGIC",
+      "TOB_NYLOCAS_BIG_INCOMING_MAGIC",
+      "TOB_NYLOCAS_FIGHTING_MAGIC",
+      "TOB_NYLOCAS_BIG_FIGHTING_MAGIC",
+      "NYLOCAS_BOSS_MAGIC",
+      "TOB_BLOAT",
+      "MAIDEN_ELEMENTAL",
+      "MAIDEN_BLOOD_SLUG",
+      "VERZIK_NYLOCAS_MAGIC",
+      "TOB_VERZIK_PHASE2_ARMOUREDNYLOCAS",
+      "TOB_VERZIK_PHASE2_BLOODNYLOCAS",
+      "TOB_VERZIK_CREEPER",
+      "TOB_SOTETSEG_CREEPER",
+      "MY2ARM_AMBASSADOR",
+      "MY2ARM_MOTHER",
+      "MY2ARM_MOTHER_ENTHRONED",
+      "MY2ARM_MOTHER_BATTLE_MELEE",
+      "MY2ARM_MOTHER_BATTLE_RANGED",
+      "MY2ARM_MOTHER_BATTLE_MAGIC",
+      "MY2ARM_SNOWFLAKE",
+      "MY2ARM_MUSHROOM",
+      "MY2ARM_MUSHROOM_DYING",
+      "MY2ARM_DONTKNOWWHAT",
+      "MY2ARM_DONTKNOWWHAT_BATTLE",
+      "MY2ARM_DONTKNOWWHAT_STUNNED",
+      "MY2ARM_SENTRY_BOULDER",
+      "MY2ARM_SENTRY_ROOT_BACKGROUND",
+      "MY2ARM_SENTRY_ROOT_PATROLLING",
+      "MY2ARM_SENTRY_ICICLE_BACKGROUND",
+      "MY2ARM_SENTRY_ICICLE_PATROLLING",
+      "MY2ARM_SENTRY_DRIFTWOOD_BACKGROUND",
+      "MY2ARM_SENTRY_DRIFTWOOD_PATROLLING",
+      "MY2ARM_SENTRY_PEBBLE_BACKGROUND",
+      "MY2ARM_SENTRY_PEBBLE_PATROLLING",
+      "MY2ARM_SENTRY_GOATPOO_BACKGROUND",
+      "MY2ARM_SENTRY_GOATPOO_PATROLLING",
+      "MY2ARM_SENTRY_YELLOWSNOW_BACKGROUND",
+      "MY2ARM_SENTRY_YELLOWSNOW_PATROLLING",
+      "MY2ARM_SENTRY_BUTTERFLY",
+      "MY2ARM_SENTRY_BUTTERFLY_PATROLLING",
+      "MY2ARM_SENTRY_ODDSTONE",
+      "MY2ARM_SENTRY_ODDSTONE_PATROLLING",
+      "MY2ARM_SENTRY_SQUIRREL",
+      "MY2ARM_SENTRY_SQUIRREL_PATROLLING",
+      "MY2ARM_FLASHBACK_TROLL_1",
+      "MY2ARM_FLASHBACK_TROLL_2",
+      "MY2ARM_FLASHBACK_TROLL_3",
+      "MY2ARM_FLASHBACK_TROLL_4",
+      "POH_SMOKE_PET_OLD",
+      "SMOKE_PET_OLD",
+      "DEADMAN_FINAL_ICEGIANT",
+      "DEADMAN_FINAL_ICEGIANT2",
+      "DEADMAN_FINAL_ICEGIANT3",
+      "HYDRA_PET",
+      "HYDRA_PET_FIRE",
+      "HYDRA_PET_EXTINGUISHED",
+      "TROBIN_ARCEUUS_FOCUS_VISIBLE",
+      "TROBIN_ARCEUUS_VISIBLE",
+      "ARCQUEST_GHOST1",
+      "ARCQUEST_GHOST2",
+      "POH_HYDRA_PET",
+      "POH_HYDRA_PET_FIRE",
+      "POH_HYDRA_PET_EXTINGUISHED",
+      "ARCEUUS_LORD_TEST_01",
+      "ARCEUUS_LORD_TEST_02",
+      "KAHLITH_GUARDIAN_1",
+      "KAHLITH_GUARDIAN_2",
+      "KAHLITH_GUARDIAN_3",
+      "KAHLITH_GUARDIAN_4",
+      "KAHLITH_GUARDIAN_BANK",
+      "KAHLITH_HUNTER_1",
+      "KAHLITH_HUNTER_2",
+      "KAHLITH_MYSTIC_MAIN",
+      "KAHLITH_MYSTIC_1",
+      "KAHLITH_MYSTIC_2",
+      "KAHLITH_MYSTIC_3",
+      "KAHLITH_ARTISAN_1",
+      "KAHLITH_ARTISAN_2",
+      "KAHLITH_ARTISAN_3",
+      "KAHLITH_HYDRA_HUNTER",
+      "KAHLITH_DRAKE_HUNTER",
+      "KAHLITH_WYRM_HUNTER",
+      "KAHLITH_ALCHEMICAL_HUNTER",
+      "HYDRA",
+      "SULPHUR_LIZARD",
+      "HYDRABOSS",
+      "HYDRABOSS_P1_TRANSITION",
+      "HYDRABOSS_3",
+      "HYDRABOSS_2",
+      "SLAYER_MASTER_8",
+      "KEBOS_SPEAR_SALESMEN",
+      "SLAYER_LARRAN",
+      "SARACHNIS",
+      "SARACHNIS_MELEE_SPAWN",
+      "SARACHNIS_MAGE_SPAWN",
+      "POH_GAUNTLET_PET",
+      "POH_GAUNTLET_PET",
+      "POH_GAUNTLET_PET_CORRUPT",
+      "POH_GAUNTLET_PET_CORRUPT",
+      "POH_ZALCANO_PET",
+      "PRIF_MOSSGIANT",
+      "GAUNTLET_PET",
+      "GAUNTLET_PET",
+      "GAUNTLET_PET_CORRUPT",
+      "GAUNTLET_PET_CORRUPT",
+      "ZALCANO_PET",
+      "II_IMPLING_TYPE_12_JOHNNY",
+      "II_IMPLING_TYPE_12_JUNIOR",
+      "II_IMPLING_TYPE_12_ANDY",
+      "II_IMPLING_TYPE_12_JOEY",
+      "II_IMPLING_TYPE_12_TROUBLE",
+      "II_IMPLING_TYPE_12_HINGY",
+      "II_IMPLING_TYPE_12_ZOLTY",
+      "II_IMPLING_TYPE_12_NEIL",
+      "II_IMPLING_TYPE_12_YANNY",
+      "II_IMPLING_TYPE_12_MATTY",
+      "II_IMPLING_TYPE_12_STACE",
+      "II_IMPLING_TYPE_12_IAN",
+      "II_IMPLING_TYPE_12_JAMIE",
+      "II_IMPLING_TYPE_12_DAMO",
+      "II_IMPLING_TYPE_12_XANDER",
+      "II_IMPLING_TYPE_12_STEVEO",
+      "II_IMPLING_TYPE_12_STEWIE",
+      "SOTE_SEREN_VIS",
+      "SOTE_SEREN_MEMORY",
+      "SOTE_SEREN_ITHELL",
+      "SOTE_SEREN_CADARN",
+      "SOTE_SEREN_CRWYS",
+      "SOTE_SEREN_AMLODD",
+      "SOTE_SEREN_MEILYR",
+      "SOTE_SEREN_HEFIN",
+      "SOTE_SEREN_TRAHAEARN",
+      "SOTE_SEREN_IORWERTH",
+      "OTHAINIAN_VIS",
+      "DOOMION_VIS",
+      "HOLTHION_VIS",
+      "CRYSTAL_HUNLLEF_DEATH",
+      "CRYSTAL_HUNLLEF_CRYSTALS",
+      "CRYSTAL_RAT",
+      "CRYSTAL_SPIDER",
+      "CRYSTAL_BAT",
+      "CRYSTAL_UNICORN",
+      "CRYSTAL_SCORPION",
+      "CRYSTAL_WOLF",
+      "CRYSTAL_BEAR",
+      "CRYSTAL_DRAGON",
+      "CRYSTAL_DARK_BEAST",
+      "CRYSTAL_HUNLLEF_DEATH_HM",
+      "CRYSTAL_HUNLLEF_CRYSTALS_HM",
+      "CRYSTAL_RAT_HM",
+      "CRYSTAL_SPIDER_HM",
+      "CRYSTAL_BAT_HM",
+      "CRYSTAL_UNICORN_HM",
+      "CRYSTAL_SCORPION_HM",
+      "CRYSTAL_WOLF_HM",
+      "CRYSTAL_BEAR_HM",
+      "CRYSTAL_DRAGON_HM",
+      "CRYSTAL_DARK_BEAST_HM",
+      "ZALCANO",
+      "ZALCANO_WEAK",
+      "PRIF_GHOST_VISIBLE",
+      "PRIF_GEE",
+      "SUPERIOR_BASILISK_KNIGHT",
+      "BASILISK_KNIGHT",
+      "BAKUNA",
+      "TYPHOR_CUTSCENE",
+      "TYPHOR",
+      "VRITRA",
+      "NIGHTMARE_HUSK_MAGIC",
+      "NIGHTMARE_HUSK_RANGED",
+      "SANCTUARY_GHOST",
+      "SUPERIOR_PYRELORD",
+      "NIGHTMARE_CHALLENGE_HUSK_MAGIC",
+      "NIGHTMARE_CHALLENGE_HUSK_RANGED",
+      "TUT2_GIANTRAT",
+      "HALLOWED_GHOST_INSTANCE_OWL",
+      "HALLOWED_GHOST_LOBBY_OWL_VISIBLE",
+      "HALLOWED_GHOST_INSTANCE_UNICORN",
+      "HALLOWED_GHOST_LOBBY_UNICORN_VISIBLE",
+      "HALLOWED_GHOST_INSTANCE_WOLF",
+      "HALLOWED_GHOST_LOBBY_WOLF_VISIBLE",
+      "HALLOWED_GHOST_INSTANCE_LION",
+      "HALLOWED_GHOST_LOBBY_LION_VISIBLE",
+      "HALLOWED_GHOST_INSTANCE_ARCHPRIEST",
+      "HALLOWED_GHOST_LOBBY_ARCHPRIEST_VISIBLE",
+      "HALLOWED_PROJECTILE_NPC",
+      "HALLOWED_PROJECTILE_NPC_T2",
+      "HALLOWED_PROJECTILE_NPC_T3",
+      "GH_GIANT1",
+      "GH_GIANT2",
+      "GH_GIANT3",
+      "SUPERIOR_HYDRA",
+      "WILD_CAVE_INACTIVE_GHOST",
+      "WILD_CAVE_INACTIVE_GHOST_SMALL_ROAM",
+      "NZONE_GA_BEAST_HARD",
+      "NZONE_GA_BEAST_NORMAL",
+      "GA_BEAST",
+      "SOUL_WARS_TUT_SOUL_WEAK_1",
+      "SOUL_WARS_TUT_SOUL_WEAK_2",
+      "SOUL_WARS_TUT_SOUL_STRONG_1",
+      "SOUL_WARS_TUT_SOUL_STRONG_2",
+      "SOUL_WARS_SOUL_WEAK_1",
+      "SOUL_WARS_SOUL_WEAK_2",
+      "SOUL_WARS_SOUL_STRONG_1",
+      "SOUL_WARS_SOUL_STRONG_2",
+      "SOUL_WARS_PLAYER_GHOST",
+      "SW_BIRD_BLUE",
+      "SW_TOWER_GHOST1",
+      "SW_TOWER_GHOST2",
+      "BIM_GOLEM_BOSS",
+      "BIM_GOLEM_GUARDIAN_CUTSCENE",
+      "BIM_GOLEM_BOSS_INACTIVE_CUTSCENE",
+      "CAMDOZAAL_GOLEM_CHAOS",
+      "CAMDOZAAL_GOLEM_CHAOS_ROCK",
+      "CAMDOZAAL_GOLEM_BODY",
+      "CAMDOZAAL_GOLEM_BODY_ROCK",
+      "CAMDOZAAL_GOLEM_MIND",
+      "CAMDOZAAL_GOLEM_MIND_ROCK",
+      "CAMDOZAAL_GOLEM_FLAWED",
+      "CAMDOZAAL_GOLEM_FLAWED_ROCK",
+      "POH_VERZIK_PET_BLOAT",
+      "POH_VERZIK_PET_XARPUS",
+      "TOB_NYLOCAS_INCOMING_MAGIC_STORY",
+      "TOB_NYLOCAS_BIG_INCOMING_MAGIC_STORY",
+      "TOB_NYLOCAS_FIGHTING_MAGIC_STORY",
+      "TOB_NYLOCAS_BIG_FIGHTING_MAGIC_STORY",
+      "NYLOCAS_BOSS_MAGIC_STORY",
+      "TOB_NYLOCAS_INCOMING_MAGIC_HARD",
+      "TOB_NYLOCAS_BIG_INCOMING_MAGIC_HARD",
+      "TOB_NYLOCAS_FIGHTING_MAGIC_HARD",
+      "TOB_NYLOCAS_BIG_FIGHTING_MAGIC_HARD",
+      "NYLOCAS_MINIBOSS_MAGIC_HARD",
+      "NYLOCAS_BOSS_MAGIC_HARD",
+      "TOB_BLOAT_STORY",
+      "TOB_BLOAT_HARD",
+      "MAIDEN_ELEMENTAL_STORY",
+      "MAIDEN_BLOOD_SLUG_STORY",
+      "MAIDEN_ELEMENTAL_HARD",
+      "MAIDEN_BLOOD_SLUG_HARD",
+      "VERZIK_NYLOCAS_MAGIC_STORY",
+      "TOB_VERZIK_PHASE2_ARMOUREDNYLOCAS_STORY",
+      "TOB_VERZIK_PHASE2_BLOODNYLOCAS_STORY",
+      "TOB_VERZIK_CREEPER_STORY",
+      "VERZIK_NYLOCAS_MAGIC_HARD",
+      "TOB_VERZIK_PHASE2_ARMOUREDNYLOCAS_HARD",
+      "TOB_VERZIK_PHASE2_BLOODNYLOCAS_HARD",
+      "TOB_VERZIK_CREEPER_HARD",
+      "TOB_SOTETSEG_CREEPER_STORY",
+      "TOB_SOTETSEG_CREEPER_HARD",
+      "VERZIK_PET_BLOAT",
+      "VERZIK_PET_XARPUS",
+      "SMALL_BAT_OUTDOORS",
+      "AKD_XAMPHUR_CUTSCENE",
+      "AKD_XAMPHUR_CUTSCENE_TRANSITION_A",
+      "AKD_XAMPHUR_CUTSCENE_TRANSITION_B",
+      "AKD_XAMPHUR_COMBAT",
+      "AKD_XAMPHUR_COMBAT_NOHANDS",
+      "AKD_TROBIN_ARCEUUS_CUTSCENE",
+      "AKD_TROBIN_ARCEUUS_VIS",
+      "POH_MENAGERIE_SARACHNISPET_ORANGE",
+      "POH_MENAGERIE_SARACHNISPET_BLUE",
+      "SARACHNISPET_ORANGE",
+      "SARACHNISPET_BLUE",
+      "TOBQUEST_VERZIK_NYLO",
+      "TOBQUEST_BLOAT",
+      "TOBQUEST_ATHANATOS",
+      "TOBQUEST_NYLOCAS_3",
+      "DEADMAN_FINAL_REDGIANT",
+      "WILD_CAVE_INACTIVE_GHOST_SMALL_ROAM2",
+      "WILD_CAVE_DUSTDEVIL",
+      "SEAGULL",
+      "GIANTS_FOUNDRY_KOVAC_FAKE_ATTACK",
+      "GIANTS_FOUNDRY_KOVAC_QUEST",
+      "GIANTS_FOUNDRY_KOVAC_QUEST_CUTSCENE",
+      "GIANTS_FOUNDRY_KOVAC_1OP",
+      "GIANTS_FOUNDRY_KOVAC",
+      "DOV_SHARATHTEERK_CUTSCENE"
     ],
     "objectIds": [
-      2491,
-      2492,
-      3351,
-      3352,
-      4502,
-      5252,
-      6188,
-      10436,
-      10487,
-      12005,
-      12006,
-      13378,
-      14373,
-      15257,
-      15510,
-      15511,
-      17208,
-      17324,
-      18960,
-      27131,
-      29146,
-      29151,
-      29152,
-      29253,
-      29753,
-      29754,
-      29755,
-      29756,
-      29757,
-      29758,
-      29759,
-      29760,
-      29761,
-      29762,
-      29774,
-      29794,
-      29795,
-      29796,
-      29797,
-      29798,
-      29799,
-      29867,
-      29991,
-      30015,
-      30016,
-      30017,
-      30018,
-      30034,
-      30520,
-      30656,
-      30657,
-      30658,
-      30659,
-      30660,
-      30661,
-      30868,
-      31920,
-      31922,
-      31924,
-      31936,
-      31957,
-      31958,
-      31959,
-      31960,
-      33199,
-      33200,
-      33201,
-      33202,
-      33203,
-      33204,
-      33205,
-      33206,
-      33207,
-      33208,
-      33209,
-      33210,
-      34420,
-      34681,
-      35852,
-      35900,
-      35901,
-      36501,
-      37492,
-      37493,
-      37494,
-      37495,
-      37496,
-      37497,
-      37498,
-      37499,
-      37500,
-      37501,
-      37502,
-      37503,
-      37504,
-      37505,
-      37506,
-      37507,
-      37508,
-      37509,
-      37510,
-      37511,
-      37512,
-      37513,
-      37514,
-      37515,
-      37516,
-      37517,
-      37518,
-      37519,
-      37520,
-      37521,
-      37522,
-      37523,
-      37524,
-      37525,
-      37526,
-      37527,
-      37528,
-      37529,
-      37530,
-      37531,
-      37532,
-      37533,
-      37534,
-      37535,
-      37536,
-      37537,
-      37538,
-      37539,
-      37540,
-      37541,
-      37542,
-      37543,
-      37544,
-      37545,
-      37546,
-      37866,
-      38500,
-      38501,
-      38505,
-      40246,
-      40250,
-      40274,
-      40281,
-      40955,
-      41875,
-      41876
+      "FAI_VARROCK_GYPSY_LAMP",
+      "FAI_VARROCK_GYPSY_LANTERN",
+      "UPASS_CAGE_DUMMY",
+      "UPASS_CAGE_DUMMY_DUMMY",
+      "FAI_VARROCK_SWING_LANTERN",
+      "ROVING_FIRE_REMAINS",
+      "DWARF_KELDAGRIM_BLACKSMITHTOOLS",
+      "ELID_FOUNTAIN",
+      "ELID_BLACKSMITHTOOLS",
+      "FAIRY_MUSHROOM_TORCH_RED",
+      "FAIRY_MUSHROOM_TORCH_BLUE",
+      "POH_DEMON",
+      "PEST_BLACKSMITHTOOLS",
+      "POH_DUNGEON_TREASURE_2",
+      "II_FENCEGATE_L",
+      "II_FENCEGATE_LC",
+      "EYEGLO_BATTLE_TORTOISE_REVEAL",
+      "QIP_DIGSITE_SWING_LANTERN",
+      "TOURTRAP_QIP_CART_CAMEL",
+      "SHAYZIEN_WALL_LOWER_01",
+      "POH_TIPJAR",
+      "POH_ADVENTURE_LOG_1",
+      "POH_ADVENTURE_LOG_2",
+      "POH_THEME_ZANARIS_HERO",
+      "RAIDS_LASERCRABS_BIGCRYSTAL_1",
+      "RAIDS_LASERCRABS_BIGCRYSTAL_2",
+      "RAIDS_LASERCRABS_BIGCRYSTAL_3",
+      "RAIDS_LASERCRABS_BIGCRYSTAL_4",
+      "RAIDS_LASERCRABS_BIGCRYSTAL_5",
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_BLACK",
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_CYAN",
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_MAGENTA",
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_YELLOW",
+      "RAIDS_LASERCRABS_SMALLCRYSTAL_WHITE",
+      "RAIDS_VASANISTIRIO_CRYSTAL_ON",
+      "RAIDS_CRYTAL1",
+      "RAIDS_CRYTAL2",
+      "RAIDS_CRYTAL3",
+      "RAIDS_CRYTAL4",
+      "RAIDS_CRYTAL5",
+      "RAIDS_CRYTAL6",
+      "RAIDS_TEKTON_ANVIL",
+      "LIZARDMAN_LAMP",
+      "RAIDS_BLOCKAGE_PURPLE",
+      "RAIDS_BLOCKAGE_PURPLE_SMALL",
+      "RAIDS_BLOCKAGE_ORANGE",
+      "RAIDS_BLOCKAGE_GREEN",
+      "OLM_CRYSTAL_ATTACK_LARGE",
+      "HUNTING_TRAIL_SPAWN_FOSSIL2",
+      "FOSSIL_FLORA_SWAMP_SKROOM_01_SMALL",
+      "FOSSIL_FLORA_SWAMP_SKROOM_02_SMALL",
+      "FOSSIL_FLORA_SWAMP_SKROOM_01_MEDIUM",
+      "FOSSIL_FLORA_SWAMP_SKROOM_02_MEDIUM",
+      "FOSSIL_FLORA_SWAMP_SKROOM_01_LARGE",
+      "FOSSIL_FLORA_SWAMP_SKROOM_02_LARGE",
+      "FOSSIL_DUMMYSHROOM",
+      "OSB5_DISPLAY_GRA",
+      "OSB5_ADVENTURE_LOG",
+      "OSB5_JEWELLERY_BOX",
+      "OSB5_DISPLAY_NMZ",
+      "SHAYZIENQUEST_CRYSTAL_CYAN",
+      "SHAYZIENQUEST_CRYSTAL_MAGENTA",
+      "SHAYZIENQUEST_CRYSTAL_YELLOW",
+      "SHAYZIENQUEST_CRYSTAL_COMPLETE",
+      "MY2ARM_MOTHER",
+      "MY2ARM_DONTKNOWWHAT",
+      "MY2ARM_BOULDER",
+      "MY2ARM_ROOT",
+      "MY2ARM_ICICLE",
+      "MY2ARM_DRIFTWOOD",
+      "MY2ARM_PEBBLE",
+      "MY2ARM_GOATPOO",
+      "MY2ARM_YELLOWSNOW",
+      "MY2ARM_BUTTERFLY",
+      "MY2ARM_ODDSTONE",
+      "MY2ARM_SQUIRREL",
+      "MOLCH_LIZARD_EGGS_CORNER",
+      "OSB6_DISPLAY_MYARM",
+      "SOTE_HUNTING_TRAIL_CORNER_MIRROR",
+      "DARK_SEREN_CUTSCENE_DEFEATED",
+      "DARK_SEREN_DEFEATED_VIS",
+      "PRIF_AMLODD_RUNE_SHOP_SIGN",
+      "POH_JEWELLERY_BOX_1_BASE",
+      "POH_JEWELLERY_BOX_1_DUEL_ARENA",
+      "POH_JEWELLERY_BOX_1_CASTLE_WARS",
+      "POH_JEWELLERY_BOX_1_CLAN_WARS",
+      "POH_JEWELLERY_BOX_1_BURTHORPE",
+      "POH_JEWELLERY_BOX_1_BARB",
+      "POH_JEWELLERY_BOX_1_CORP",
+      "POH_JEWELLERY_BOX_1_TOG",
+      "POH_JEWELLERY_BOX_1_WINTERTODT",
+      "POH_JEWELLERY_BOX_2_BASE",
+      "POH_JEWELLERY_BOX_2_DUEL_ARENA",
+      "POH_JEWELLERY_BOX_2_CASTLE_WARS",
+      "POH_JEWELLERY_BOX_2_CLAN_WARS",
+      "POH_JEWELLERY_BOX_2_BURTHORPE",
+      "POH_JEWELLERY_BOX_2_BARB",
+      "POH_JEWELLERY_BOX_2_CORP",
+      "POH_JEWELLERY_BOX_2_TOG",
+      "POH_JEWELLERY_BOX_2_WINTERTODT",
+      "POH_JEWELLERY_BOX_2_WARRIORS_GUILD",
+      "POH_JEWELLERY_BOX_2_CHAMPS_GUILD",
+      "POH_JEWELLERY_BOX_2_PRAYER_GUILD",
+      "POH_JEWELLERY_BOX_2_RANGE_GUILD",
+      "POH_JEWELLERY_BOX_2_FISHING_GUILD",
+      "POH_JEWELLERY_BOX_2_MINING_GUILD",
+      "POH_JEWELLERY_BOX_2_CRAFTING_GUILD",
+      "POH_JEWELLERY_BOX_2_COOKING_GUILD",
+      "POH_JEWELLERY_BOX_2_WOODCUTTING_GUILD",
+      "POH_JEWELLERY_BOX_2_FARMING_GUILD",
+      "POH_JEWELLERY_BOX_3_BASE",
+      "POH_JEWELLERY_BOX_3_DUEL_ARENA",
+      "POH_JEWELLERY_BOX_3_CASTLE_WARS",
+      "POH_JEWELLERY_BOX_3_CLAN_WARS",
+      "POH_JEWELLERY_BOX_3_BURTHORPE",
+      "POH_JEWELLERY_BOX_3_BARB",
+      "POH_JEWELLERY_BOX_3_CORP",
+      "POH_JEWELLERY_BOX_3_TOG",
+      "POH_JEWELLERY_BOX_3_WINTERTODT",
+      "POH_JEWELLERY_BOX_3_WARRIORS_GUILD",
+      "POH_JEWELLERY_BOX_3_CHAMPS_GUILD",
+      "POH_JEWELLERY_BOX_3_PRAYER_GUILD",
+      "POH_JEWELLERY_BOX_3_RANGE_GUILD",
+      "POH_JEWELLERY_BOX_3_FISHING_GUILD",
+      "POH_JEWELLERY_BOX_3_MINING_GUILD",
+      "POH_JEWELLERY_BOX_3_CRAFTING_GUILD",
+      "POH_JEWELLERY_BOX_3_COOKING_GUILD",
+      "POH_JEWELLERY_BOX_3_WOODCUTTING_GUILD",
+      "POH_JEWELLERY_BOX_3_FARMING_GUILD",
+      "POH_JEWELLERY_BOX_3_MISC",
+      "POH_JEWELLERY_BOX_3_GE",
+      "POH_JEWELLERY_BOX_3_FALADOR_PARK",
+      "POH_JEWELLERY_BOX_3_DONDAKAN_ROCK",
+      "POH_JEWELLERY_BOX_3_EDGEVILLE",
+      "POH_JEWELLERY_BOX_3_KARAMJA",
+      "POH_JEWELLERY_BOX_3_DRAYNOR",
+      "POH_JEWELLERY_BOX_3_KHARID",
+      "SANCTUARY_SLEEPY_NIGHTMARE",
+      "HS_PILLAR_01_TOP_01",
+      "HS_PILLAR_01_TOP_02",
+      "HS_PILLAR_02_TOP_01",
+      "PET_LOC_BANDOS",
+      "PET_LOC_SMOKE",
+      "PET_LOC_LAZYCAT_HELL",
+      "PET_LOC_WILEYCAT_HELL",
+      "BR_UNICORN",
+      "AKD_LIZARD_EGGS_CORNER_NOOP",
+      "AKD_LIZARD_EGGS_CORNER_OP"
     ]
   },
   {
     "description": "TREES",
     "baseMaterial": "BARK",
     "objectIds": [
-      1278, 1279, 2409, 9731,
-      10041, 10832, 14309,
-      16546, 16547, 16548, 19167,
-      20845, 23639, 37967,
-      37968, 42832, 42842
+      "TREE2", "TREE3", "LEPRECHAUNTREE", "NEWBIETREE2",
+      "WOM_TREE", "MAPLETREE", "PEST_TREE2",
+      "ARDOUGNE_LOG_BALANCE_LEFT_SC", "ARDOUGNE_LOG_BALANCE_MID_SC", "ARDOUGNE_LOG_BALANCE_RIGHT_SC", "ZEP_TREE3",
+      "MACRO_FORESTERTREE2", "TREE_FORROPESWING1", "TUT2_TREE2",
+      "TUT2_TREE2_NOOP", "GIM_TREE", "GREYBOX_NUMBER_TILE_0"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1094,9 +1094,9 @@
     "description": "Tree - Double Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      1276, 1277, 9730, 14308,
-      19165, 20803, 20844, 37965,
-      37966
+      "TREE", "LIGHTTREE", "NEWBIETREE", "PEST_TREE",
+      "ZEP_TREE", "DRILL_TREE", "MACRO_FORESTER_TREE", "TUT2_TREE",
+      "TUT2_TREE_NOOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1113,26 +1113,26 @@
     "description": "Spirit trees",
     "baseMaterial": "BARK",
     "objectIds": [
-      8343,
-      8344,
-      8345,
-      8346,
-      8347,
-      8348,
-      8349,
-      8350,
-      8351,
-      8352,
-      8353,
-      8354,
-      8355,
-      8356,
-      8357,
-      26259,
-      26260,
-      26261,
-      26262,
-      26263
+      "SPIRIT_TREE_SEEDLING",
+      "SPIRIT_TREE_1",
+      "SPIRIT_TREE_2",
+      "SPIRIT_TREE_3",
+      "SPIRIT_TREE_4",
+      "SPIRIT_TREE_5",
+      "SPIRIT_TREE_6",
+      "SPIRIT_TREE_7",
+      "SPIRIT_TREE_8",
+      "SPIRIT_TREE_9",
+      "SPIRIT_TREE_10",
+      "SPIRIT_TREE_11",
+      "SPIRIT_TREE_FULLYGROWN",
+      "SPIRIT_TREE_CLAIMXP",
+      "SPIRIT_TREE_STUMP",
+      "SPIRITTREE_BIG_1OP",
+      "SPIRITTREE_BIG_2OPS",
+      "SPIRITTREE_BIG_2OPS_ORBS",
+      "SPIRITTREE_SMALL_1OP",
+      "SPIRITTREE_SMALL_2OPS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1142,18 +1142,18 @@
     "description": "Diseased spirit trees",
     "baseMaterial": "BARK",
     "objectIds": [
-      8358,
-      8359,
-      8360,
-      8361,
-      8362,
-      8363,
-      8364,
-      8365,
-      8366,
-      8367,
-      8368,
-      8369
+      "SPIRIT_TREE_DISEASED_1",
+      "SPIRIT_TREE_DISEASED_2",
+      "SPIRIT_TREE_DISEASED_3",
+      "SPIRIT_TREE_DISEASED_4",
+      "SPIRIT_TREE_DISEASED_5",
+      "SPIRIT_TREE_DISEASED_6",
+      "SPIRIT_TREE_DISEASED_7",
+      "SPIRIT_TREE_DISEASED_8",
+      "SPIRIT_TREE_DISEASED_9",
+      "SPIRIT_TREE_DISEASED_10",
+      "SPIRIT_TREE_DISEASED_11",
+      "SPIRIT_TREE_DISEASED_FULLGROWN"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1163,18 +1163,18 @@
     "description": "Dead spirit trees",
     "baseMaterial": "BARK",
     "objectIds": [
-      8370,
-      8371,
-      8372,
-      8373,
-      8374,
-      8375,
-      8376,
-      8377,
-      8378,
-      8379,
-      8380,
-      8381
+      "SPIRIT_TREE_DEAD_1",
+      "SPIRIT_TREE_DEAD_2",
+      "SPIRIT_TREE_DEAD_3",
+      "SPIRIT_TREE_DEAD_4",
+      "SPIRIT_TREE_DEAD_5",
+      "SPIRIT_TREE_DEAD_6",
+      "SPIRIT_TREE_DEAD_7",
+      "SPIRIT_TREE_DEAD_8",
+      "SPIRIT_TREE_DEAD_9",
+      "SPIRIT_TREE_DEAD_10",
+      "SPIRIT_TREE_DEAD_11",
+      "SPIRIT_TREE_DEAD_FULLYGROWN"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1184,70 +1184,70 @@
     "description": "Spirit fairy trees",
     "baseMaterial": "BARK",
     "objectIds": [
-      29422,
-      29423,
-      29424,
-      29425,
-      29426,
-      29427,
-      29428,
-      29429,
-      29430,
-      29431,
-      29432,
-      29433,
-      29434,
-      29435,
-      29436,
-      29437,
-      29438,
-      29439,
-      29440,
-      29441,
-      29442,
-      29443,
-      29444,
-      29445,
-      29446,
-      29447,
-      29448,
-      29449,
-      29450,
-      29451,
-      29452,
-      29453,
-      29454,
-      29455,
-      29456,
-      29457,
-      29458,
-      29459,
-      29460,
-      29461,
-      29462,
-      29463,
-      29464,
-      29465,
-      29466,
-      29467,
-      29468,
-      29469,
-      29470,
-      29471,
-      29472,
-      29473,
-      29474,
-      29475,
-      29476,
-      29477,
-      29478,
-      29479,
-      29480,
-      29481,
-      29482,
-      29483,
-      29484,
-      29485
+      "POH_SPIRIT_RING_LAST_AIP",
+      "POH_SPIRIT_RING_LAST_AIS",
+      "POH_SPIRIT_RING_LAST_AIR",
+      "POH_SPIRIT_RING_LAST_AIQ",
+      "POH_SPIRIT_RING_LAST_ALP",
+      "POH_SPIRIT_RING_LAST_ALS",
+      "POH_SPIRIT_RING_LAST_ALR",
+      "POH_SPIRIT_RING_LAST_ALQ",
+      "POH_SPIRIT_RING_LAST_AKP",
+      "POH_SPIRIT_RING_LAST_AKS",
+      "POH_SPIRIT_RING_LAST_AKR",
+      "POH_SPIRIT_RING_LAST_AKQ",
+      "POH_SPIRIT_RING_LAST_AJP",
+      "POH_SPIRIT_RING_LAST_AJS",
+      "POH_SPIRIT_RING_LAST_AJR",
+      "POH_SPIRIT_RING_LAST_AJQ",
+      "POH_SPIRIT_RING_LAST_DIP",
+      "POH_SPIRIT_RING_LAST_DIS",
+      "POH_SPIRIT_RING_LAST_DIR",
+      "POH_SPIRIT_RING_LAST_DIQ",
+      "POH_SPIRIT_RING_LAST_DLP",
+      "POH_SPIRIT_RING_LAST_DLS",
+      "POH_SPIRIT_RING_LAST_DLR",
+      "POH_SPIRIT_RING_LAST_DLQ",
+      "POH_SPIRIT_RING_LAST_DKP",
+      "POH_SPIRIT_RING_LAST_DKS",
+      "POH_SPIRIT_RING_LAST_DKR",
+      "POH_SPIRIT_RING_LAST_DKQ",
+      "POH_SPIRIT_RING_LAST_DJP",
+      "POH_SPIRIT_RING_LAST_DJS",
+      "POH_SPIRIT_RING_LAST_DJR",
+      "POH_SPIRIT_RING_LAST_DJQ",
+      "POH_SPIRIT_RING_LAST_CIP",
+      "POH_SPIRIT_RING_LAST_CIS",
+      "POH_SPIRIT_RING_LAST_CIR",
+      "POH_SPIRIT_RING_LAST_CIQ",
+      "POH_SPIRIT_RING_LAST_CLP",
+      "POH_SPIRIT_RING_LAST_CLS",
+      "POH_SPIRIT_RING_LAST_CLR",
+      "POH_SPIRIT_RING_LAST_CLQ",
+      "POH_SPIRIT_RING_LAST_CKP",
+      "POH_SPIRIT_RING_LAST_CKS",
+      "POH_SPIRIT_RING_LAST_CKR",
+      "POH_SPIRIT_RING_LAST_CKQ",
+      "POH_SPIRIT_RING_LAST_CJP",
+      "POH_SPIRIT_RING_LAST_CJS",
+      "POH_SPIRIT_RING_LAST_CJR",
+      "POH_SPIRIT_RING_LAST_CJQ",
+      "POH_SPIRIT_RING_LAST_BIP",
+      "POH_SPIRIT_RING_LAST_BIS",
+      "POH_SPIRIT_RING_LAST_BIR",
+      "POH_SPIRIT_RING_LAST_BIQ",
+      "POH_SPIRIT_RING_LAST_BLP",
+      "POH_SPIRIT_RING_LAST_BLS",
+      "POH_SPIRIT_RING_LAST_BLR",
+      "POH_SPIRIT_RING_LAST_BLQ",
+      "POH_SPIRIT_RING_LAST_BKP",
+      "POH_SPIRIT_RING_LAST_BKS",
+      "POH_SPIRIT_RING_LAST_BKR",
+      "POH_SPIRIT_RING_LAST_BKQ",
+      "POH_SPIRIT_RING_LAST_BJP",
+      "POH_SPIRIT_RING_LAST_BJS",
+      "POH_SPIRIT_RING_LAST_BJR",
+      "POH_SPIRIT_RING_LAST_BJQ"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1257,12 +1257,12 @@
     "description": "Path of Glouphrie spirit tree (all states)",
     "baseMaterial": "BARK",
     "objectIds": [
-      49592,
-      49593,
-      49594,
-      49595,
-      49596,
-      49597
+      "POG_SPIRIT_TREE_DEAD",
+      "POG_SPIRIT_TREE_DEAD_NOOP",
+      "POG_SPIRIT_TREE_ALIVE_INITIAL",
+      "POG_SPIRIT_TREE_ALIVE_STATIC",
+      "POG_SPIRIT_TREE_ALIVE_NOOP",
+      "POG_SPIRIT_TREE_ANIM"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1272,8 +1272,8 @@
     "description": "Prifddinas spirit tree without leaf texture",
     "baseMaterial": "BARK",
     "objectIds": [
-      35949,
-      35950
+      "SPIRITTREE_PRIF_1OP",
+      "SPIRITTREE_PRIF_2OPS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -1282,13 +1282,13 @@
     "description": "Fallen Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      1297,
-      9663,
-      14571,
-      14642,
-      14600,
-      33197,
-      40315
+      "DARKFALLENTREE",
+      "FALLENTREE_LIGHT",
+      "WILD2_FALLEN_TREE",
+      "WILD4_FALLEN_TREE",
+      "WILD3_FALLEN_TREE",
+      "MY2ARM_SNOW_COVERED_TREE_FALLEN_AGILITY",
+      "PORCINE_CART_FALLENTREE_VISIBLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1299,39 +1299,39 @@
     "description": "DEAD_TREES",
     "baseMaterial": "BARK",
     "objectIds": [
-      1282,
-      1283,
-      1284,
-      1285,
-      1286,
-      1289,
-      1365,
-      1383,
-      3891,
-      3967,
-      3968,
-      4051,
-      4052,
-      4054,
-      5902,
-      5903,
-      5904,
-      5905,
-      9733,
-      10056,
-      11510,
-      14513,
-      14514,
-      14515,
-      14521,
-      14564,
-      14565,
-      14566,
-      30150,
-      33186,
-      33187,
-      34933,
-      39679
+      "DEADTREE1",
+      "DEADTREE1_LARGE",
+      "DEADTREE4",
+      "LIGHTDEADTREE1",
+      "DEADTREE2",
+      "DEADTREE2_DARK",
+      "DEADTREE2_SWAMP",
+      "DEADTREE6",
+      "REGICIDE_TREE_DEAD2_D2",
+      "REGICIDE_TREE_SWAMP1",
+      "REGICIDE_TREE_SWAMP2",
+      "DEADTREE4SWAMP",
+      "COPPICETREE_SWAMP",
+      "REGICIDE_TREE_DEAD2SWAMP",
+      "MDAUGHTER_IMPASSABLE_TREE",
+      "MDAUGHTER_IMPASSABLE_TREE2",
+      "MDAUGHTER_PASSABLE_TREE",
+      "MDAUGHTER_PASSABLE_TREE_STUMP",
+      "NEWBIEDEADTREE2",
+      "MACRO_DIGGER_TREE",
+      "DRAYNOR_DEADTREE",
+      "WILD1_TREE_A",
+      "WILD1_TREE_B",
+      "WILD1_TREE_C",
+      "WILD1_FALLEN_TREE",
+      "WILD2_TREE_A",
+      "WILD2_TREE_B",
+      "WILD2_TREE_C",
+      "MISTMYST_TREE",
+      "MY2ARM_CLIFF_SHORTCUT_3_NOROPE",
+      "MY2ARM_CLIFF_SHORTCUT_3_ROPE",
+      "DEADTREE1_NOOP",
+      "WILDY_HUB_TREE_BIG"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -1340,21 +1340,21 @@
     "description": "TREE_STUMP",
     "baseMaterial": "BARK",
     "objectIds": [
-      1341,
-      1342,
-      1353,
-      1358,
-      4328,
-      6212,
-      9661,
-      9712,
-      10057,
-      14516,
-      14517,
-      14567,
-      14596,
-      14638,
-      50089
+      "TREESTUMP",
+      "TREESTUMP2",
+      "DEADTREE2_STUMP_DARK",
+      "DEADTREE6_STUMP",
+      "VIKING_TREESTUMP",
+      "DEADTREE4_STUMP",
+      "TREESTUMP_MODELLED",
+      "MAPLE_TREE_STUMP_NEW",
+      "MACRO_DIGGER_STUMP",
+      "WILD0_TREE_STUMP",
+      "WILD1_TREE_STUMP",
+      "WILD2_TREE_STUMP",
+      "WILD3_TREE_STUMP",
+      "WILD4_TREE_STUMP",
+      "DOV_HUNTING_TREESTUMP_NOOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -1363,45 +1363,45 @@
     "description": "Objects - Tree - Yew",
     "baseMaterial": "BARK",
     "objectIds": [
-      4536,
-      5121,
-      8502,
-      8503,
-      8504,
-      8505,
-      8506,
-      8507,
-      8508,
-      8509,
-      8510,
-      8511,
-      8512,
-      8513,
-      8514,
-      8515,
-      8516,
-      8517,
-      8518,
-      8519,
-      8520,
-      8521,
-      8522,
-      8523,
-      8524,
-      8525,
-      8526,
-      8527,
-      8528,
-      8529,
-      8530,
-      8531,
-      8532,
-      8533,
-      8534,
-      9714,
-      10822,
-      42391,
-      42427
+      "POH_BIG_TREE6_4",
+      "POH_SMALL_TREE6_5",
+      "YEW_TREE_SEEDLING",
+      "YEW_TREE_1",
+      "YEW_TREE_2",
+      "YEW_TREE_3",
+      "YEW_TREE_4",
+      "YEW_TREE_5",
+      "YEW_TREE_6",
+      "YEW_TREE_7",
+      "YEW_TREE_8",
+      "YEW_TREE_9",
+      "YEW_TREE_FULLYGROWN_1",
+      "YEW_TREE_FULLYGROWN_2",
+      "YEW_TREE_STUMP",
+      "YEW_TREE_DISEASED_1",
+      "YEW_TREE_DISEASED_2",
+      "YEW_TREE_DISEASED_3",
+      "YEW_TREE_DISEASED_4",
+      "YEW_TREE_DISEASED_5",
+      "YEW_TREE_DISEASED_6",
+      "YEW_TREE_DISEASED_7",
+      "YEW_TREE_DISEASED_8",
+      "YEW_TREE_DISEASED_9",
+      "YEW_TREE_DISEASED_FULLYGROWN",
+      "YEW_TREE_DEAD_1",
+      "YEW_TREE_DEAD_2",
+      "YEW_TREE_DEAD_3",
+      "YEW_TREE_DEAD_4",
+      "YEW_TREE_DEAD_5",
+      "YEW_TREE_DEAD_6",
+      "YEW_TREE_DEAD_7",
+      "YEW_TREE_DEAD_8",
+      "YEW_TREE_DEAD_9",
+      "YEW_TREE_DEAD_FULLYGROWN",
+      "YEW_TREE_STUMP_NEW",
+      "YEWTREE",
+      "TREE_YEW_DEFAULT01",
+      "YEWTREE_NOOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -1410,11 +1410,11 @@
     "description": "Objects - Tree - Willow",
     "baseMaterial": "BARK",
     "objectIds": [
-      9471,
-      10819,
-      10829,
-      10831,
-      10833
+      "WILLOW_TREE2OR3OR4_STUMP",
+      "WILLOWTREE",
+      "WILLOW_TREE2",
+      "WILLOW_TREE3",
+      "WILLOW_TREE4"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -1430,8 +1430,8 @@
     "uvOrientation": 42,
     "retainVanillaUvs": true,
     "objectIds": [
-      9034,
-      9035
+      "MAHOGANYTREE",
+      "MAHOGANY_STUMP"
     ]
   },
   {
@@ -1441,18 +1441,18 @@
     "uvScale": 0.25,
     "retainVanillaUvs": true,
     "objectIds": [
-      30407,
-      30408,
-      30409,
-      30410,
-      30411,
-      30412,
-      30413,
-      30414,
-      30415,
-      30416,
-      30417,
-      30418
+      "MAHOGANY_TREE_1",
+      "MAHOGANY_TREE_2",
+      "MAHOGANY_TREE_3",
+      "MAHOGANY_TREE_4",
+      "MAHOGANY_TREE_5",
+      "MAHOGANY_TREE_6",
+      "MAHOGANY_TREE_7",
+      "MAHOGANY_TREE_8",
+      "MAHOGANY_TREE_9",
+      "MAHOGANY_TREE_FULLYGROWN_CLAIMXP",
+      "MAHOGANY_TREE_FULLYGROWN",
+      "MAHOGANY_TREE_STUMP"
     ]
   },
   {
@@ -1471,11 +1471,11 @@
       }
     ],
     "objectIds": [
-      9036,
-      9037,
-      15032,
-      36686,
-      40758
+      "TEAKTREE",
+      "TEAK_STUMP",
+      "CHICKEN_CRATE",
+      "PRIF_TEAKTREE",
+      "TEAKTREE_UPDATE"
     ]
   },
   {
@@ -1494,23 +1494,23 @@
       }
     ],
     "objectIds": [
-      30437,
-      30438,
-      30439,
-      30440,
-      30441,
-      30442,
-      30443,
-      30444,
-      30445,
-      30446
+      "TEAK_TREE_SEEDLING",
+      "TEAK_TREE_1",
+      "TEAK_TREE_2",
+      "TEAK_TREE_3",
+      "TEAK_TREE_4",
+      "TEAK_TREE_5",
+      "TEAK_TREE_6",
+      "TEAK_TREE_FULLYGROWN_CLAIMXP",
+      "TEAK_TREE_FULLYGROWN",
+      "TEAK_TREE_STUMP"
     ]
   },
   {
     "description": "Objects - Tree - Juniper",
     "baseMaterial": "BARK",
     "objectIds": [
-      27499
+      "MATURE_JUNIPER_TREE"
     ],
     "uvType": "BOX",
     "uvOrientationZ": 128,
@@ -1520,14 +1520,14 @@
     "description": "Objects - Trees - Tirannwn Tree",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      3879,
-      3880,
-      3881,
-      3882,
-      3883,
-      3884,
-      3893,
-      37272
+      "REGICIDE_TREE_LARGE",
+      "REGICIDE_TREE_STUMP",
+      "REGICIDE_TREE_LARGE2",
+      "REGICIDE_TREE_LARGE3",
+      "REGICIDE_TREE_SMALL",
+      "REGICIDE_TREE_STUMP_SMALL",
+      "REGICIDE_TREE_BASE",
+      "SOTE_FLOWERS"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -1536,7 +1536,7 @@
     "description": "Tirannwn - Lord Crwys Tree",
     "baseMaterial": "LIGHT_BARK",
     "npcIds": [
-      8902
+      "SOTE_LORD_CRWYS_VIS_TREE"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -1545,8 +1545,8 @@
     "description": "Objects - Trees - Tirannwn Leafless Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      3886, 3887, 3888, 3889,
-      3890, 3939
+      "REGICIDE_TREE_DEAD1", "REGICIDE_TREE_DEAD2", "REGICIDE_TREE_DEAD1_D1", "REGICIDE_TREE_DEAD2_D1",
+      "REGICIDE_TREE_DEAD1_D2", "REGICIDE_CROSS_OVER3"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -1564,13 +1564,13 @@
     "description": "Tirannwn - Wood Debris",
     "baseMaterial": "BARK",
     "objectIds": [
-      3907,
-      3908,
-      3909,
-      3910,
-      3911,
-      3942,
-      3943
+      "REGICIDE_TWIGS1",
+      "REGICIDE_TWIGS2",
+      "REGICIDE_TWIGS3",
+      "REGICIDE_TWIGS_LOG",
+      "REGICIDE_TWIGS_FADE",
+      "REGICIDE_HOLLOWLOG",
+      "REGICIDE_HOLLOWLOGSMALLER"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -1585,7 +1585,7 @@
     "description": "Tirannwn - Trap - Sticks",
     "baseMaterial": "BARK",
     "objectIds": [
-      3922
+      "REGICIDE_TRAP_WOODSPRING"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -1603,8 +1603,8 @@
     "baseMaterial": "ROCK_1",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      3919,
-      3920
+      "REGICIDE_TRAP_ARROWTRIP",
+      "REGICIDE_ROCK1_TRAP"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -1630,11 +1630,11 @@
     "description": "Objects - Trees - Tirannwn - Lletya Entrance and Dense Forest",
     "baseMaterial": "BARK",
     "objectIds": [
-      3937,
-      3938,
-      3998,
-      3999,
-      8742
+      "REGICIDE_CROSS_OVER1",
+      "REGICIDE_CROSS_OVER2",
+      "REGICIDE_CROSS_OVER2_TYRAS_CAMP",
+      "REGICIDE_CROSS_OVER1_TYRAS_CAMP",
+      "ELF_VILLAGE_TREEGATE"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -1657,16 +1657,16 @@
     "baseMaterial": "ROCK_1",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      3894,
-      3895,
-      3896,
-      3897,
-      35856,
-      35858,
-      35860,
-      35857,
-      35855,
-      35859
+      "REGICIDE_ROCK1",
+      "REGICIDE_ROCK2",
+      "REGICIDE_ROCK3",
+      "REGICIDE_ROCK4",
+      "SOTE_HUNTING_ROCK2_NOOP",
+      "SOTE_HUNTING_ROCK3_NOOP",
+      "SOTE_HUNTING_ROCK4_NOOP",
+      "SOTE_HUNTING_ROCK3_OP",
+      "SOTE_HUNTING_ROCK2_OP",
+      "SOTE_HUNTING_ROCK4_OP"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -1686,8 +1686,8 @@
     "baseMaterial": "ROCK_1",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      3885,
-      3892
+      "REGICIDE_ROOTTREE",
+      "REGICIDE_TREE_FALLEN"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -1713,11 +1713,11 @@
     "description": "Tirannwn - Elven Lamp",
     "baseMaterial": "BARK",
     "objectIds": [
-      3918,
-      8774,
-      35868,
-      35867,
-      34958
+      "REGICIDE_CRYSTAL_LAMP",
+      "ELF_VILLAGE_LAMP",
+      "SOTE_HUNTING_LAMP_NOOP",
+      "SOTE_HUNTING_LAMP_OP",
+      "REGICIDE_CRYSTAL_LAMP_BLOCKWALK_ONLY"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -1733,7 +1733,7 @@
     "description": "Tirannwn - Spear Wall",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      3991
+      "REGICIDE_SPEARWALL_STRAIGHT"
     ],
     "colorOverrides": [
       {
@@ -1748,13 +1748,13 @@
     "description": "Tirannwn - Tents",
     "baseMaterial": "BURLAP",
     "objectIds": [
-      781,
-      783,
-      784,
-      3979,
-      3981,
-      3982,
-      3983
+      "REGICIDE_DARKELF_TENTROOF",
+      "REGICIDE_DARKELF_TENTWALL",
+      "REGICIDE_DARKELF_TENTROOFCENTRE",
+      "REGICIDE_TENT_HUMAN",
+      "REGICIDE_TENTROOF1_HUMAN",
+      "REGICDE_TENTROOFCENTRE1",
+      "REGICIDE_TENTROOFCENTRE1"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -1770,8 +1770,8 @@
     "description": "Tirannwn - Tents - Guy Rope",
     "baseMaterial": "ROPE",
     "objectIds": [
-      785,
-      3989
+      "REGICIDE_DARKELF_GUIDEROPES",
+      "REGICIDE_GUIDEROPES2"
     ],
     "uvType": "BOX",
     "uvScale": 0.35,
@@ -1788,7 +1788,7 @@
     "description": "Tirannwn - Iorwerth Camp - Standard",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      786
+      "REGICIDE_DARKELF_STANDARD"
     ],
     "colorOverrides": [
       {
@@ -1804,8 +1804,8 @@
     "description": "Tirannwn - Tyras Camp - Standard",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      3992,
-      3993
+      "REGICIDE_STANDARD1_TYRUS",
+      "REGICIDE_STANDARD2_TYRUS"
     ],
     "uvType": "BOX"
   },
@@ -1813,9 +1813,9 @@
     "description": "Tirannwn - Tyras - Catapult",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      3976,
-      3977,
-      3978
+      "REGICIDE_CATAPULT",
+      "REGICIDE_CATAPULT_LEFT",
+      "REGICIDE_CATAPULT_RIGHT"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -1841,9 +1841,9 @@
     "description": "Poison Waste - Sulphur Pile",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      3962,
-      3963,
-      3964
+      "REGICIDE_SULPHAR1",
+      "REGICIDE_SULPHAR2",
+      "REGICIDE_SULPHAR3"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -1852,7 +1852,7 @@
     "description": "Poison Waste - Sulphur Vent",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      3965
+      "REGICIDE_SULPHAR_VENT"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -1869,7 +1869,7 @@
     "description": "Poison Waste - Sulphur Gas",
     "baseMaterial": "GRAY_90",
     "objectIds": [
-      3966
+      "REGICIDE_SULPHAR_GAS"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -1878,7 +1878,7 @@
     "description": "Poison Waste - Zul-Andra - Torch",
     "baseMaterial": "BARK",
     "objectIds": [
-      10658
+      "SNAKEBOSS_STANDING_TORCH"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -1893,7 +1893,7 @@
     "description": "Poison Waste - Zulrah - Sacrificial Boat",
     "baseMaterial": "HD_WOOD_PLANKS_2",
     "objectIds": [
-      46242
+      "SNAKEBOSS_BOAT_2OPS"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -1908,7 +1908,7 @@
     "description": "Arandar - Fence",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      3524
+      "OLDFENCING"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -1918,9 +1918,9 @@
     "description": "Arandar - Shortcut Rocks",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      16514,
-      16515,
-      16516
+      "ELVES_OVERPASS_SC_ROCKS_TOP",
+      "ELVES_OVERPASS_SC_ROCKS_BOTTOM",
+      "ELVES_OVERPASS_SC_ROCKS_FALLOFF"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -1930,9 +1930,9 @@
     "description": "Arandar - Limestone",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      11382,
-      11383,
-      11384
+      "LIMESTONE_ROCK1",
+      "LIMESTONE_ROCK2",
+      "LIMESTONE_ROCK3"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -1941,10 +1941,10 @@
     "description": "Floating Rocks - Remove Ripples",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6707,
-      6708,
-      6709,
-      10663
+      "HARMLESS_ROCK_POOL",
+      "HARMLESS_ROCK_POOL_SMALL",
+      "HARMLESS_ROCK_POOL_BITS",
+      "SNAKEBOSS_STEPPINGSTONE"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -1961,7 +1961,7 @@
     "description": "FARMING_PATCH_1",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      7517
+      "FARMING_DIRTPATCH"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -1969,9 +1969,9 @@
     "description": "FARMING_PATCH_2",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      7522,
-      7523,
-      46420
+      "FARMING_BORDER_STRAIGHT_LIGHT",
+      "FARMING_BORDER_CORNER_LIGHT",
+      "FARMING_DIRTPATCH_DARK"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -1979,7 +1979,7 @@
     "description": "Farming Patch 3 - Keldagrim",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      8861, 8862, 8863, 8864, 8876
+      "KELDA_HOP_PATCH_WEEDED", "KELDA_HOP_PATCH_WEEDS_1", "KELDA_HOP_PATCH_WEEDS_2", "KELDA_HOP_PATCH_WEEDS_3", "FARMING_DIRTPATCH_KELDAGRIM"
     ],
     "upwardsNormals": true,
     "colorOverrides": [
@@ -1994,50 +1994,50 @@
     "description": "GRASS",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      4336,
-      4809,
-      4810,
-      4811,
-      4985,
-      4986,
-      4987,
-      4988,
-      4989,
-      4990,
-      5341,
-      9502,
-      9503,
-      9504,
-      16382,
-      16383,
-      16384,
-      16385,
-      19824,
-      19825,
-      19826,
-      19827,
-      19828,
-      19829,
-      19830,
-      19831,
-      19832,
-      19833,
-      19834,
-      19835,
-      19836,
-      19837,
-      19838,
-      23914,
-      23915,
-      23916,
-      31777,
-      31778,
-      31779,
-      31780,
-      19839,
-      4812,
-      4813,
-      4814
+      "VIKING_GRASS_4",
+      "MM_JUNGLE_GRASS1",
+      "MM_JUNGLE_GRASS2",
+      "MM_JUNGLE_GRASS3",
+      "SLAYER_SHORT_GRASS_1",
+      "SLAYER_SHORT_GRASS_2",
+      "SLAYER_SHORT_GRASS_3",
+      "SLAYER_SHORT_GRASS_4",
+      "SLAYER_SHORT_GRASS_3_CASTLE_EDGE",
+      "SLAYER_SHORT_GRASS_4_CASTLE_EDGE",
+      "AHOY_SHORT_GRASS_4_WALL_CORNER",
+      "LIGHTGREEN_GRASS1",
+      "LIGHTGREEN_GRASS2",
+      "LIGHTGREEN_GRASS3",
+      "GRASSLAND_SHORT_GRASS_1",
+      "GRASSLAND_SHORT_GRASS_2",
+      "GRASSLAND_SHORT_GRASS_3",
+      "GRASSLAND_SHORT_GRASS_4",
+      "HUNTING_LONG_JUNGLE_GRASS1",
+      "HUNTING_LONG_JUNGLE_GRASS2",
+      "HUNTING_LONG_JUNGLE_GRASS3",
+      "HUNTING_JUNGLE_GRASS1",
+      "HUNTING_JUNGLE_GRASS2",
+      "HUNTING_JUNGLE_GRASS3",
+      "HUNTING_GREENVINE_STRAIGHT",
+      "HUNTING_GREENVINE_CORNER",
+      "HUNTING_GREENVINE_JUNCTION",
+      "HUNTING_GREENVINE_DIAG1",
+      "HUNTING_GREENVINE_DIAG2",
+      "HUNTING_GREENVINE_DIAG3",
+      "HUNTING_GREENVINE_DIAGFILLER",
+      "HUNTING_GREENVINE_END",
+      "HUNTING_GREENVINE_END_DIAG",
+      "GRASSLAND_SHORT_3_CASTLE_EDGE",
+      "GRASSLAND_SHORT_4_CASTLE_EDGE",
+      "GRASSLAND_SHORT_4_CASTLE_EDGE2",
+      "DS2_OGRE_BROWN_GRASS_1",
+      "DS2_OGRE_BROWN_GRASS_2",
+      "DS2_OGRE_BROWN_GRASS_3",
+      "DS2_OGRE_BROWN_GRASS_4",
+      "HUNTING_JUNGLE_PLANT1",
+      "MM_LONG_JUNGLE_GRASS1",
+      "MM_LONG_JUNGLE_GRASS2",
+      "MM_LONG_JUNGLE_GRASS3"
     ],
     "flatNormals": true,
     "inheritTileColorType": "UNDERLAY"
@@ -2049,102 +2049,102 @@
     "inheritTileColorType": "UNDERLAY",
     "castShadows": false,
     "objectIds": [
-      1253,
-      1272,
-      1273,
-      1274,
-      3547,
-      3548,
-      3549,
-      3698,
-      3699,
-      3700,
-      4333,
-      4334,
-      4335,
-      4530,
-      4735,
-      4736,
-      4737,
-      4738,
-      4740,
-      4741,
-      4742,
-      4739,
-      5210,
-      5211,
-      5212,
-      5213,
-      5533,
-      5534,
-      5535,
-      5335,
-      5336,
-      5337,
-      5338,
-      5339,
-      5340,
-      5342,
-      5338,
-      5536,
-      6817,
-      6818,
-      6819,
-      6835,
-      6836,
-      6837,
-      6838,
-      7049,
-      7050,
-      7051,
-      7262,
-      7263,
-      7264,
-      7265,
-      7266,
-      7267,
-      7269,
-      8724,
-      9484,
-      9485,
-      9486,
-      9487,
-      9488,
-      9489,
-      9490,
-      9491,
-      9505,
-      9506,
-      9507,
-      13861,
-      13862,
-      13863,
-      14775,
-      14776,
-      14777,
-      14778,
-      20742,
-      20743,
-      20744,
-      20745,
-      20746,
-      20747,
-      30862,
-      30863,
-      30864,
-      34490,
-      34491,
-      34492,
-      34493
+      "GRASS_1",
+      "GRASS_1_SWAMP",
+      "GRASS_2_SWAMP",
+      "GRASS_3_SWAMP",
+      "REGICIDE_GRASS1",
+      "REGICIDE_GRASS2",
+      "REGICIDE_GRASS3",
+      "DEATH_GRASS_1",
+      "DEATH_GRASS_2",
+      "DEATH_GRASS_3",
+      "VIKING_GRASS_1",
+      "VIKING_GRASS_2",
+      "VIKING_GRASS_3",
+      "POH_GRASS",
+      "SHORT_GRASS_1",
+      "SHORT_GRASS_2",
+      "SHORT_GRASS_3",
+      "SHORT_GRASS_4",
+      "SHORT_GRASS_4_CASTLE_EDGE",
+      "SHORT_GRASS_4_CASTLE_EDGE2",
+      "SHORT_GRASS_4_CASTLE_CORNER",
+      "SHORT_GRASS_3_CASTLE_EDGE",
+      "FENK_LIGHT_GRASS_1",
+      "FENK_LIGHT_GRASS_2",
+      "FENK_LIGHT_GRASS_3",
+      "FENK_LIGHT_GRASS_4",
+      "SHORT_GRASS_3_WALL_EDGE",
+      "SHORT_GRASS_4_WALL_EDGE",
+      "SHORT_GRASS_4_WALL_CORNER",
+      "AHOY_SHORT_GRASS_1",
+      "AHOY_SHORT_GRASS_2",
+      "AHOY_SHORT_GRASS_3",
+      "AHOY_SHORT_GRASS_4",
+      "AHOY_SHORT_GRASS_3_WALL_EDGE",
+      "AHOY_SHORT_GRASS_4_WALL_EDGE",
+      "AHOY_SHORT_GRASS_WALL_EDGE_2",
+      "AHOY_SHORT_GRASS_4",
+      "SHORT_GRASS_WALL_EDGE_2",
+      "SHORT_GRASS_DARK_1",
+      "SHORT_GRASS_DARK_2",
+      "SHORT_GRASS_DARK_3",
+      "SHORT_GRASS_DARK_4",
+      "SHORT_GRASS_DARK_3_CASTLE_EDGE",
+      "SHORT_GRASS_DARK_4_CASTLE_EDGE",
+      "SHORT_GRASS_DARK_4_CASTLE_EDGE2",
+      "SHORT_GRASS_DARK_3_WALL_EDGE",
+      "SHORT_GRASS_DARK_4_WALL_EDGE",
+      "SHORT_GRASS_DARK_4_WALL_CORNER",
+      "DEATH_SHORT_GRASS_1",
+      "DEATH_SHORT_GRASS_2",
+      "DEATH_SHORT_GRASS_3",
+      "DEATH_SHORT_GRASS_4",
+      "DEATH_SHORT_GRASS_3_WALL_EDGE",
+      "DEATH_SHORT_GRASS_4_WALL_EDGE",
+      "DEATH_SHORT_GRASS_WALL_EDGE_2",
+      "AHOY_SHORT_GRASS_2_WALL_CORNER",
+      "SHORT_GRASS_2_WALL_CORNER",
+      "LONG_GRASS_1",
+      "LONG_GRASS_2",
+      "LONG_GRASS_3",
+      "LONG_GRASS_4",
+      "LONG_GRASS_3_CASTLE_EDGE",
+      "LONG_GRASS_4_CASTLE_EDGE",
+      "LONG_GRASS_4_CASTLE_EDGE2",
+      "YELLOW_GRASS1",
+      "YELLOW_GRASS2",
+      "YELLOW_GRASS3",
+      "TEMPLETREK_GRASS1",
+      "TEMPLETREK_GRASS2",
+      "TEMPLETREK_GRASS3",
+      "WILD_MUD_GRASS_1",
+      "WILD_MUD_GRASS_2",
+      "WILD_MUD_GRASS_3",
+      "WILD_MUD_GRASS_4",
+      "BARROWS_SHORT_GRASS_1",
+      "BARROWS_SHORT_GRASS_2",
+      "BARROWS_SHORT_GRASS_3",
+      "BARROWS_SHORT_GRASS_4",
+      "BARROWS_GRASS_3_WALL_EDGE",
+      "BARROWS_GRASS_4_WALL_EDGE",
+      "FOSSIL_GRASS_LUSH_LONG",
+      "FOSSIL_GRASS_LUSH_SHORT",
+      "FOSSIL_GRASS_LUSH_SPARSE",
+      "KEBOS_FARMING_GUILD_GRASS_1",
+      "KEBOS_FARMING_GUILD_GRASS_2",
+      "KEBOS_FARMING_GUILD_GRASS_3",
+      "KEBOS_FARMING_GUILD_GRASS_4"
     ]
   },
   {
     "description": "Short grass that is constructed out of triangles at perpendicular angles from each other. Shouldn't cast shadows, and should use up as the normal direction to prevent lighting artifacts.",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      1257,
-      1258,
-      1259
+      "GRASS_LIGHT_1",
+      "GRASS_LIGHT_2",
+      "GRASS_LIGHT_3"
     ],
     "flatNormals": true,
     "upwardsNormals": true,
@@ -2155,97 +2155,97 @@
     "description": "Farming Patch Grass without Dirt",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      7558,
-      7559,
-      7560,
-      7574,
-      7575,
-      7576,
-      7744,
-      7745,
-      7746,
-      7773,
-      7774,
-      7775,
-      7841,
-      7842,
-      7843,
-      7844,
-      7845,
-      7846,
-      8048,
-      8049,
-      8050,
-      8133,
-      8134,
-      8135,
-      8136,
-      8137,
-      8138,
-      8312,
-      8313,
-      8314,
-      8340,
-      8341,
-      8342,
-      8393,
-      8394,
-      8395,
-      9167,
-      9168,
-      9163,
-      9178,
-      9179,
-      9180,
-      9182,
-      9183,
-      9184,
-      9186,
-      9187,
-      9188,
-      9211,
-      9212,
-      9213,
-      9225,
-      9226,
-      9227,
-      9234,
-      9235,
-      9236,
-      10097,
-      10098,
-      10099,
-      10103,
-      30477,
-      30475,
-      30479,
-      30484,
-      30485,
-      30486,
-      33695,
-      33696,
-      33697,
-      33722,
-      33723,
-      33724,
-      33981,
-      33982,
-      33983,
-      34036,
-      34037,
-      34038,
-      34040,
-      34041,
-      34042,
-      34044,
-      34045,
-      34046,
-      34048,
-      34049,
-      34050,
-      34908,
-      34909,
-      34910
+      "BELLADONNA_PATCH_WEEDS_1",
+      "BELLADONNA_PATCH_WEEDS_2",
+      "BELLADONNA_PATCH_WEEDS_3",
+      "BUSH_PATCH_WEEDS_1",
+      "BUSH_PATCH_WEEDS_2",
+      "BUSH_PATCH_WEEDS_3",
+      "CACTUS_PATCH_WEEDS_1",
+      "CACTUS_PATCH_WEEDS_2",
+      "CACTUS_PATCH_WEEDS_3",
+      "CALQUAT_PATCH_WEEDS_1",
+      "CALQUAT_PATCH_WEEDS_2",
+      "CALQUAT_PATCH_WEEDS_3",
+      "FLOWER_PATCH_WEEDS_1",
+      "FLOWER_PATCH_WEEDS_2",
+      "FLOWER_PATCH_WEEDS_3",
+      "FLOWER_PATCH_WEEDS_1_MORY",
+      "FLOWER_PATCH_WEEDS_2_MORY",
+      "FLOWER_PATCH_WEEDS_3_MORY",
+      "FRUIT_TREE_PATCH_WEEDS_1",
+      "FRUIT_TREE_PATCH_WEEDS_2",
+      "FRUIT_TREE_PATCH_WEEDS_3",
+      "HERB_PATCH_WEEDS_1",
+      "HERB_PATCH_WEEDS_2",
+      "HERB_PATCH_WEEDS_3",
+      "HERB_PATCH_WEEDS_1_MORY",
+      "HERB_PATCH_WEEDS_2_MORY",
+      "HERB_PATCH_WEEDS_3_MORY",
+      "BITTERCAP_PATCH_WEEDS_1",
+      "BITTERCAP_PATCH_WEEDS_2",
+      "BITTERCAP_PATCH_WEEDS_3",
+      "SPIRIT_TREE_PATCH_WEEDS_1",
+      "SPIRIT_TREE_PATCH_WEEDS_2",
+      "SPIRIT_TREE_PATCH_WEEDS_3",
+      "TREE_PATCH_WEEDS_1",
+      "TREE_PATCH_WEEDS_2",
+      "TREE_PATCH_WEEDS_3",
+      "GARDEN_DELPHINIUMS_WEEDS_1",
+      "GARDEN_DELPHINIUMS_WEEDS_2",
+      "RUGSIDE_DARK_RED",
+      "GARDEN_ROSEBUSH_PINK_WEEDS_1",
+      "GARDEN_ROSEBUSH_PINK_WEEDS_2",
+      "GARDEN_ROSEBUSH_PINK_WEEDS_3",
+      "GARDEN_ROSEBUSH_WHITE_WEEDS_1",
+      "GARDEN_ROSEBUSH_WHITE_WEEDS_2",
+      "GARDEN_ROSEBUSH_WHITE_WEEDS_3",
+      "GARDEN_ROSEBUSH_RED_WEEDS_1",
+      "GARDEN_ROSEBUSH_RED_WEEDS_2",
+      "GARDEN_ROSEBUSH_RED_WEEDS_3",
+      "GARDEN_WHITE_TREE_WEEDS_1",
+      "GARDEN_WHITE_TREE_WEEDS_2",
+      "GARDEN_WHITE_TREE_WEEDS_3",
+      "GARDEN_SNOWDROPS_WEEDS_1",
+      "GARDEN_SNOWDROPS_WEEDS_2",
+      "GARDEN_SNOWDROPS_WEEDS_3",
+      "GARDEN_VINES_WEEDS_1",
+      "GARDEN_VINES_WEEDS_2",
+      "GARDEN_VINES_WEEDS_3",
+      "DEAL_BLINDWEED_WEEDS3",
+      "DEAL_BLINDWEED_WEEDS2",
+      "DEAL_BLINDWEED_WEEDS1",
+      "DEAL_OVERGROWN_PATCH",
+      "HARDWOOD_TREE_PATCH_WEEDS_1",
+      "TEAK_TREE_6_DEAD_TOP",
+      "HARDWOOD_TREE_PATCH_WEEDS_3",
+      "SEAWEED_PATCH_WEEDS_1",
+      "SEAWEED_PATCH_WEEDS_2",
+      "SEAWEED_PATCH_WEEDS_3",
+      "CELASTRUS_PATCH_WEEDED",
+      "CELASTRUS_PATCH_WEEDS_1",
+      "CELASTRUS_PATCH_WEEDS_2",
+      "HESPORI_PATCH_WEEDS_3",
+      "HESPORI_PATCH_WEEDS_2",
+      "HESPORI_PATCH_WEEDS_1",
+      "ANIMA_PATCH_WEEDS_1",
+      "ANIMA_PATCH_WEEDS_2",
+      "ANIMA_PATCH_WEEDS_3",
+      "FARMING_PATCH_REDWOOD_3X3_WEEDS_1",
+      "FARMING_PATCH_REDWOOD_3X3_WEEDS_2",
+      "FARMING_PATCH_REDWOOD_3X3_WEEDS_3",
+      "FARMING_PATCH_REDWOOD_3X2_WEEDS_1",
+      "FARMING_PATCH_REDWOOD_3X2_WEEDS_2",
+      "FARMING_PATCH_REDWOOD_3X2_WEEDS_3",
+      "FARMING_PATCH_REDWOOD_2X3_WEEDS_1",
+      "FARMING_PATCH_REDWOOD_2X3_WEEDS_2",
+      "FARMING_PATCH_REDWOOD_2X3_WEEDS_3",
+      "FARMING_PATCH_REDWOOD_2X2_WEEDS_1",
+      "FARMING_PATCH_REDWOOD_2X2_WEEDS_2",
+      "FARMING_PATCH_REDWOOD_2X2_WEEDS_3",
+      "CRYSTAL_TREE_PATCH_WEEDS_1",
+      "CRYSTAL_TREE_PATCH_WEEDS_2",
+      "CRYSTAL_TREE_PATCH_WEEDS_3"
     ],
     "upwardsNormals": true
   },
@@ -2253,21 +2253,21 @@
     "description": "Farming Patch Grass with Dirt",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      8208,
-      8209,
-      8210,
-      8574,
-      8575,
-      8576,
-      8577,
-      8578,
-      8579,
-      9400,
-      9401,
-      9402,
-      15063,
-      15064,
-      15065
+      "HOP_PATCH_WEEDS_1",
+      "HOP_PATCH_WEEDS_2",
+      "HOP_PATCH_WEEDS_3",
+      "VEG_PATCH_WEEDS_1",
+      "VEG_PATCH_WEEDS_2",
+      "VEG_PATCH_WEEDS_3",
+      "VEG_PATCH_WEEDS_1_MORY",
+      "VEG_PATCH_WEEDS_2_MORY",
+      "VEG_PATCH_WEEDS_3_MORY",
+      "TWOCATS_PATCH_WEED1",
+      "TWOCATS_PATCH_WEED2",
+      "TWOCATS_PATCH_WEED3",
+      "MISC_WEEDINGPATCH_HEAVYWEEDS",
+      "MISC_WEEDINGPATCH_MEDWEEDS",
+      "MISC_WEEDINGPATCH_LIGHTWEEDS"
     ],
     "upwardsNormals": true,
     "colorOverrides": [
@@ -2282,12 +2282,12 @@
     "description": "Farming Patch Grass with Dirt and Scarecrow",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      7916,
-      7917,
-      7918,
-      9338,
-      9339,
-      9340
+      "FARMING_SCARECROW_WEEDS_1",
+      "FARMING_SCARECROW_WEEDS_2",
+      "FARMING_SCARECROW_WEEDS_3",
+      "FARMING_SCARECROW_WEEDS_1_MORY",
+      "FARMING_SCARECROW_WEEDS_2_MORY",
+      "FARMING_SCARECROW_WEEDS_3_MORY"
     ],
     "upwardsNormals": true,
     "colorOverrides": [
@@ -2301,17 +2301,17 @@
   {
     "description": "Kharidian Desert Grass",
     "baseMaterial": "GRAY_75",
-    "objectIds": [ 3547, 3548, 3549 ],
+    "objectIds": [ "REGICIDE_GRASS1", "REGICIDE_GRASS2", "REGICIDE_GRASS3" ],
     "areas": [ "KHARID_DESERT_REGION" ]
   },
   {
     "description": "Short grass with rock objects",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      17446,
-      17447,
-      17448,
-      17449
+      "QIP_DS_STONE_FLOOR1",
+      "QIP_DS_STONE_FLOOR2",
+      "QIP_DS_STONE_FLOOR_EDGE1",
+      "QIP_DS_STONE_FLOOR_EDGE2"
     ],
     "flatNormals": true,
     "castShadows": false
@@ -2320,14 +2320,14 @@
     "description": "Short grass with rock objects usually found around Farming Patches",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      7129,
-      7518,
-      7519,
-      34494,
-      34495,
-      34496,
-      46411,
-      46412
+      "FAI_VARROCK_FARMING_BORDER_STRAIGHT",
+      "FARMING_BORDER_STRAIGHT",
+      "FARMING_BORDER_CORNER",
+      "KEBOS_FARMING_GUILD_BORDER_STRAIGHT",
+      "KEBOS_FARMING_GUILD_BORDER_CORNER",
+      "KEBOS_FARMING_GUILD_BORDER_CORNER_OUTSIDE",
+      "TGOD_GARDEN_TEMPLE_FARMING_BORDER_STRAIGHT",
+      "TGOD_GARDEN_TEMPLE_FARMING_BORDER_CORNER_OUTSIDE"
     ],
     "flatNormals": true,
     "castShadows": false,
@@ -2345,7 +2345,7 @@
     "areas": [ "FARMING_GUILD_HESPORI" ],
     "baseMaterial": "COLORED_GRASS",
     "objectIds": [
-      34492
+      "KEBOS_FARMING_GUILD_GRASS_3"
     ]
   },
   {
@@ -2353,8 +2353,8 @@
     "areas": [ "FARMING_GUILD_HESPORI" ],
     "baseMaterial": "COLORED_GRASS",
     "objectIds": [
-      34494,
-      34496
+      "KEBOS_FARMING_GUILD_BORDER_STRAIGHT",
+      "KEBOS_FARMING_GUILD_BORDER_CORNER_OUTSIDE"
     ],
     "castShadows": false,
     "colorOverrides": [
@@ -2376,8 +2376,8 @@
     "description": "Short grass with rock objects Morytania Farming Patches",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      7520,
-      7521
+      "FARMING_BORDER_STRAIGHT_DARK",
+      "FARMING_BORDER_CORNER_DARK"
     ],
     "flatNormals": true,
     "castShadows": false,
@@ -2394,11 +2394,11 @@
     "description": "Objects with Short grass which shouldn't cast shadows and shouldn't inherit tile color",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      3934,
-      3935,
-      3936,
-      7110,
-      7111
+      "REGICIDE_BLUE_GRASS1",
+      "REGICIDE_BLUE_GRASS2",
+      "REGICIDE_BLUE_GRASS3",
+      "FAI_VARROCK_DRAINS1",
+      "FAI_VARROCK_DRAINS2"
     ],
     "castShadows": false,
     "flatNormals": true
@@ -2407,20 +2407,20 @@
     "description": "Varlamore, Fortis and Avium Grass",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      51804,
-      51805,
-      51806,
-      51808,
-      51809,
-      51807,
-      51810,
-      51811,
-      51812,
-      51813,
-      51814,
-      51815,
-      51816,
-      51817
+      "AVIUM_GRASS_1",
+      "AVIUM_GRASS_2",
+      "AVIUM_GRASS_3",
+      "AVIUM_GRASS_5",
+      "AVIUM_GRASS_6",
+      "AVIUM_GRASS_4",
+      "AVIUM_GRASS_TALL1",
+      "AVIUM_GRASS_TALL2",
+      "AVIUM_GRASS_TALL3",
+      "AVIUM_GRASS_TALL4",
+      "AVIUM_GRASS_TALL1_DRY",
+      "AVIUM_GRASS_TALL2_DRY",
+      "AVIUM_GRASS_TALL3_DRY",
+      "AVIUM_GRASS_TALL4_DRY"
     ],
     "flatNormals": true,
     "castShadows": false
@@ -2430,7 +2430,7 @@
     "baseMaterial": "GRAY_75",
     "areas": [ "VARLAMORE" ],
     "objectIds": [
-      19829
+      "HUNTING_JUNGLE_GRASS3"
     ],
     "flatNormals": true,
     "castShadows": false
@@ -2440,14 +2440,14 @@
     "baseMaterial": "GRAY_75",
     "seasonalTheme": "WINTER",
     "objectIds": [
-      7129,
-      7518,
-      7519,
-      7520,
-      7521,
-      34494,
-      34495,
-      34496
+      "FAI_VARROCK_FARMING_BORDER_STRAIGHT",
+      "FARMING_BORDER_STRAIGHT",
+      "FARMING_BORDER_CORNER",
+      "FARMING_BORDER_STRAIGHT_DARK",
+      "FARMING_BORDER_CORNER_DARK",
+      "KEBOS_FARMING_GUILD_BORDER_STRAIGHT",
+      "KEBOS_FARMING_GUILD_BORDER_CORNER",
+      "KEBOS_FARMING_GUILD_BORDER_CORNER_OUTSIDE"
     ],
     "flatNormals": true,
     "inheritTileColorType": "UNDERLAY",
@@ -2457,7 +2457,7 @@
     "description": "Fixes weird pattern made by grass in POH",
     "areas": [ "PLAYER_OWNED_HOUSE" ],
     "objectIds": [
-      4530
+      "POH_GRASS"
     ],
     "baseMaterial": "GRAY_65",
     "flatNormals": true,
@@ -2466,10 +2466,10 @@
   {
     "description": "GRASS_MAINTAIN_ORIGINAL_COLOR",
     "objectIds": [
-      16823,
-      16824,
-      16825,
-      16826
+      "LUNAR_BROWN_GRASS_1",
+      "LUNAR_BROWN_GRASS_2",
+      "LUNAR_BROWN_GRASS_3",
+      "LUNAR_BROWN_GRASS_4"
     ],
     "flatNormals": true,
     "castShadows": false
@@ -2478,46 +2478,46 @@
     "description": "WOODEN_FENCES",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      166,
-      167,
-      883,
-      980,
-      981,
-      991,
-      992,
-      1007,
-      1008,
-      1565,
-      1566,
-      2664,
-      2665,
-      7055,
-      9511,
-      9623,
-      9470,
-      9708,
-      1558,
-      1559,
-      1560,
-      1561,
-      1562,
-      1563,
-      1564,
-      1565,
-      1566,
-      1567,
-      1739,
-      1740,
-      2438,
-      2439,
-      993,
-      7527,
-      20857,
-      23917,
-      23918,
-      23919,
-      25677,
-      10714
+      "PLAGUESHEEP_GATEL",
+      "PLAGUESHEEP_GATER",
+      "RUSTIC_FENCEGATE_L",
+      "FENCING",
+      "GARDENFENCING",
+      "GRASSYFENCING",
+      "GRASSYFENCING2",
+      "FENCE_TERMINATOR_LEFT",
+      "FENCE_TERMINATOR_RIGHT",
+      "INACTIVEFENCEGATE_R",
+      "INACTIVEFENCEGATE_L",
+      "MURDERDOGGATEL",
+      "MURDERDOGGATER",
+      "FARMING_FENCING",
+      "PIER_RAIL_BROKE",
+      "RIMMINGTON_FENCING",
+      "NEWBIEGATECLOSEDL2",
+      "NEWBIEGATECLOSEDR2",
+      "FENCEGATE_L",
+      "OPENFENCEGATE_L",
+      "FENCEGATE_R",
+      "FARMING_FENCEGATE_L",
+      "FARMING_FENCEGATE_R",
+      "FARMING_OPENFENCEGATE_L",
+      "FARMING_OPENFENCEGATE_R",
+      "INACTIVEFENCEGATE_R",
+      "INACTIVEFENCEGATE_L",
+      "OPENFENCEGATE_R",
+      "FARMING_FENCE_GATE_PERM_OPEN_L",
+      "FARMING_FENCE_GATE_PERM_OPEN_R",
+      "GRANDTREE_FENCEGATE_L",
+      "GRANDTREE_FENCEGATE_R",
+      "FULLSTYLE",
+      "FARMING_STYLE",
+      "MACRO_BEE_FENCING",
+      "RUSTIC_FENCEGATE_R",
+      "RUSTIC_OPENFENCEGATE_L",
+      "RUSTIC_OPENFENCEGATE_R",
+      "MURDER_QIP_GARDENFENCING",
+      "ROYAL_RAIL"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -2528,7 +2528,7 @@
     "description": "Wooden - Fences - V Slats",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      17310
+      "QIP_DIGSITE_GARDEN_FENCE"
     ],
     "uvOrientation": 512,
     "uvType": "MODEL_XY"
@@ -2537,14 +2537,14 @@
     "description": "STONE_STEPS",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      3684,
-      4279,
-      9675,
-      9676,
-      9677,
-      9678,
-      20950,
-      20951
+      "DEATH_SKEWSTEPS",
+      "VIKING_SKEWSTEPS",
+      "RIMMINGTON_SKEWSTEPS",
+      "RIMMINGTON_SKEWSTEPS_CORNER",
+      "RIMMINGTON_FLOORSTEPS",
+      "RIMMINGTON_FLOORSTEPS_WATER_SOURCE",
+      "NTK_SKEWSTEPS",
+      "NTK_SKEWSTEPS_CORNER"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -2552,12 +2552,12 @@
   {
     "description": "LUMBRIDGE_CASTLE_WALLS",
     "objectIds": [
-      1651,
-      1911,
-      1912,
-      1913,
-      1943,
-      1944
+      "CROSS_CASTLEEDGE",
+      "CASTLEWALL",
+      "BIGSTONE_CASTLEWALL",
+      "CASTLEBATTLEMENTS",
+      "CASTLECRUMBLY_L",
+      "CASTLECRUMBLY_R"
     ],
     "flatNormals": true
   },
@@ -2565,11 +2565,11 @@
     "description": "VARROCK_FOUNTAIN_FLOOR",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      7150,
-      7149,
-      7151,
-      7152,
-      7153
+      "FAI_VARROCK_CENTRAL_SQUARE_FLOOR02",
+      "FAI_VARROCK_CENTRAL_SQUARE_FLOOR01",
+      "FAI_VARROCK_CENTRAL_SQUARE_FLOOR03",
+      "FAI_VARROCK_CENTRAL_SQUARE_FLOOR04",
+      "FAI_VARROCK_CENTRAL_SQUARE_FLOOR05"
     ],
     "flatNormals": true,
     "uvType": "MODEL_XZ"
@@ -2578,11 +2578,11 @@
     "description": "Varrock Fountain Walls and Statue",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      7144,
-      7145,
-      7146,
-      7147,
-      7148
+      "FAI_VARROCK_CENTRAL_SQUARE_STATUE01",
+      "FAI_VARROCK_CENTRAL_SQUARE_STATUE_FOOT01",
+      "FAI_VARROCK_CENTRAL_SQUARE_STATUE_RAILING01",
+      "FAI_VARROCK_CENTRAL_SQUARE_STATUE_RAILING_MIRROR01",
+      "FAI_VARROCK_CENTRAL_SQUARE_STATUE_FOOT_MIRROR01"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -2591,7 +2591,7 @@
     "description": "Varrock Fountain Rocks with Water",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      7143
+      "FAI_VARROCK_CENTRAL_SQUARE01"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -2607,51 +2607,51 @@
     "description": "VARROCK_KNIGHT_STATUE",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      3642
+      "FAI_VARROCK_STATUE_KNIGHT_SWORD"
     ]
   },
   {
     "description": "GRAND_EXCHANGE_FLOOR",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      9371,
-      10689,
-      10690,
-      10691,
-      10692,
-      10693,
-      10694,
-      10695,
-      10696,
-      10699,
-      10700,
-      10701,
-      10702,
-      10703,
-      10704,
-      10705,
-      10706,
-      10711,
-      10712,
-      10713,
-      11703,
-      11704,
-      11705,
-      11706,
-      11707,
-      11708,
-      11709,
-      11710,
-      11711,
-      11712,
-      11713,
-      11714,
-      11715,
-      11716,
-      11717,
-      15810,
-      16010,
-      16155
+      "EXCHANGE_STAIRS_VAR01_MIRROR",
+      "EXCHANGE_STAIRS_VAR01",
+      "EXCHANGE_STAIRS_VAR01_63",
+      "EXCHANGE_STAIRS_VAR01_64",
+      "EXCHANGE_STAIRS_VAR01_65",
+      "EXCHANGE_STAIRS_VAR01_66",
+      "EXCHANGE_STAIRS_VAR01_67",
+      "EXCHANGE_STAIRS_VAR01_69",
+      "EXCHANGE_STAIRS_VAR01_70",
+      "EXCHANGE_STAIRS_VAR01_63_MIRROR",
+      "EXCHANGE_STAIRS_VAR01_64_MIRROR",
+      "EXCHANGE_STAIRS_VAR01_69_MIRROR",
+      "EXCHANGE_STAIRS_VAR01_70_MIRROR",
+      "EXCHANGE_FLOOR_ARMOURY01_1X1",
+      "EXCHANGE_FLOOR_ARMOURY02_1X1",
+      "EXCHANGE_FLOOR_ARMOURY03_1X1",
+      "EXCHANGE_FLOOR_ARMOURY04_1X1",
+      "EXCHANGE_FLOOR_HERBS01_1X1",
+      "EXCHANGE_FLOOR_HERBS02_1X1",
+      "EXCHANGE_FLOOR_HERBS03_1X1",
+      "SNAKEBOSS_FAIRY_MUSHROOM_RING",
+      "EXCHANGE_FLOOR_HERBS04_1X1",
+      "EXCHANGE_FLOOR_LOGS01_1X1",
+      "EXCHANGE_FLOOR_LOGS02_1X1",
+      "EXCHANGE_FLOOR_LOGS03_1X1",
+      "EXCHANGE_FLOOR_LOGS04_1X1",
+      "EXCHANGE_FLOOR_MINERALS01_1X1",
+      "EXCHANGE_FLOOR_MINERALS02_1X1",
+      "EXCHANGE_FLOOR_MINERALS03_1X1",
+      "EXCHANGE_FLOOR_MINERALS04_1X1",
+      "EXCHANGE_FLOOR_RUNE01_1X1",
+      "EXCHANGE_FLOOR_RUNE02_1X1",
+      "EXCHANGE_FLOOR_RUNE03_1X1",
+      "EXCHANGE_FLOOR_RUNE04_1X1",
+      "EXCHANGE_FLOOR_VAR01_1X1",
+      "EXCHANGE_FLOOR_VAR02_1X1",
+      "EXCHANGE_FLOOR_VAR03_1X1",
+      "EXCHANGE_FLOOR_VAR04_1X1"
     ],
     "flatNormals": true,
     "uvType": "MODEL_XZ"
@@ -2660,12 +2660,12 @@
     "description": "GRAND_EXCHANGE_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23755,
-      23776,
-      23777,
-      23778,
-      23779,
-      23795
+      "FAI_VARROCK_SMALL_WALL",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_CAPPED",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_HILLSKEW",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_HILLSKEW_SHARELIGHT",
+      "FAI_VARROCK_CASTLE_WALL_NO_BACK",
+      "FAI_VARROCK_CASTLE_WALL_NO_BACK_HILLSKEW"
     ],
     "flatNormals": true
   },
@@ -2673,7 +2673,7 @@
     "description": "GRAND_EXCHANGE_CLAN_PORTAL",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      41724
+      "CLAN_HUB_PORTAL"
     ],
     "flatNormals": true,
     "shadowOpacityThreshold": 0.12
@@ -2682,44 +2682,44 @@
     "description": "GRAND_EXCHANGE_STONE_DECORATION",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      10063,
-      10643,
-      10644,
-      10645,
-      10646,
-      10647,
-      10648,
-      10649,
-      10650,
-      10651,
-      10652,
-      10653,
-      10654,
-      10655,
-      10656,
-      10657,
-      10664,
-      10665,
-      10666,
-      10667,
-      10668,
-      10669,
-      10673,
-      10674,
-      10675,
-      10676,
-      10677,
-      10678,
-      10679,
-      10680,
-      10681,
-      10682,
-      10683,
-      10684,
-      10685,
-      10686,
-      10687,
-      10688
+      "EXCHANGE_LOWER_CENTRE_PILLAR",
+      "EXCHANGE_UPPER_CENTRAL_PILLAR",
+      "EXCHANGE_PILLAR_ICON",
+      "EXCHANGE_TOP_WALL_01",
+      "EXCHANGE_TOP_WALL_02",
+      "EXCHANGE_WALL_LOWER",
+      "EXCHANGE_WALL_LOWER_ARCH_01",
+      "EXCHANGE_WALL_LOWER_ARCH_01_MIRROR",
+      "EXCHANGE_WALL_LOWER_ARCH_01_FLIP",
+      "EXCHANGE_WALL_LOWER_ARCH_02",
+      "EXCHANGE_WALL_LOWER_ARCH_02_MIRROR",
+      "EXCHANGE_WALL_LOWER_ARCH_02_FLIP",
+      "EXCHANGE_WALL_LOWER_FOR_PILLAR",
+      "EXCHANGE_WALL_LOWER_PILLAR",
+      "EXCHANGE_WALL_LOWER_PILLAR_CORNER_01",
+      "EXCHANGE_WALL_LOWER_PILLAR_CORNER_02",
+      "EXCHANGE_WALL_LOWER_PILLAR_DIAG",
+      "EXCHANGE_WALL_UPPER",
+      "EXCHANGE_WALL_UPPER_ARCH_01",
+      "EXCHANGE_WALL_UPPER_ARCH_01_MIRROR",
+      "EXCHANGE_WALL_UPPER_ARCH_02",
+      "EXCHANGE_WALL_UPPER_ARCH_02_MIRROR",
+      "EXCHANGE_WALL_UPPER_ARCH_02_FLIP",
+      "EXCHANGE_WALL_UPPER_ARCH_03",
+      "EXCHANGE_WALL_UPPER_ARCH_03_FLIP",
+      "EXCHANGE_WALL_UPPER_ARCH_04",
+      "EXCHANGE_WALL_UPPER_ARCH_04_MIRROR",
+      "EXCHANGE_WALL_UPPER_ARCH_04_FLIP",
+      "EXCHANGE_WALL_UPPER_ARCH_04_FRONT",
+      "EXCHANGE_WALL_UPPER_ARCH_04_FRONT_MIRROR",
+      "EXCHANGE_WALL_UPPER_FOR_PILLAR",
+      "EXCHANGE_WALL_UPPER_FOR_PILLAR_MIRROR",
+      "EXCHANGE_WALL_UPPER_FOR_PILLAR_FLIP",
+      "EXCHANGE_WALL_UPPER_PILLAR",
+      "EXCHANGE_WALL_UPPER_PILLAR_CORNER_01",
+      "EXCHANGE_WALL_UPPER_PILLAR_CORNER_02",
+      "EXCHANGE_WALL_UPPER_PILLAR_CORNER_FLIPPED_02",
+      "EXCHANGE_WALL_UPPER_PILLAR_DIAG"
     ],
     "flatNormals": true
   },
@@ -2737,22 +2737,22 @@
       }
     ],
     "objectIds": [
-      490,
-      492,
-      493,
-      494,
-      495,
-      506,
-      507,
-      508,
-      509,
-      510,
-      515,
-      517,
-      518,
-      519,
-      520,
-      40285
+      "FAI_VARROCK_SHANTY_WALL",
+      "FAI_VARROCK_SHANTY_WALL_SHARELIGHT",
+      "FAI_VARROCK_SHANTY_WALL_END_RIGHT",
+      "FAI_VARROCK_SHANTY_WALL_END_LEFT",
+      "FAI_VARROCK_SHANTY_WALL2",
+      "FAI_VARROCK_SHANTY_STRONGER_JOIN",
+      "FAI_VARROCK_WALLS_SHANTY_JOIN",
+      "FAI_VARROCK_WALLS_SHANTY_JOIN_MIRROR",
+      "FAI_VARROCK_WALLS_SHANTY_JOIN_LVL2",
+      "FAI_VARROCK_WALLS_SHANTY_JOIN_LVL2_MIRROR",
+      "FAI_VARROCK_CASTLE_AND_SHANTY_2X2_FIX",
+      "FAI_VARROCK_SHANTY_JOINT",
+      "FAI_VARROCK_SHANTY_JOINT_MIRROR",
+      "FAI_VARROCK_SHANTY_JOINT_LV2",
+      "FAI_VARROCK_SHANTY_JOINT_MIRROR_LV2",
+      "FAI_VARROCK_SHANTY_STRONGER_JOIN_MIRROR"
     ]
   },
   {
@@ -2769,10 +2769,10 @@
       }
     ],
     "objectIds": [
-      441,
-      442,
-      454,
-      23745
+      "FAI_VARROCK_POOR_WALL_WINDOW1",
+      "FAI_VARROCK_POOR_WALL_WINDOW2",
+      "FAI_VARROCK_POOR_WINDOW_LVL2_INTERIOR",
+      "FAI_VARROCK_INTERIOR_WINDOW_SHUTTERS"
     ]
   },
   {
@@ -2788,13 +2788,13 @@
       }
     ],
     "objectIds": [
-      480,
-      481,
-      482,
-      485,
-      486,
-      487,
-      488
+      "FAI_VARROCK_POOR_FILLER",
+      "FAI_VARROCK_POOR_HORRIBLE_FILLER",
+      "FAI_VARROCK_POOR_HORRIBLE_FILLER2",
+      "FAI_VARROCK_POOR_TO_BATTLE_FILLER",
+      "FAI_VARROCK_POOR_TO_BATTLE_FILLER2",
+      "FAI_VARROCK_POOR_INTERIOR_FILLER",
+      "FAI_VARROCK_POOR_INTERIOR_FILLER_MIRROR"
     ]
   },
   {
@@ -2804,18 +2804,18 @@
     "uvType": "BOX",
     "uvOrientation": 448,
     "objectIds": [
-      496,
-      497,
-      498,
-      499,
-      500,
-      501,
-      502,
-      503,
-      26589,
-      26590,
-      26591,
-      26592
+      "FAI_VARROCK_SHANTY_WALL_LEV2",
+      "FAI_VARROCK_SHANTY_WALL_LEV2_TYPE2",
+      "FAI_VARROCK_SHANTY_WALL_LEV2_END_RIGHT",
+      "FAI_VARROCK_SHANTY_WALL_LEV2_END_LEFT",
+      "FAI_VARROCK_SHANTY_WALL_INSIDE",
+      "FAI_VARROCK_SHANTY_WALL_INSIDE_MIRROR",
+      "FAI_VARROCK_SHANTY_WALL_INSIDE_END_LEFT",
+      "FAI_VARROCK_SHANTY_WALL_INSIDE_END_RIGHT",
+      "FAI_VARROCK_SHANTY_WALL_LEV2_SHORTER",
+      "FAI_VARROCK_SHANTY_WALL_LEV2_TYPE2_SHORTER",
+      "FAI_VARROCK_SHANTY_WALL_LEV2_END_RIGHT_SHORTER",
+      "FAI_VARROCK_SHANTY_WALL_LEV2_END_LEFT_SHORTER"
     ]
   },
   {
@@ -2841,8 +2841,8 @@
       }
     ],
     "objectIds": [
-      23743,
-      23744
+      "FAI_VARROCK_INTERIOR_WINDOW",
+      "FAI_VARROCK_INTERIOR_WINDOW_TYPE1"
     ]
   },
   {
@@ -2863,8 +2863,8 @@
       }
     ],
     "objectIds": [
-      23746,
-      23747
+      "FAI_VARROCK_INTERIOR_WINDOW_TALL",
+      "FAI_VARROCK_INTERIOR_WINDOW_TALL_TERM"
     ]
   },
   {
@@ -2885,149 +2885,149 @@
       }
     ],
     "objectIds": [
-      23807
+      "FAI_VARROCK_CASTLE_INTERIOR_WINDOW_CHURCH"
     ]
   },
   {
     "description": "Walls",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      436,
-      437,
-      438,
-      443,
-      444,
-      445,
-      448,
-      449,
-      450,
-      455,
-      462,
-      477,
-      451,
-      452,
-      453,
-      455,
-      456,
-      457,
-      458,
-      458,
-      459,
-      460,
-      461,
-      462,
-      463,
-      464,
-      465,
-      466,
-      467,
-      468,
-      469,
-      471,
-      472,
-      473,
-      474,
-      475,
-      476,
-      477,
-      478,
-      483,
-      484,
-      489,
-      491,
-      504,
-      505,
-      511,
-      512,
-      513,
-      514,
-      516,
-      9264,
-      9265,
-      9269,
-      23734,
-      23735,
-      23736,
-      23737,
-      23738,
-      23739,
-      23740,
-      23741,
-      23742,
-      23757,
-      23758,
-      23759,
-      23775,
-      23780,
-      23783,
-      23784,
-      23794,
-      23797,
-      23798,
-      23799,
-      23801,
-      23802,
-      23803,
-      23804,
-      23805,
-      23806,
-      23808,
-      23809,
-      23810,
-      23811,
-      23812,
-      23813,
-      23814,
-      23815,
-      23816,
-      23817,
-      23818,
-      23819,
-      23820,
-      23821,
-      23822,
-      23823,
-      23824,
-      23825,
-      23826,
-      23827,
-      23828,
-      23829,
-      23835,
-      23836,
-      23837,
-      23838,
-      23839,
-      23840,
-      23841,
-      23842,
-      23843,
-      23844,
-      23859,
-      23860,
-      23861,
-      23862,
-      23863,
-      23864,
-      23865,
-      23874,
-      23875,
-      23876,
-      23877,
-      23878,
-      23879,
-      23880,
-      23881,
-      23882,
-      23883,
-      23884,
-      23885,
-      23907,
-      23908,
-      23909,
-      23910,
-      41840,
-      24428
+      "FAI_VARROCK_POOR_WALL",
+      "FAI_VARROCK_POOR_WALL_TOP",
+      "FAI_VARROCK_POOR_WALL_TOP_ACTIVE",
+      "FAI_VARROCK_POOR_WALL_HOLES",
+      "FAI_VARROCK_POOR_WALL_DOUBLE",
+      "FAI_VARROCK_POOR_WALL_DOUBLE_TERM",
+      "FAI_VARROCK_POOR_WALL_DOUBLE_JOINL",
+      "FAI_VARROCK_POOR_WALL_DOUBLE_JOINR",
+      "FAI_VARROCK_POOR_WALL_LVL2",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_SMALL",
+      "FAI_VARROCK_POOR_WALL_TERM",
+      "FAI_VARROCK_POOR_WALL_LVL2_DOUBLE",
+      "FAI_VARROCK_POOR_WALL_LVL2_OFFSET1",
+      "FAI_VARROCK_POOR_WALL_LVL2_OFFSET2",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_DOUBLE",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_DOUBLE_LEFT",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_DOUBLE_SMALL",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_DOUBLE_SMALL",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_LEFT",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_INV",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_INV_LEFT",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_SMALL",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_SMALL_LEFT",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_SMALL_INV",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_SMALL_INV_LEFT",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_LVL2_SMALL",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_LVL2",
+      "FAI_VARROCK_WALLS_POOR_CRUMBLE_LVL2_LEFT",
+      "FAI_VARROCK_POOR_STONE_PILE1",
+      "FAI_VARROCK_POOR_STONE_PILE2",
+      "FAI_VARROCK_WALLS_CRUMBLE_LOW1",
+      "FAI_VARROCK_WALLS_CRUMBLE_LOW2",
+      "FAI_VARROCK_POOR_WALL_CRACK3",
+      "FAI_VARROCK_POOR_WALL_CRACK2",
+      "FAI_VARROCK_POOR_WALL_CRACK",
+      "FAI_VARROCK_POOR_WALL_TERM",
+      "FAI_VARROCK_POOR_PLASTER",
+      "FAI_VARROCK_LVL2_POOR_BATTLEMENT_FILLER",
+      "FAI_VARROCK_LVL2_POOR_BATTLEMENT_FILLER_MIRROR",
+      "FAI_VARROCK_POOR_CASTLE_JOIN",
+      "FAI_VARROCK_SHANTY_WALL_THREE",
+      "FAI_VARROCK_SHANTY_STRONGER_BLEND",
+      "FAI_VARROCK_SHANTY_STRONGER_BLEND_MIRROR",
+      "FAI_VARROCK_SHANTY_WALL_STRONGER",
+      "FAI_VARROCK_SHANTY_WALL_STRONGER_SHARELIGHT",
+      "FAI_VARROCK_CASTLE_SHANTY_JOIN_LOW_LEFT",
+      "FAI_VARROCK_CASTLE_SHANTY_JOIN_TOP_RIGHT",
+      "FAI_VARROCK_SHANTY_AND_BATTLEMENT",
+      "GARDEN_TRELLIS",
+      "GARDEN_TRELLIS_CONCAVE",
+      "GARDEN_TRELLIS_WALL_MIRROR",
+      "FAI_VARROCKWALL_HILLSKEW",
+      "FAI_VARROCK_INTERIORWALL",
+      "FAI_VARROCK_INTERIORWALL_BLACK",
+      "FAI_VARROCK_INTERIORWALL_BLACK_TOP",
+      "FAI_VARROCK_INTERIORWALL_TERM",
+      "FAI_VARROCK_INTERIORWALL_DOUBLE",
+      "FAI_VARROCK_INTERIOR_BANKWALL_CORNER",
+      "FAI_VARROCK_INTERIOR_BANKWALL_CORNER_END",
+      "FAI_VARROCK_INTERIORWALL_DOUBLE_TERM",
+      "FAI_VARROCK_SMALL_WALL_FILLER_MIRROR",
+      "FAI_VARROCK_SMALL_WALL_CASTLE_FILLER",
+      "FAI_VARROCK_SMALL_WALL_CASTLE_FILLER_MIRROR",
+      "FAI_VARROCK_CASTLE_BATTLEMENT",
+      "FAI_VARROCK_CASTLE_WALL_TOPPED",
+      "FAI_VARROCK_CASTLE_WALL_TOPPED_EDGE",
+      "FAI_VARROCK_CASTLE_WALL_TOPPED_LOW_MEM",
+      "FAI_VARROCK_CASTLE_WALL_NO_BACK_BUTRESS",
+      "FAI_VARROCK_CASTLEWALL",
+      "FAI_VARROCK_CASTLEWALL_TERM_LEFT",
+      "FAI_VARROCK_CASTLEWALL_TERM_RIGHT",
+      "FAI_VARROCK_CASTLE_INTERIOR_MIRROR",
+      "FAI_VARROCK_CASTLE_INTERIOR_MIRROR_TERM",
+      "FAI_VARROCK_CASTLE_INTERIOR_MIRROR_TERM_LIP",
+      "FAI_VARROCK_CASTLE_INTERIOR_MIRROR_TERM_LIP_MIRROR",
+      "FAI_VARROCK_CASTLE_INTERIOR_CUSTOM",
+      "FAI_VARROCK_CASTLE_INTERIOR_WINDOW",
+      "FAI_VARROCK_CASTLE_WALLS_WINDOW",
+      "FAI_VARROCK_CASTLE_WALLS_PILLAR",
+      "FAI_VARROCK_BUTRESS",
+      "FAI_VARROCK_BUTRESS_DARK",
+      "FAI_VARROCK_BUTRESS_DARK_NO_GRASS",
+      "FAI_VARROCK_MUSEUM_PILLARS",
+      "FAI_VARROCK_CASTLE_WALLS_BATTLE_INT_FILLER_R",
+      "FAI_VARROCK_CASTLE_WALLS_BATTLE_INT_FILLER_L",
+      "FAI_VARROCK_CASTLE_GARDEN_FILL",
+      "FAI_VARROCK_CASTLE_GARDEN_FILL_2",
+      "FAI_VARROCK_CASTLE_INTERIOR",
+      "FAI_VARROCK_CASTLE_INTERIOR_RESIZE",
+      "FAI_VARROCK_CASTLE_INTERIOR_TERM_RESIZE",
+      "FAI_VARROCK_CASTLE_INTERIOR_OFFSET",
+      "FAI_VARROCK_CASTLE_INTERIOR_SHARELIGHT",
+      "FAI_VARROCK_CASTLE_INTERIOR_WINDOW_LARGE_OFFSET",
+      "FAI_VARROCK_CASTLE_INTERIOR_DOUBLE",
+      "FAI_VARROCK_CASTLE_INTERIOR_DOUBLE_TERM",
+      "FAI_VARROCK_CASTLE_INTERIOR_TERM",
+      "FAI_VARROCK_CASTLE_INTERIOR_TERM_RIGHT",
+      "FAI_VARROCK_CASTLE_INTERIOR_TERM_LEFT",
+      "FAI_VARROCK_CASTLE_INTERIOR_WINDOW_LARGE",
+      "FAI_VARROCK_CRUMBLY_WALL2",
+      "FAI_VARROCK_CRUMBLY_WALL2_MIRROR",
+      "FAI_VARROCK_CRUMBLY_WALL3",
+      "FAI_VARROCK_CRUMBLY_WALL3_INSIDE",
+      "FAI_VARROCK_CRUMBLY_WALL4",
+      "FAI_VARROCK_CRUMBLY_WALL4_MIRROR",
+      "FAI_VARROCK_CRUMBLY_WALL5",
+      "FAI_VARROCK_CRUMBLY_WALL5_INSIDE",
+      "FAI_VARROCK_CRUMBLY_WALL5_INSIDE_MIRROR",
+      "FAI_VARROCK_CRUMBLY_WALL5_MIRROR",
+      "FAI_VARROCK_WATCHTOWER_SUPPORT_LVL1",
+      "FAI_VARROCK_WATCHTOWER_SUPPORT_LVL2",
+      "FAI_VARROCK_WATCHTOWER_WOODEN_BEAM_LVL2",
+      "FAI_VARROCK_WATCHTOWER_CORNER_LVL3",
+      "FAI_VARROCK_WATCHTOWER_WALL_LVL3",
+      "FAI_VARROCK_WATCHTOWER_ROOF_LVL4",
+      "FAI_VARROCK_WATCHTOWER_ROOF_3X3",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_SHAPE_8_RIGHT",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_SHAPE_8_LEFT",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_SHAPE_8_RIGHT_2",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_SHAPE_8_LEFT_2",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_SHAPE_8_RIGHT_WALL",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_SHAPE_8_LEFT_WALL",
+      "FAI_VARROCK_CASTLE_WALLS_BATTLEMENT_TERM",
+      "FAI_VARROCK_CASTLE_WALLS_BATTLEMENT_TERM_MIRROR",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_JOIN",
+      "FAI_VARROCK_CASTLE_BATTLEMENT_JOIN_MIRROR",
+      "FAI_VARROCK_MUSEUM_SKEWSTEPS_NORTH",
+      "FAI_VARROCK_MUSEUM_SKEWSTEPS_SOUTH",
+      "FAI_VARROCK_CASTLE_ARCH_L",
+      "FAI_VARROCK_CASTLE_ARCH_R",
+      "FAI_VARROCK_CASTLE_ARCH_TOP",
+      "FAI_VARROCK_CASTLE_ARCH_JOINT",
+      "AKD_PISCARILIUS_BATTLEMENT_NOOP",
+      "VM_BASEMENT_WALL_STAIRS_DOWN"
     ],
     "flatNormals": true
   },
@@ -3037,107 +3037,107 @@
     "uvType": "BOX",
     "uvScale": 0.3,
     "objectIds": [
-      23834,
-      23994,
-      23995,
-      23996,
-      23997,
-      23998,
-      23999,
-      24026,
-      24027,
-      24028,
-      24029,
-      24030,
-      24031,
-      24032,
-      24033,
-      24034,
-      24035,
-      24115,
-      24116,
-      24119,
-      24120,
-      24125,
-      24127,
-      24128,
-      24131,
-      24132,
-      24134,
-      24135,
-      24137,
-      24175,
-      24176,
-      24178,
-      24180,
-      24182,
-      24183,
-      24184,
-      24185,
-      24186,
-      24188,
-      24189,
-      24191,
-      24193,
-      24194,
-      24195,
-      24196,
-      24198,
-      24199,
-      24200,
-      24203,
-      24206,
-      24207,
-      24210,
-      24211,
-      24212,
-      24213,
-      24215,
-      24216,
-      24217,
-      24218,
-      24219,
-      24220,
-      24221,
-      24227,
-      24235,
-      24236,
-      24237,
-      24238,
-      24239,
-      24242,
-      24243,
-      24244,
-      24245,
-      24246,
-      24247,
-      24256,
-      24260,
-      24261,
-      24262,
-      24264,
-      24266,
-      24267,
-      24268,
-      24269,
-      24270,
-      24271,
-      24272,
-      24273,
-      24274,
-      23982,
-      23983,
-      23984,
-      23985,
-      23986,
-      23987,
-      23988,
-      23989,
-      23990,
-      23991,
-      23992,
-      23993,
-      24222
+      "FAI_VARROCK_CRUMBLY_WALL_JOINT",
+      "FAI_FALADOR_WALLS",
+      "FAI_FALADOR_WALL_WINDOW",
+      "FAI_FALADOR_INTERIOR_WALLS_FLIPPED",
+      "FAI_FALADOR_LOW_WALL",
+      "FAI_FALADOR_LOW_BRIDGE_WALL",
+      "FAI_FALADOR_LOW_WALL_INVERSE",
+      "FAI_FALADOR_BATTLEMENTS_HILLSKEW",
+      "FAI_FALADOR_BATTLEMENTS_TERMINATOR_RIGHT",
+      "FAI_FALADOR_BATTLEMENTS_TERMINATOR_LEFT",
+      "FAI_FALADOR_CASTLE_WALLS_HILLSKEW",
+      "FAI_FALADOR_CASTLE_WALLS_DOUBLE_TERMINATOR",
+      "FAI_FALADOR_CASTLE_WALLS_TERMINATOR_RHT",
+      "FAI_FALADOR_CASTLE_WALLS_TERMINATOR_LFT",
+      "FAI_FALADOR_CASTLE_WALLS_HILLSKEW_TERMINATOR_RIGHT",
+      "FAI_FALADOR_CASTLE_WALLS_HILLSKEW_TERMINATOR_LEFT",
+      "FAI_FALADOR_CRENELATION_HILLSKEW",
+      "FAI_FALADOR_INTERIOR_TALLER",
+      "FAI_FALADOR_INTERIOR_WINDOW_TALLER",
+      "FAI_FALADOR_WALLS_TALLER",
+      "FAI_FALADOR_WALL_WINDOW_TALLER",
+      "FAI_FALADOR_ROOFKIT_SLATE",
+      "FAI_FALADOR_ROOFKIT_SLATE_CORNER_RIGHT",
+      "FAI_FALADOR_ROOFKIT_SLATE_EDGECUT",
+      "FAI_FALADOR_ROOFKIT_SLATE_TWO",
+      "FAI_FALADOR_ROOFKIT_SLATE_THREE",
+      "FAI_FALADOR_ROOFKIT_SLATE_OFFSET_UP",
+      "FAI_FALADOR_ROOFKIT_SLATE_OFFSET_UP_2",
+      "FAI_FALADOR_ROOF_EDGE_OFFSET_UP",
+      "FAI_FALADOR_CASTLE_WALLS",
+      "FAI_FALADOR_CASTLE_WALLS_L2",
+      "FAI_FALADOR_CASTLE_WALLS_FIX_LFT",
+      "FAI_FALADOR_CASTLE_WALLS_2_TALLER",
+      "FAI_FALADOR_CASTLE_WALLS_L2_LFT",
+      "FAI_FALADOR_CASTLE_WALLS_L2_5_TERMINATOR_RHT",
+      "FAI_FALADOR_CASTLE_WALLS_L2_5_TERMINATOR_LFT",
+      "FAI_FALADOR_CASTLE_WALLS_SARODOMIN",
+      "FAI_FALADOR_CASTLE_WALLS_SARODOMIN_L2",
+      "FAI_FALADOR_INTERIOR",
+      "FAI_FALADOR_INTERIOR_WINDOW",
+      "FAI_FALADOR_BATTLEMENTS",
+      "FAI_FALADOR_BATTLEMENTS_2_TALL_TERMINATOR_LFT",
+      "FAI_FALADOR_BATTLEMENTS_2_TALL_TERMINATOR_RHT",
+      "FAI_FALADOR_BATTLEMENTS_L3_TALL",
+      "FAI_FALADOR_BATTLEMENTS_SARODOMIN",
+      "FAI_FALADOR_ROOF_EDGE_R",
+      "FAI_FALADOR_ROOF_EDGE_L",
+      "FAI_FALADOR_ROOF_EDGE_TWO_R",
+      "FAI_FALADOR_ROOF_EDGE_TWO_L",
+      "FAI_FALADOR_ROOF_EDGE_TWO_MID_R",
+      "FAI_FALADOR_ROOF_EDGE_TWO_MID_L",
+      "FAI_FALADOR_ROOF_EDGE_THREE_R",
+      "FAI_FALADOR_ROOF_EDGE_THREE_L",
+      "FAI_FALADOR_ROOF_EDGE",
+      "FAI_FALADOR_ROOF_EDGE_MIRROR",
+      "FAI_FALADOR_ROOF_CUT_R",
+      "FAI_FALADOR_BRICKS_1",
+      "FAI_FALADOR_BRICKS_2",
+      "FAI_FALADOR_PILEOFBRICKS_L",
+      "FAI_FALADOR_PILEOFBRICKS_R",
+      "FAI_FALADOR_CASTLE_CRUMBLE_L",
+      "FAI_FALADOR_CASTLE_CRUMBLE_R",
+      "FAI_FALADOR_ROOF_EDGE_OFFSETS_V",
+      "FAI_INV_FALADOR_CASTLE_WALLS",
+      "FAI_INV_FALADOR_CASTLE_WALLS_RHT",
+      "FAI_INV_FALADOR_CASTLE_WALLS_LFT",
+      "FAI_INV_FALADOR_CASTLE_WALLS_5_TERMINATOR_RHT",
+      "FAI_INV_FALADOR_CASTLE_WALLS_5_TERMINATOR_LFT",
+      "FAI_INTERIOR_FALADOR_CASTLE_WALLS",
+      "FAI_INTERIOR_FALADOR_CASTLE_WALLS_TERMINATOR_RT",
+      "FAI_INTERIOR_FALADOR_CASTLE_WALLS_TERMINATOR_LFT",
+      "FAI_INV_FALADOR_BATTLEMENTS",
+      "FAI_WALL_FIX_ONE",
+      "FAI_WALL_FIX_TWO",
+      "FAI_FALADOR_PARTY_ROOM_SPIRALSTAIRS_RAILING",
+      "FAI_FALADOR_PARTY_ROOM_WALL_BIG",
+      "FAI_FALADOR_PARTY_ROOM_WALL",
+      "FAI_FALADOR_PARTY_ROOM_WALL_CORNER",
+      "FAI_FALADOR_PARTY_ROOM_WALL_CORNER_MIRROR",
+      "FAI_FALADOR_PARTY_ROOM_WALL_END",
+      "FAI_FALADOR_PARTY_ROOM_WALL_END_MIRROR",
+      "FAI_FALADOR_PARTY_ROOM_DOUBLE_WALL",
+      "FAI_FALADOR_PARTY_ROOM_WALL_WINDOW_BIG",
+      "FAI_FALADOR_PARTY_ROOM_WALL_WINDOW_BIG_TERM",
+      "FAI_FALADOR_PARTY_ROOM_WALL_WINDOW_BIG_TERM_MIRROR",
+      "FAI_FALADOR_PARTY_ROOM_WALL_WINDOW",
+      "FAI_FALADOR_PARTY_ROOM_BATTLEMENT_CORNER",
+      "FAI_FALADOR_PARTY_ROOM_BATTLEMENT_CORNER_MIRROR",
+      "FAI_WALLGATE_START",
+      "FAI_WALLGATE_MID",
+      "FAI_WALLGATE_END",
+      "FAI_WALLGATE_TOP_START",
+      "FAI_WALLGATE_TOP_MID",
+      "FAI_WALLGATE_TOP_END",
+      "FAI_WALLGATE_START_MIRROR",
+      "FAI_WALLGATE_MID_MIRROR",
+      "FAI_WALLGATE_END_MIRROR",
+      "FAI_WALLGATE_TOP_START_MIRROR",
+      "FAI_WALLGATE_TOP_MID_MIRROR",
+      "FAI_WALLGATE_TOP_END_MIRROR",
+      "FAI_FALADOR_CASTLE_CRUMBLE_MID"
     ],
     "flatNormals": true
   },
@@ -3145,24 +3145,24 @@
     "description": "STATUE_OF_SARADOMIN_1",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      24043,
-      24044
+      "FAI_FALADOR_SARADOMIN_STATUE",
+      "FAI_FALADOR_SARADOMIN_STATUE_GREY"
     ]
   },
   {
     "description": "STONE_SIGNPOST",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23970,
-      23971
+      "FAI_STONE_SIGN_BOTTOM",
+      "FAI_STONE_SIGN_TOP"
     ]
   },
   {
     "description": "FALADOR_STEPS_1",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      7386,
-      7387
+      "RD_SKEWSTEPS",
+      "RD_SKEWSTEPS_CORNER"
     ],
     "flatNormals": true
   },
@@ -3170,17 +3170,17 @@
     "description": "Al Kharid and PoH Whitewashed Walls",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      1415,
-      1416,
-      3152,
-      3160,
-      3161,
-      3162,
-      21799,
-      33348,
-      26585,
-      26586,
-      26587
+      "DESERTWALL",
+      "DESERTROOFWALL",
+      "DUEL_ARENA_BIGWALL",
+      "DUEL_ARENA_BIGWALL_COUNTERSIDE",
+      "DUEL_ARENA_BIGWALL_COUNTERSIDE_MIRROR",
+      "DUEL_ARENA_BIGWALL_COUNTERMID",
+      "DESERTWALL_WINDOW_BUILT_IN",
+      "KHARID_BIGWINDOW",
+      "DESERTWALL_RAISED",
+      "DESERTROOFWALL_RAISED",
+      "DESERTROOFWALL_NOBLOCKRANGE"
     ],
     "flatNormals": true,
     "uvType": "BOX"
@@ -3189,22 +3189,22 @@
     "description": "CITHAREDE_ABBEY_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      39725,
-      39726,
-      39727,
-      39728,
-      39729,
-      39730,
-      39731,
-      39732,
-      39733,
-      39734,
-      39735,
-      39736,
-      39737,
-      39738,
-      39739,
-      39740
+      "GH_WALL_01",
+      "GH_WALL_02",
+      "GH_WALL_03",
+      "GH_WALL_LOW_01",
+      "GH_WALL_LOW_02",
+      "GH_WALL_CRUMBLE_L",
+      "GH_WALL_CRUMBLE_L_02",
+      "GH_WALL_CRUMBLE_SMALL_L",
+      "GH_WALL_CRUMBLE_R",
+      "GH_WALL_CRUMBLE_R_02",
+      "GH_WALL_CRUMBLE_SMALL_R",
+      "GH_WALL_WINDOW_01",
+      "GH_WALL_WINDOW_02",
+      "GH_WALL_ARCH_L",
+      "GH_WALL_ARCH_R",
+      "GH_STONE_PILE1"
     ],
     "flatNormals": true
   },
@@ -3212,18 +3212,18 @@
     "description": "SEERS_COURTHOUSE_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      25966,
-      25967,
-      25969,
-      25970,
-      25971,
-      25972,
-      25973,
-      25974,
-      25975,
-      25978,
-      25979,
-      26010
+      "KR_COURTHOUSE_WALL",
+      "KR_COURTHOUSE_WALL_WINDOW",
+      "KR_COURTHOUSE_WALL_WINDOW_BEAM_DOUBLE",
+      "KR_COURTHOUSE_WALL_BEAM_SINGLE",
+      "KR_COURTHOUSE_WALL_BEAM_SINGLE_MIRROR",
+      "KR_COURTHOUSE_WALL_BEAM_SINGLE_CAPPED",
+      "KR_COURTHOUSE_WALL_BEAM_SINGLE_CAPPED_MIRROR",
+      "KR_COURTHOUSE_WALL_JAIL_BLEND",
+      "KR_COURTHOUSE_WALL_JAIL_BLEND_MIRROR",
+      "KR_COURTHOUSE_WALL_JAIL_BEAM_SINGLE",
+      "KR_COURTHOUSE_WALL_JAIL_BEAM_SINGLE_MIRROR",
+      "KR_COURTHOUSE_PILLAR"
     ],
     "flatNormals": true
   },
@@ -3231,37 +3231,37 @@
     "description": "SEERS_BUILDING_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      25753,
-      25755,
-      25756,
-      25757,
-      25890,
-      25895,
-      25896,
-      25897,
-      25898,
-      25899,
-      25901,
-      25902,
-      25903,
-      25904,
-      25905,
-      25906,
-      25907,
-      25908,
-      25909,
-      25911,
-      25957,
-      25958,
-      25959,
-      25960,
-      25961,
-      25962,
-      25963,
-      25964,
-      25965,
-      26114,
-      26115
+      "KR_SEERS_VILLAGE_MINECART_AREA_WALL",
+      "KR_SEERS_VILLAGE_MINECART_AREA_ARCH_L",
+      "KR_SEERS_VILLAGE_MINECART_AREA_ARCH_R",
+      "KR_SEERS_VILLAGE_MINECART_AREA_ARCH_TOP",
+      "KR_SEERS_VILLAGE_WALL",
+      "KR_SEERS_VILLAGE_WALL_INVERTED",
+      "KR_SEERS_VILLAGE_PUB_WALL",
+      "KR_SEERS_VILLAGE_WALL_TERM_01",
+      "KR_SEERS_VILLAGE_WALL_TERM_02",
+      "KR_SEERS_VILLAGE_WALL_WINDOW",
+      "KR_SEERS_VILLAGE_WALL_WINDOW_TERM_02",
+      "KR_SEERS_VILLAGE_WALL_WINDOW_CHURCH",
+      "KR_SEERS_VILLAGE_WALL_WINDOW_CHURCH_INVERTED",
+      "KR_SEERS_VILLAGE_WALL_WINDOW_CHURCH_TERM_01",
+      "KR_SEERS_VILLAGE_WALL_WINDOW_CHURCH_TERM_02",
+      "KR_SEERS_VILLAGE_WALL_INTERNAL",
+      "KR_SEERS_VILLAGE_WALL_INTERNAL_FILLER",
+      "KR_SEERS_VILLAGE_WALL_INTERNAL_FILLER_MIRROR",
+      "KR_SEERS_VILLAGE_WALL_INTERNAL_TERM_01",
+      "KR_SEERS_VILLAGE_WALL_INTERNAL_TERM_FILLER",
+      "KR_COURTHOUSE_BASE_01",
+      "KR_COURTHOUSE_BASE_02",
+      "KR_COURTHOUSE_BASE_03",
+      "KR_COURTHOUSE_BASE_CORNER",
+      "KR_COURTHOUSE_BASE_INSIDE_CORNER",
+      "KR_COURTHOUSE_BASE_STEPS_EDGE",
+      "KR_COURTHOUSE_BASE_STEPS_EDGE_MIRROR",
+      "KR_COURTHOUSE_BASE_STEPS_MID",
+      "KR_COURTHOUSE_BASE_TOP",
+      "ELEMENTAL_WORKSHOP_ODDWALL_R",
+      "ELEMENTAL_WORKSHOP_ODDWALL_L"
     ],
     "flatNormals": true
   },
@@ -3269,19 +3269,19 @@
     "description": "Sinclair Mansion - exterior walls",
     "baseMaterial": "STONE",
     "objectIds": [
-      26059,
-      26060,
-      26061,
-      26062,
-      26063,
-      26064,
-      26065,
-      26066,
-      26071,
-      26072,
-      26110,
-      26111,
-      26112
+      "KR_MANSION_INTERNAL_WALLS_JUNCTION2",
+      "KR_MANSION_EXTERNAL_WALLS",
+      "KR_MANSION_EXTERNAL_WALLS_CAP_01",
+      "KR_MANSION_EXTERNAL_WALLS_CAP_02",
+      "KR_MANSION_EXTERNAL_WALLS_JUNCTION1",
+      "KR_MANSION_EXTERNAL_WALLS_JUNCTION1_CAPPED",
+      "KR_MANSION_EXTERNAL_WALLS_JUNCTION2",
+      "KR_MANSION_EXTERNAL_WALL_WINDOW",
+      "KR_MANSION_EXTERNAL_WALLS_WITH_FENCE",
+      "KR_MANSION_EXTERNAL_WALLS_WITH_FENCE_MIRROR",
+      "KR_MANSION_WINDOW_MULTI_01",
+      "KR_MANSION_WINDOW_MULTI_02",
+      "KR_MANSION_WINDOW_MULTI_03"
     ],
     "flatNormals": true
   },
@@ -3289,20 +3289,20 @@
     "description": "Murder Mystery house - interior walls",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      26054,
-      26055,
-      26056,
-      26057,
-      26058,
-      26069,
-      26070
+      "KR_MANSION_INTERNAL_WALLS",
+      "KR_MANSION_INTERNAL_WALLS_CAP",
+      "KR_MANSION_INTERNAL_WALLS_CAP_MIRROR",
+      "KR_MANSION_INTERNAL_WALLS_JUNCTION1",
+      "KR_MANSION_INTERNAL_WALLS_JUNCTION1_CAP",
+      "KR_MANSION_INTERNAL_WALLS_DIAG",
+      "KR_MANSION_INTERNAL_WALLS_DIAG_02"
     ],
     "flatNormals": true
   },
   {
     "description": "Murder Mystery house - white table",
     "objectIds": [
-      597
+      "LONGTABLE_WIDE"
     ],
     "baseMaterial": "GRAY_75"
   },
@@ -3311,21 +3311,21 @@
     "baseMaterial": "STONE_NORMALED",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      979,
-      5566,
-      5567,
-      5568,
-      5570,
-      20717,
-      20718,
-      20719,
-      20741,
-      23888,
-      23889,
-      23890,
-      23891,
-      23892,
-      5569
+      "DRYSTONEWALL",
+      "DRYSTONEWALL_BUST",
+      "DRYSTONEWALL_FALL",
+      "DRYSTONEWALL_FALL_MIRR",
+      "DRYSTONEWALL_GRASS",
+      "BARROW_LOW_WALLS_PILLAR",
+      "BARROW_LOW_WALLS_PILLARL",
+      "BARROW_LOW_WALLS_PILLARTOP",
+      "BARROWS_DRYSTONEWALL_GRASS",
+      "FAI_VARROCK_STONE_SHORT_WALL",
+      "FAI_VARROCK_STONE_SHORT_WALL_CUT",
+      "FAI_VARROCK_CASTLE_WALL_SHORT_WALL_BLEND",
+      "FAI_VARROCK_CASTLE_WALL_SHORT_WALL_BLEND_MIRROR",
+      "FAI_VARROCK_STONE_SHORT_WALL_CUT_MIRROR",
+      "DRYSTONEWALL_PILE"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -3337,22 +3337,22 @@
     "description": "STATUE_OF_A_WARRIOR_1",
     "baseMaterial": "MARBLE_2_GLOSS",
     "objectIds": [
-      562,
-      566
+      "STATUE_FEMALEWARRIOR",
+      "STATUE_MALEWARRIOR"
     ]
   },
   {
     "description": "KARAMJA_DUNGEON_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      1428,
-      21719,
-      21729,
-      21730,
-      21736,
-      21737,
-      21725,
-      21726
+      "CAVEWALL_FACE1_LEV2",
+      "KARAM_CAVEWALL_FACE1",
+      "KARAM_DUNGEON_CAVEWALL_VINEBLOCKINGL",
+      "KARAM_DUNGEON_CAVEWALL_VINEBLOCKINGR",
+      "KARAM_CAVEWALL_VINE",
+      "KARAM_CAVEWALL_VINE_LEV2",
+      "KARAM_DUNGEON_CAVESTAIRS2",
+      "KARAM_DUNGEON_CAVESTAIRS_LEV2_DOWN2"
     ]
   },
   {
@@ -3361,51 +3361,51 @@
     "uvType": "BOX",
     "tzHaarRecolorType": "GRADIENT",
     "objectIds": [
-      11818,
-      11819,
-      11820,
-      11821,
-      11822,
-      11823,
-      11824,
-      11825,
-      11826,
-      11827,
-      11828,
-      11829,
-      11837,
-      11838,
-      11839,
-      11840,
-      11841,
-      11842,
-      11971,
-      11972,
-      11973,
-      11974,
-      11981,
-      11983,
-      11984,
-      11985,
-      30272,
-      30273,
-      11833,
-      11834,
-      11836,
-      30271,
-      41013,
-      30269,
-      30270
+      "TZHAAR_CAVE_WALL_1",
+      "TZHAAR_CAVE_WALL_2",
+      "TZHAAR_CAVE_WALL_3",
+      "TZHAAR_CAVE_WALL_4",
+      "TZHAAR_CAVE_WALL_5",
+      "TZHAAR_CAVE_WALL_6",
+      "TZHAAR_CAVE_WALL_7",
+      "TZHAAR_CAVE_WALL_8",
+      "TZHAAR_CAVE_WALL_9",
+      "TZHAAR_CAVE_WALL_10",
+      "TZHAAR_CAVE_WALL_ALCOVE",
+      "TZHAAR_CAVE_WALL_ALCOVE2",
+      "TZHAAR_CAVE_FENCE1",
+      "TZHAAR_CAVE_FENCE2",
+      "TZHAAR_CAVE_FENCE3",
+      "TZHAAR_CAVE_FENCE4",
+      "TZHAAR_CAVE_FENCE5",
+      "TZHAAR_CAVE_FENCE6",
+      "TZHAAR_CAVEWALL_TOP",
+      "TZHAAR_CAVE_WALL_OVERHANG_1",
+      "TZHAAR_CAVE_WALL_OVERHANG_2",
+      "TZHAAR_CAVE_WALL_OVERHANG_3",
+      "TZHAAR_WEAPON_STORE_ICON",
+      "TZHAAR_BANK_STORE_ICON",
+      "TZHAAR_GEM_STORE_ICON",
+      "TZHAAR_MINIGAME_START_ICON",
+      "TZHAAR_WALL_CHARGING_STEPS",
+      "TZHAAR_STALAGMITE_1",
+      "TZHAAR_FIGHTCAVE_WALL_ENTRANCE",
+      "TZHAAR_FIGHTCAVE_WALL_EXIT",
+      "TZHAAR_KARAMJADUNGEON_WALL_EXIT",
+      "TZHAAR_WALL_CHARGING_PILLAR",
+      "JAD_CHALLENGE_SCOREBOARD",
+      "TZHAAR_WALL_CHARGING_FULL",
+      "TZHAAR_WALL_CHARGING_EMPTY"
     ]
   },
   {
     "description": "TZHAAR_GRADIENT",
     "objectIds": [
-      11847,
-      11848,
-      11849,
-      11850,
-      11982
+      "TZHAAR_CAVE_FLOOR_1",
+      "TZHAAR_CAVE_FLOOR_2",
+      "TZHAAR_CAVE_FLOOR_3",
+      "TZHAAR_CAVE_FLOOR_4",
+      "TZHAAR_MAGIC_STORE_ICON"
     ],
     "tzHaarRecolorType": "GRADIENT"
   },
@@ -3415,39 +3415,39 @@
     "uvType": "BOX",
     "tzHaarRecolorType": "HUE_SHIFT",
     "objectIds": [
-      26723,
-      26724,
-      26725,
-      30263,
-      30264,
-      30265
+      "MORULREK_FLOOR_EDGE_01",
+      "MORULREK_FLOOR_EDGE_02",
+      "MORULREK_FLOOR_CORNER_OUTER_01",
+      "MORULREK_FLOOR_CORNER_OUTER_02",
+      "MORULREK_FLOOR_CORNER_INSIDE_01",
+      "MORULREK_FLOOR_CORNER_INSIDE_02"
     ]
   },
   {
     "description": "APE_ATOLL_DUNGEON_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      4898
+      "CAVEWALL_FACE1_NOT_LOW_DETAIL"
     ]
   },
   {
     "description": "KOUREND_PATHS",
     "baseMaterial": "STONE_NORMALED_DARK",
     "objectIds": [
-      13705,
-      13706,
-      13707,
-      13708,
-      13709,
-      13710,
-      13711,
-      13712,
-      13713,
-      13714,
-      13715,
-      13716,
-      13717,
-      42722
+      "KOUREND_FOOTPATH_01",
+      "KOUREND_FOOTPATH_02",
+      "KOUREND_FOOTPATH_03",
+      "KOUREND_FOOTPATH_04",
+      "KOUREND_FOOTPATH_05",
+      "KOUREND_FOOTPATH_06",
+      "KOUREND_FOOTPATH_07",
+      "KOUREND_FOOTPATH_08",
+      "KOUREND_FOOTPATH_09",
+      "KOUREND_FOOTPATH_10",
+      "KOUREND_FOOTPATH_11",
+      "KOUREND_FOOTPATH_12",
+      "KOUREND_FOOTPATH_13",
+      "QUEST_START_ICON_KINGDOMDIVIDED"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 1.2
@@ -3456,7 +3456,7 @@
     "description": "KOUREND_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23800
+      "FAI_VARROCK_CASTLEWALL_HILLSKEW"
     ],
     "flatNormals": true
   },
@@ -3464,18 +3464,18 @@
     "description": "KOUREND_WALLS_COLUMNS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      41837,
-      41838
+      "AKD_PISCARILIUS_PILLAR_BROKEN_NOOP",
+      "AKD_PISCARILIUS_PILLAR_NOOP"
     ]
   },
   {
     "description": "Kourend - Kingstown - Statue of King Rada",
     "baseMaterial": "MARBLE_2_DARK",
     "objectIds": [
-      14193,
-      14194,
-      14195,
-      27785
+      "KOUREND_STATUE_COMPLETE_BOTTOM",
+      "KOUREND_STATUE_COMPLETE_MIDDLE",
+      "KOUREND_STATUE_COMPLETE_TOP",
+      "ZEAH_KOUREND_STATUE_PLINTH"
     ],
     "uvType": "BOX",
     "uvScale": 1.1
@@ -3484,47 +3484,47 @@
     "description": "SHAYZIEN_SHAY_SHRINE",
     "baseMaterial": "MARBLE_3_GLOSS",
     "objectIds": [
-      42160
+      "SHAYZIEN_CAT_SHRINE"
     ]
   },
   {
     "description": "SHAYZIEN_HERO_STATUE",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      25194
+      "DRAGON_SLAYER_QIP_DRAGON_STATUE"
     ]
   },
   {
     "description": "SHAYZIEN_DRAGON_STATUE",
     "baseMaterial": "MARBLE_2_GLOSS",
     "objectIds": [
-      42178
+      "AKD_SHAYZIEN_GRAVEYARD_STATUE"
     ]
   },
   {
     "description": "SHAYZIEN_GRAVE",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      28451
+      "ARCHEUUS_LONG_GRAVE_02"
     ]
   },
   {
     "description": "SHAYZIEN_CEREMONIAL_PILLAR",
     "baseMaterial": "BLANK_GLOSS",
     "objectIds": [
-      42167,
-      42168,
-      42169,
-      42170,
-      42171,
-      42172,
-      42173,
-      42174,
-      42175,
-      42176,
-      42177,
-      42179,
-      42180
+      "AKD_SHAYZIEN_GRAVESTONE01_DEFAULT",
+      "AKD_SHAYZIEN_GRAVESTONE01_RIGHT",
+      "AKD_SHAYZIEN_GRAVESTONE01_LEFT",
+      "AKD_SHAYZIEN_GRAVESTONE01_VAR01",
+      "AKD_SHAYZIEN_GRAVESTONE01_VAR02",
+      "AKD_SHAYZIEN_GRAVESTONE01_SPECIAL",
+      "AKD_SHAYZIEN_GRAVESTONE02_DEFAULT",
+      "AKD_SHAYZIEN_GRAVESTONE02_RIGHT",
+      "AKD_SHAYZIEN_GRAVESTONE02_LEFT",
+      "AKD_SHAYZIEN_GRAVESTONE02_VAR01",
+      "AKD_SHAYZIEN_GRAVESTONE02_SPECIAL",
+      "AKD_SHAYZIEN_MONUMENT",
+      "AKD_SHAYZIEN_MONUMENT_PLAQUE"
     ],
     "flatNormals": true
   },
@@ -3532,51 +3532,51 @@
     "description": "Wilderness and Shayzien - Rock Walls",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      2341,
-      14543,
-      14544,
-      14545,
-      14546,
-      14547,
-      14548,
-      14549,
-      14550,
-      14551,
-      14553,
-      14556,
-      14557,
-      14558,
-      14559,
-      14560,
-      14561,
-      14562,
-      14622,
-      14623,
-      14624,
-      14625,
-      14626,
-      14627,
-      14628,
-      14629,
-      14630,
-      14631,
-      14632,
-      14729,
-      14730,
-      14770,
-      14723,
-      14724,
-      14725,
-      14726,
-      14727,
-      14728,
-      14733,
-      14734,
-      42110,
-      42111,
-      46997,
-      46998,
-      53579
+      "BKSECRETDOOR",
+      "WILD1_WALL",
+      "WILD1_WALL_TOP",
+      "WILD1_WALL_CRUMBLE_L",
+      "WILD1_WALL_CRUMBLE_SMALL_L",
+      "WILD1_WALL_CRUMBLE_R",
+      "WILD1_WALL_CRUMBLE_SMALL_R",
+      "WILD1_WALL_TOP_CRUMBLE_L",
+      "WILD1_WALL_TOP_CRUMBLE_SMALL_L",
+      "WILD1_WALL_TOP_CRUMBLE_R",
+      "WILD1_WALL_SHUTTERED",
+      "WILD1_WALL_STONE_PILE1",
+      "WILD1_WALL_STONE_PILE2",
+      "WILD1_WALL_BATTLEMENT",
+      "WILD1_WALL_BATTLEMENT_CRUMBLE_L",
+      "WILD1_WALL_BATTLEMENT_CRUMBLE_R",
+      "WILD1_WALL_WINDOW_SML",
+      "WILD1_WALL_WINDOW_SML_TOP",
+      "WILD3_WALL",
+      "WILD3_WALL_CRUMBLE_L",
+      "WILD3_WALL_CRUMBLE_SMALL_L",
+      "WILD3_WALL_CRUMBLE_R",
+      "WILD3_WALL_CRUMBLE_SMALL_R",
+      "WILD3_WALL_SHUTTERED",
+      "WILD3_WALL_CRUMBLE_LOW1",
+      "WILD3_WALL_CRUMBLE_LOW2",
+      "WILD3_WALL_STONE_PILE1",
+      "WILD3_WALL_STONE_PILE2",
+      "WILD3_WALL_BATTLEMENT",
+      "WILD6_WALL_CRUMBLE_LOW1",
+      "WILD6_WALL_CRUMBLE_LOW2",
+      "WILD_TEMPLE_WALLS",
+      "WILD6_WALL",
+      "WILD6_WALL_CRUMBLE_L",
+      "WILD6_WALL_CRUMBLE_SMALL_L",
+      "WILD6_WALL_CRUMBLE_R",
+      "WILD6_WALL_CRUMBLE_SMALL_R",
+      "WILD6_WALL_SHUTTERED",
+      "WILD6_WALL_BATTLEMENT",
+      "WILD6_WALL_WINDOW_SML",
+      "WALLKIT_SHAYZIEN_CHURCH_WINDOW01",
+      "WALLKIT_SHAYZIEN_CHURCH_WINDOW02",
+      "WILD_VETION_BRICKS01",
+      "WILD_VETION_BRICKS02",
+      "WILD3_WALL_BATTLEMENT_NO_GRADIENT"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -3585,11 +3585,11 @@
     "description": "SHAYZIEN_WALLS_WOOD",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      42107,
-      42108,
-      42109,
-      42112,
-      42113
+      "WALLKIT_SHAYZIEN_RESIDENTIAL01",
+      "WALLKIT_SHAYZIEN_RESIDENTIAL02",
+      "WALLKIT_SHAYZIEN_SHOP01",
+      "WALLKIT_SHAYZIEN_SUPPORT01",
+      "WALLKIT_SHAYZIEN_FENCE01"
     ],
     "flatNormals": true
   },
@@ -3597,28 +3597,28 @@
     "description": "SHAYZIEN_STAIRS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      42193,
-      42195,
-      42196
+      "AKD_SHAYZIEN_BAR_SPIRALSTAIRS",
+      "SHAYZIEN_MANOR_STAIRS",
+      "SHAYZIEN_MANOR_STAIRSTOP"
     ],
     "flatNormals": true
   },
   {
     "description": "MOUNT_KARUULM_WALLS",
     "objectIds": [
-      34347,
-      34384,
-      34385,
-      34386,
-      34387,
-      34388,
-      34389,
-      34390,
-      34391,
-      34392,
-      34393,
-      34394,
-      34395
+      "BRIMSTONE_ROCK_CLIFF_2X2",
+      "BRIMSTONE_ROCK_CLIFF_1",
+      "BRIMSTONE_ROCK_CLIFF_2",
+      "BRIMSTONE_ROCK_CLIFF_3",
+      "BRIMSTONE_ROCK_CLIFF_4",
+      "BRIMSTONE_ROCK_CLIFF_5",
+      "BRIMSTONE_ROCK_CLIFF_6",
+      "BRIMSTONE_ROCK_CLIFF_E",
+      "BRIMSTONE_ROCK_CLIFF_Q",
+      "BRIMSTONE_ROCK_CLIFF_W",
+      "BRIMSTONE_ROCK_CLIFF_R",
+      "BRIMSTONE_ROCK_CLIFF_T",
+      "BRIMSTONE_ROCK_CLIFF_U"
     ],
     "flatNormals": true
   },
@@ -3626,26 +3626,26 @@
     "description": "Wintertodt Terrain",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      29293,
-      29296,
-      29295,
-      29294,
-      29279,
-      29265,
-      29280,
-      29265,
-      15258,
-      15451,
-      29135,
-      29134,
-      29281,
-      29282,
-      29286,
-      29285,
-      29278,
-      29283,
-      29284,
-      29266
+      "WINT_WALL_A",
+      "WINT_WALL_PILLAR_A",
+      "WINT_WALL_C",
+      "WINT_WALL_B",
+      "WINT_TOP_A",
+      "WINT_SNOW_A",
+      "WINT_EDGE_A",
+      "WINT_SNOW_A",
+      "WINT_FLOOR_A",
+      "WINT_FLOOR_B",
+      "WINT_FLOOR_D",
+      "WINT_FLOOR_C",
+      "WINT_EDGE_CORNER",
+      "WINT_EDGE_OUTER",
+      "WINT_PILLAR_B",
+      "WINT_PILLAR_A",
+      "WINT_SNOW_C",
+      "WINT_BROKEN_FLOOR",
+      "WINT_BROKEN_EDGE",
+      "WINT_SNOW_B"
     ],
     "uvType": "BOX",
     "uvScale": 1.25
@@ -3654,7 +3654,7 @@
     "description": "Wintertodt Root Terrain",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      29297
+      "WINT_WALL_BRUMA_ROOT_A"
     ],
     "uvType": "BOX",
     "uvScale": 1.25,
@@ -3677,7 +3677,7 @@
     "description": "Wintertodt Herb Terrain",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      29298
+      "WINT_WALL_HERB_ROOT_B"
     ],
     "uvType": "BOX",
     "uvScale": 1.25,
@@ -3693,12 +3693,12 @@
     "description": "Wintertodt Railings",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      29288,
-      29287,
-      29289,
-      29290,
-      29291,
-      29292
+      "WINT_BALCONY_B",
+      "WINT_BALCONY_A",
+      "WINT_BALCONY_PILLAR_A",
+      "WINT_BALCONY_CAP_L",
+      "WINT_BALCONY_CAP_R",
+      "WINT_BALCONY_NONE"
     ],
     "uvType": "BOX",
     "uvScale": 1.25
@@ -3707,23 +3707,23 @@
     "description": "Wintertodt Wooden Objects",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      29319,
-      29320,
-      29317,
-      29318,
-      29316,
-      29301,
-      29305,
-      29302,
-      29321,
-      29303,
-      29304,
-      55411,
-      55412,
-      55413,
-      55414,
-      55415,
-      55416
+      "WINT_CHEST_TINDERBOX",
+      "WINT_CHEST_VIAL",
+      "WINT_CHEST_KNIFE",
+      "WINT_CHEST_AXE",
+      "WINT_CHEST_HAMMER",
+      "WINT_CRATE_EMPTY",
+      "WINT_CRATE_4",
+      "WINT_CRATE_1",
+      "WINT_BANKCHEST",
+      "WINT_CRATE_2",
+      "WINT_CRATE_3",
+      "WINT_REWARD_PILE_EMPTY",
+      "WINT_REWARD_PILE_1",
+      "WINT_REWARD_PILE_2",
+      "WINT_REWARD_PILE_3",
+      "WINT_REWARD_PILE_4",
+      "WINT_REWARD_PILE_FULL"
     ],
     "colorOverrides": [
       {
@@ -3735,25 +3735,25 @@
     ]
   },
   {
-  "description": "Wintertodt Barrel Group",
-  "baseMaterial": "SNOW_1",
-  "objectIds": [
-    26330
-  ],
-  "colorOverrides": [
-    {
-      "colors": "h == 5",
-      "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-      "uvType": "BOX",
-      "uvScale": 0.75
-    }
-  ]
+    "description": "Wintertodt Barrel Group",
+    "baseMaterial": "SNOW_1",
+    "objectIds": [
+      "GODWARS_DEBRIS_BARRICADE_3BARRELS"
+    ],
+    "colorOverrides": [
+      {
+        "colors": "h == 5",
+        "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
+        "uvType": "BOX",
+        "uvScale": 0.75
+      }
+    ]
   },
   {
     "description": "Wintertodt Bruma Roots",
     "baseMaterial": "VERY_LIGHT_BARK",
     "objectIds": [
-      29311
+      "WINT_ROOTS"
     ],
     "colorOverrides": [
       {
@@ -3770,7 +3770,7 @@
     "description": "Wintertodt Herb Roots",
     "baseMaterial": "VERY_LIGHT_BARK",
     "objectIds": [
-      29315
+      "WINT_HERB_ROOTS"
     ],
     "colorOverrides": [
       {
@@ -3787,9 +3787,9 @@
     "description": "Wintertodt Brazier",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      29312,
-      29313,
-      29314
+      "WINT_BRAZIER",
+      "WINT_BRAZIER_BROKEN",
+      "WINT_BRAZIER_LIT"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -3804,7 +3804,7 @@
     "description": "Wintertodt Storm - Brighten",
     "baseMaterial": "GRAY_150",
     "objectIds": [
-      29308
+      "WINT_SNOW_STORM"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -3813,11 +3813,11 @@
     "description": "Wintertodt Tents",
     "baseMaterial": "CARPET",
     "objectIds": [
-      29307,
-      29306,
-      17359,
-      17360,
-      17361
+      "WINT_TENT_DIAG",
+      "WINT_TENT",
+      "QIP_DIGSITE_TENT_WALL",
+      "QIP_DIGSITE_TENT_ROOF",
+      "QIP_DIGSITE_TENT_DOOR"
     ],
     "uvType": "BOX"
   },
@@ -3825,7 +3825,7 @@
     "description": "Wintertodt Wooden Cart",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      27364
+      "SHAYZIEN_CART"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -3835,7 +3835,7 @@
     "description": "Wintertodt Snow Pile with Wooden Wheel",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      26314
+      "GODWARS_DEBRIS_DAMAGEDBIGWHEEL"
     ],
     "uvType": "BOX"
   },
@@ -3843,33 +3843,33 @@
     "description": "STATUE_BUST",
     "baseMaterial": "MARBLE_1_GLOSS",
     "objectIds": [
-      576,
-      26127,
-      26128,
-      26129
+      "BUST3",
+      "MURDER_QIP_BUST_01",
+      "MURDER_QIP_BUST_02",
+      "MURDER_QIP_BUST_03"
     ]
   },
   {
     "description": "CASTLE_WARS_WALLS",
     "objectIds": [
-      1620,
-      1622,
-      1631,
-      1940,
-      4409,
-      4410,
-      4445,
-      4908,
-      4446,
-      4447
+      "OLDCASTLEWALL",
+      "OLDCASTLEBATTLEMENTS",
+      "OLDWALL",
+      "CROSS_OLDCASTLEEDGE",
+      "CASTLEWARS_WALL_SARADOMIN",
+      "CASTLEWARS_CASTLEBATTLEMENTS_SARADOMIN",
+      "CASTLEWARS_BATTLEMENTS_SARADOMIN_BLOCKRANGE",
+      "CASTLEWARS_CASTLEBATTLEMENTS_ZAMORAK",
+      "CASTLEWARS_BATTLEMENTS_SARADOMIN_CLIMBABLE",
+      "CASTLEWARS_BATTLEMENTS_ZAMORAK_CLIMBABLE"
     ],
     "flatNormals": true
   },
   {
     "description": "CASTLE_WARS_DECORATION",
     "objectIds": [
-      4435,
-      4436
+      "CASTLEWARS_BANNER_RED",
+      "CASTLEWARS_BANNER_BLUE"
     ],
     "flatNormals": true
   },
@@ -3881,19 +3881,19 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      2109,
-      2160,
-      2161,
-      2162,
-      2163,
-      2164,
-      2165,
-      2166,
-      2167,
-      2168,
-      2169,
-      2170,
-      2171
+      "SLAYERTOWER_DOOR_ARCH",
+      "SLAYERTOWER_EXTERIOR_WALL",
+      "SLAYERTOWER_EXTERIOR_WALL_LVL2",
+      "SLAYERTOWER_INTERIOR_WALL",
+      "SLAYERTOWER_INTERIOR_WALL_VARI",
+      "SLAYERTOWER_CRUMBLYWALL1",
+      "SLAYERTOWER_CRUMBLYWALL1R",
+      "SLAYERTOWER_CRUMBLYWALL2",
+      "SLAYERTOWER_CRUMBLYWALLLOW",
+      "SLAYERTOWER_CRUMBLYWALLLOW2",
+      "SLAYERTOWER_WINDOW_WALL",
+      "SLAYERTOWER_WINDOW_WALL_LVL2",
+      "SLAYERTOWER_PILE_BICKS"
     ]
   },
   {
@@ -3904,10 +3904,10 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      2114,
-      2118,
-      2119,
-      2120
+      "SLAYER_STAIRS_LV1",
+      "SLAYER_STAIRS_LV1_TOP",
+      "SLAYER_STAIRS_LV2",
+      "SLAYER_STAIRS_LV2_TOP"
     ]
   },
   {
@@ -3918,8 +3918,8 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      2110,
-      2106
+      "SLAYERTOWER_DOOR_ARCH_MIRROR",
+      "SLAYERTOWER_SMALL_DOOR_ARCH"
     ]
   },
   {
@@ -3939,45 +3939,45 @@
       }
     ],
     "objectIds": [
-      2100,
-      2101,
-      2102,
-      2103,
-      2104,
-      2105,
-      2108,
-      2111,
-      2112,
-      2113
+      "SLAYERTOWER_SMALL_DOOR",
+      "SLAYERTOWER_SMALL_DOOR_OPEN",
+      "SLAYERTOWER_SMALL_DOOR_L",
+      "SLAYERTOWER_SMALL_DOOR_OPEN_L",
+      "SLAYERTOWER_SMALL_DOOR_R",
+      "SLAYERTOWER_SMALL_DOOR_OPEN_R",
+      "SLAYERTOWER_DOOR",
+      "SLAYERTOWER_DOOR_MIRROR",
+      "SLAYERTOWER_DOOR_OPEN",
+      "SLAYERTOWER_DOOR_OPEN_MIRROR"
     ]
   },
   {
     "description": "COX_OUTSIDE_RUINS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      29921,
-      29922,
-      29923,
-      29924,
-      29925,
-      29926,
-      29927,
-      29928,
-      29929,
-      29930,
-      29931,
-      29932,
-      29933,
-      29934,
-      29935,
-      29936,
-      29938,
-      29939,
-      29940,
-      29942,
-      29943,
-      29941,
-      29937
+      "TOX_PILLAR1",
+      "TOX_PILLAR2",
+      "TOX_PILLAR_FALLEN1",
+      "TOX_ARCH1",
+      "TOX_ARCH1_MIRROR",
+      "TOX_ARCH2",
+      "TOX_ARCH2_MIRROR",
+      "TOX_PILLARTALL1",
+      "TOX_PILLARTALL1_TOP",
+      "TOX_ARCHTOP1",
+      "TOX_ARCHTOP2",
+      "TOX_PILLAR_WALL1",
+      "TOX_PILLAR_WALL1_MIRROR",
+      "TOX_PILLAR_WALL2",
+      "TOX_PILLAR_WALL2_MIRROR",
+      "TOX_ARCHTOP1_DIAG",
+      "TOX_TEMPLE_ROOF_SE",
+      "TOX_TEMPLE_ROOF_NE",
+      "TOX_TEMPLE_ROOF_SW",
+      "TOX_GATES_OF_XERIC_LEFT",
+      "TOX_GATES_OF_XERIC_RIGHT",
+      "TOX_XERICIAN_ALTAR",
+      "TOX_XERIC_STATUE"
     ],
     "flatNormals": true
   },
@@ -3985,11 +3985,11 @@
     "description": "COX_PILLAR",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      29806,
-      29807,
-      29808,
-      29809,
-      29810
+      "RAIDS_PILLAR1",
+      "RAIDS_PILLAR2",
+      "RAIDS_PILLAR3",
+      "RAIDS_PILLAR4",
+      "RAIDS_PILLAR5"
     ],
     "flatNormals": true
   },
@@ -3997,42 +3997,42 @@
     "description": "GROUND_DECORATION_ROCKS",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      314,
-      316,
-      317,
-      318,
-      329,
-      330,
-      331,
-      332,
-      333,
-      334,
-      338,
-      339,
-      340,
-      341,
-      342,
-      3172,
-      3173,
-      3174,
-      3613,
-      3614,
-      3615,
-      7057,
-      7103,
-      7104,
-      7120,
-      7122,
-      7125,
-      7126,
-      10029,
-      10030,
-      10031,
-      10844,
-      10845,
-      10846,
-      10847,
-      18934
+      "DUGUPSOIL1",
+      "DUGUPSOIL3",
+      "DUGUPSOIL4",
+      "DUGUPSOIL5",
+      "DUGUPSOIL1_DESERT",
+      "DUGUPSOIL2_DESERT",
+      "DUGUPSOIL3_DESERT",
+      "DUGUPSOIL1_SOOT",
+      "DUGUPSOIL2_SOOT",
+      "DUGUPSOIL3_SOOT",
+      "DUGUPSOIL1_SANDFLOOR",
+      "DUGUPSOIL2_SANDFLOOR",
+      "DUGUPSOIL3_SANDFLOOR",
+      "DUGUPSOIL4_SANDFLOOR",
+      "DUGUPSOIL5_SANDFLOOR",
+      "DUGUPSOIL_DUEL_ARENA_WALKWAY_1",
+      "DUGUPSOIL_DUEL_ARENA_WALKWAY_2",
+      "DUGUPSOIL_DUEL_ARENA_WALKWAY_3",
+      "DUGUPSOIL1_AGILITY",
+      "DUGUPSOIL2_AGILITY",
+      "DUGUPSOIL3_AGILITY",
+      "FAI_VARROCK_PATHS_DUGUPSOIL_1",
+      "FAI_VARROCK_PATHS_DUGUPSOIL_2",
+      "FAI_VARROCK_PATHS_DUGUPSOIL_3",
+      "FAI_VARROCK_DUGUPSOIL_01_DARK",
+      "FAI_VARROCK_DUGUPSOIL_03_DARK",
+      "FAI_VARROCK_DUGUPSOIL_06_DARK",
+      "FAI_VARROCK_DUGUPSOIL_07_DARK",
+      "DUGUPSOIL_MOURNING_1",
+      "DUGUPSOIL_MOURNING_2",
+      "DUGUPSOIL_MOURNING_3",
+      "AGILITY_PYRAMID_DUGUPSOIL1",
+      "AGILITY_PYRAMID_DUGUPSOIL2",
+      "AGILITY_PYRAMID_DUGUPSOIL3",
+      "AGILITY_PYRAMID_DUGUPSOIL4",
+      "TOURTRAP_QIP_SAND_DETAIL2"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "BOX",
@@ -4042,40 +4042,40 @@
     "description": "GROUND_DECORATION_DIRT_UNCOLORED",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      184,
-      7121,
-      7123,
-      7124,
-      7128,
-      7459,
-      7460,
-      7461,
-      7462,
-      12117,
-      12118,
-      12119,
-      12191,
-      12192,
-      12193,
-      19194,
-      12195,
-      12196,
-      12197,
-      12198,
-      12199,
-      12200,
-      12586,
-      12587,
-      12710,
-      20750,
-      20751,
-      20752,
-      25093,
-      25094,
-      25095,
-      25096,
-      25097,
-      25098
+      "DUGUPSOIL1_UPASS",
+      "FAI_VARROCK_DUGUPSOIL_02_DARK",
+      "FAI_VARROCK_DUGUPSOIL_04_DARK",
+      "FAI_VARROCK_DUGUPSOIL_05_DARK",
+      "FAI_VARROCK_DUGUPSOIL_08_DARK",
+      "KORE2_HOS_SOIL_1",
+      "KORE2_HOS_SOIL_2",
+      "KORE2_HOS_SOIL_3",
+      "KORE2_HOS_SOIL_4",
+      "TANGLE_DUGUPSOIL1",
+      "TANGLE_DUGUPSOIL2",
+      "TANGLE_DUGUPSOIL3",
+      "MOLE_DUGUPSOIL_01",
+      "MOLE_DUGUPSOIL_02",
+      "MOLE_DUGUPSOIL_03",
+      "LOTR_RUINS_FLOOR_NO_WATER_EDGE_INSIDE_CORNER_LVL2",
+      "MOLE_DUGUPSOIL_05",
+      "MOLE_DUGUPSOIL_LIGHT_01",
+      "MOLE_DUGUPSOIL_LIGHT_02",
+      "MOLE_DUGUPSOIL_LIGHT_05",
+      "MOLE_DUGUPSOIL_LIGHT_06",
+      "MOLE_DUGUPSOIL_LIGHT_07",
+      "ROCKSLIDE5_UPASS",
+      "ROCKSLIDE6_UPASS",
+      "_100_GOBLINDUGUPSOIL3_UPASS",
+      "BARROWS_DUGUPSOIL_1",
+      "BARROWS_DUGUPSOIL_2",
+      "BARROWS_DUGUPSOIL_3",
+      "DRAGON_SLAYER_QIP_DUGUPSOIL_02",
+      "DRAGON_SLAYER_QIP_DUGUPSOIL_03",
+      "DRAGON_SLAYER_QIP_DUGUPSOIL_04",
+      "DRAGON_SLAYER_QIP_DUGUPSOIL_05",
+      "DRAGON_SLAYER_QIP_DUGUPSOIL_06",
+      "DRAGON_SLAYER_QIP_DUGUPSOIL_07"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.44,
@@ -4090,46 +4090,46 @@
     "description": "Ground Decoration - dirt clump colored",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      176,
-      177,
-      178,
-      322,
-      323,
-      4731,
-      4733,
-      4734,
-      5324,
-      5325,
-      5326,
-      5586,
-      5587,
-      5588,
-      9669,
-      9670,
-      9671,
-      9672,
-      9673,
-      9674,
-      10471,
-      10472,
-      10473,
-      13408,
-      13409,
-      20176,
-      20177,
-      20178,
-      20179,
-      20180,
-      20181,
-      20182,
-      20777,
-      20778,
-      20779,
-      22496,
-      44740,
-      44741,
-      44742,
-      44743
+      "GRAVEL_BROWN_2",
+      "GRAVEL_BROWN_3",
+      "GRAVEL_BROWN_4",
+      "DUGUPSOIL4_LIGHT",
+      "DUGUPSOIL5_LIGHT",
+      "RIVERBANK_DUGUPSOIL2",
+      "RIVERBANK_DUGUPSOIL4",
+      "RIVERBANK_DUGUPSOIL5",
+      "AHOY_DUGUPSOIL_1",
+      "AHOY_DUGUPSOIL_2",
+      "AHOY_DUGUPSOIL_3",
+      "DUGUPSOIL1_LIGHT_NO_GLOW",
+      "DUGUPSOIL2_LIGHT_NO_GLOW",
+      "DUGUPSOIL3_LIGHT_NO_GLOW",
+      "RIMMINGTON_ROCKSLIDE1",
+      "RIMMINGTON_ROCKSLIDE2",
+      "RIMMINGTON_ROCKSLIDE3",
+      "RIMMINGTON_ROCKSLIDE4",
+      "RIMMINGTONROCKSLIDE5",
+      "RIMMINGTON_ROCKSLIDE6",
+      "ELID_DUGUPSOIL_1",
+      "ELID_DUGUPSOIL_2",
+      "ELID_DUGUPSOIL_3",
+      "_100_OSMAN_AUTUMN_DUGUPSOIL_1",
+      "_100_OSMAN_AUTUMN_DUGUPSOIL_2",
+      "BARBASSAULT_DUGUPSOIL_RECRUITMENT_01",
+      "BARBASSAULT_DUGUPSOIL_RECRUITMENT_02",
+      "BARBASSAULT_DUGUPSOIL_RECRUITMENT_03",
+      "BARBASSAULT_DUGUPSOIL_RECRUITMENT_04",
+      "BARBASSAULT_DUGUPSOIL_RECRUITMENT_05",
+      "BARBASSAULT_DUGUPSOIL_RECRUITMENT_06",
+      "BARBASSAULT_DUGUPSOIL_RECRUITMENT_07",
+      "BARROWS_TOWN_DUGUPSOIL_1",
+      "BARROWS_TOWN_DUGUPSOIL_2",
+      "BARROWS_TOWN_DUGUPSOIL_3",
+      "RAMBLE_SWAMP_PATER_RETURN",
+      "GIANTS_FOUNDRY_DUGUPSOIL02_04",
+      "GIANTS_FOUNDRY_DUGUPSOIL02_05",
+      "GIANTS_FOUNDRY_DUGUPSOIL02_06",
+      "GIANTS_FOUNDRY_DUGUPSOIL02_07"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "WORLD_XZ"
@@ -4138,18 +4138,18 @@
     "description": "GROUND_DECORATION_SAND",
     "baseMaterial": "SAND_1",
     "objectIds": [
-      3169,
-      3170,
-      3171,
-      5271,
-      5272,
-      5273,
-      5274,
-      5275,
-      5276,
-      14914,
-      15634,
-      15635
+      "DUGUPSOIL_DUEL_ARENA_1",
+      "DUGUPSOIL_DUEL_ARENA_2",
+      "DUGUPSOIL_DUEL_ARENA_3",
+      "HARMLESS_DUGUPSOIL_SQUISHED1",
+      "HARMLESS_DUGUPSOIL_SQUISHED2",
+      "HARMLESS_DUGUPSOIL_SQUISHED3",
+      "HARMLESS_DUGUPSOIL1",
+      "HARMLESS_DUGUPSOIL2",
+      "HARMLESS_DUGUPSOIL3",
+      "SAND1",
+      "BRIDGELUM_DUGUPSOIL_1",
+      "BRIDGELUM_DUGUPSOIL_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -4159,13 +4159,13 @@
     "description": "GROUND_DECORATION_SNOW",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      10592,
-      10594,
-      13411,
-      13412,
-      13413,
-      26397,
-      26398
+      "WYVERN_DUGUPSOIL_1",
+      "WYVERN_DUGUPSOIL_3",
+      "SNOW_DUGUPSOIL_1",
+      "SNOW_DUGUPSOIL_2",
+      "SNOW_DUGUPSOIL_3",
+      "GODWARS_ENTRANCE_SNOW2",
+      "GODWARS_ENTRANCE_SNOW3"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvScale": 0.25,
@@ -4175,129 +4175,129 @@
     "description": "GROUND_DECORATION_GRAY_ROCK_UNCOLORED",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      180,
-      335,
-      337,
-      756,
-      2173,
-      2174,
-      3702,
-      3704,
-      3711,
-      3720,
-      3721,
-      3749,
-      3751,
-      5327,
-      5328,
-      5329,
-      5954,
-      5956,
-      5957,
-      9573,
-      9574,
-      9575,
-      9576,
-      9577,
-      9578,
-      9579,
-      9580,
-      9581,
-      11438,
-      11439,
-      11440,
-      12707,
-      12708,
-      12928,
-      12929,
-      12930,
-      12932,
-      13414,
-      13416,
-      14391,
-      14394,
-      14467,
-      14484,
-      14487,
-      14491,
-      14493,
-      14496,
-      14497,
-      14499,
-      15146,
-      15147,
-      15148,
-      15153,
-      15154,
-      15155,
-      15247,
-      15248,
-      15249,
-      15631,
-      15797,
-      15798,
-      15799,
-      15800,
-      15801,
-      15802,
-      15803,
-      16201,
-      16998,
-      16999,
-      17525,
-      17526,
-      17529,
-      18275,
-      18276,
-      18277,
-      18278,
-      18279,
-      18280,
-      18281,
-      18282,
-      18283,
-      18284,
-      18285,
-      18286,
-      18287,
-      18288,
-      18289,
-      18290,
-      18291,
-      18292,
-      18293,
-      18294,
-      18295,
-      18296,
-      18297,
-      18298,
-      18299,
-      18300,
-      18301,
-      18302,
-      18303,
-      18857,
-      18858,
-      18859,
-      18860,
-      18861,
-      18862,
-      19185,
-      22652,
-      22654,
-      22655,
-      23589,
-      25326,
-      25327,
-      25328,
-      25329,
-      25330,
-      28500,
-      28501,
-      28502,
-      28556,
-      28557,
-      28558
+      "GRAVEL_3",
+      "DUGUPSOIL1_GREY",
+      "DUGUPSOIL3_GREY",
+      "STONEDISC",
+      "DUGUPSOIL_SLAYER_2",
+      "DUGUPSOIL_SLAYER_3",
+      "DEATH_DUGUPSOIL_1",
+      "DEATH_DUGUPSOIL_3",
+      "DEATH_DUGUPSOIL_SQUISHED_1",
+      "DEATH_ROCKSLIDE5",
+      "DEATH_ROCKSLIDE6",
+      "DUGUPSOIL1_LAWTEMPLE",
+      "DUGUPSOIL3_LAWTEMPLE",
+      "AHOY_INDOOR_DUGUPSOIL_1",
+      "AHOY_INDOOR_DUGUPSOIL_2",
+      "AHOY_INDOOR_DUGUPSOIL_3",
+      "DWARF_SOIL1",
+      "DWARF_SOIL3",
+      "DWARF_SOIL4",
+      "CLIFF_DUGUPSOIL_1",
+      "CLIFF_DUGUPSOIL_2",
+      "CLIFF_DUGUPSOIL_3",
+      "CLIFF_DUGUPSOIL_1_MID",
+      "CLIFF_DUGUPSOIL_2_MID",
+      "CLIFF_DUGUPSOIL_3_MID",
+      "CLIFF_DUGUPSOIL_1_DARK",
+      "CLIFF_DUGUPSOIL_2_DARK",
+      "CLIFF_DUGUPSOIL_3_DARK",
+      "DUGUPSMALLROCKS_LIGHTGREY1",
+      "DUGUPSMALLROCKS_LIGHTGREY2",
+      "DUGUPSMALLROCKS_LIGHTGREY3",
+      "_100_GOBLINDUGUPSOIL1_GREY",
+      "_100_GOBLINDUGUPSOIL3_GREY",
+      "BURGH_ROCKSLIDE",
+      "BURGH_ROCKSLIDE2",
+      "BURGH_ROCK_DUGUPSOIL_1",
+      "BURGH_ROCK_DUGUPSOIL_3",
+      "_100_OSMAN_WINTER_DUGUPSOIL_1",
+      "_100_OSMAN_WINTER_DUGUPSOIL_3",
+      "WILDERNESS_ROCKS_FLOOR_HARD_02",
+      "WILDERNESS_ROCKS_FLOOR_HARD_05",
+      "WILDERNESS_ROCKS_FLOOR_SHARP_01",
+      "WILD1_DUGUPSOIL_3",
+      "WILD2_DUGUPSOIL_3",
+      "WILD3_DUGUPSOIL_1",
+      "WILD3_DUGUPSOIL_3",
+      "WILD4_DUGUPSOIL_3",
+      "WILD5_DUGUPSOIL_1",
+      "WILD5_DUGUPSOIL_3",
+      "ROYAL_DUGUPSOIL_1",
+      "ROYAL_DUGUPSOIL_2",
+      "ROYAL_DUGUPSOIL_3",
+      "ROYAL_DUGUPSOIL_LIGHTER_1",
+      "ROYAL_DUGUPSOIL_LIGHTER_2",
+      "ROYAL_DUGUPSOIL_LIGHTER_3",
+      "LUNAR_MINE_DUGUPSOIL_1",
+      "LUNAR_MINE_DUGUPSOIL_2",
+      "LUNAR_MINE_DUGUPSOIL_3",
+      "DUGUPSOIL3_MACROMAZE",
+      "LOTR_MINE_DUGUPSOIL_01",
+      "LOTR_MINE_DUGUPSOIL_02",
+      "LOTR_MINE_DUGUPSOIL_03",
+      "LOTR_MINE_DUGUPSOIL_04",
+      "LOTR_MINE_DUGUPSOIL_05",
+      "LOTR_MINE_DUGUPSOIL_06",
+      "LOTR_MINE_DUGUPSOIL_07",
+      "FAIRYTALE2_GORAK_DUGUPSOIL_1",
+      "MORYTANIA_CLIMBINGROCKS_SC_TOP",
+      "MORYTANIA_CLIMBINGROCKS_SC_BOTTOM",
+      "MYQ3_ROCKS_FLOOR_SOFT_01",
+      "MYQ3_ROCKS_FLOOR_SOFT_02",
+      "MYQ3_ROCKS_FLOOR_SOFT_05",
+      "SLUG2_ROCKS_DARK1",
+      "SLUG2_ROCKS_DARK2",
+      "SLUG2_ROCKS_DARK3",
+      "SLUG2_ROCKS_DARK4",
+      "SLUG2_ROCKS_DARK5",
+      "SLUG2_ROCKS_GREY1",
+      "SLUG2_ROCKS_GREY2",
+      "SLUG2_ROCKS_GREY3",
+      "SLUG2_ROCKS_GREY4",
+      "SLUG2_ROCKS_GREY5",
+      "SLUG2_ROCKS_LIGHT_BROWN1",
+      "SLUG2_ROCKS_LIGHT_BROWN2",
+      "SLUG2_ROCKS_LIGHT_BROWN3",
+      "SLUG2_ROCKS_LIGHT_BROWN4",
+      "SLUG2_ROCKS_LIGHT_BROWN5",
+      "SLUG2_ROCKS_MED_BROWN1",
+      "SLUG2_ROCKS_MED_BROWN2",
+      "SLUG2_ROCKS_MED_BROWN3",
+      "SLUG2_ROCKS_MED_BROWN4",
+      "SLUG2_ROCKS_MED_BROWN5",
+      "SLUG2_ROCKS_YELLOW1",
+      "SLUG2_ROCKS_YELLOW2",
+      "SLUG2_ROCKS_YELLOW3",
+      "SLUG2_ROCKS_YELLOW4",
+      "SLUG2_ROCKS_YELLOW5",
+      "SLUG2_ROCKS_OFFSET",
+      "SLUG2_ROCKS_OFFSET_GREY",
+      "SLUG2_ROCKS_OFFSET_BROWN",
+      "SLUG2_ROCKS_OFFSET_YELLOW",
+      "MYARM_ROCK_FLOOR_01",
+      "MYARM_ROCK_FLOOR_02",
+      "MYARM_ROCK_FLOOR_03",
+      "MYARM_ROCK_FLOOR_04",
+      "MYARM_ROCK_FLOOR_05",
+      "MYARM_ROCK_FLOOR_06",
+      "LOTR_RUINS_FLOOR_RUBBLE_02_LVL2",
+      "DORGESH_ROCKS_DARK1",
+      "DORGESH_ROCKS_DARK4",
+      "DORGESH_ROCKS_DARK5",
+      "ATJUN_DUGUPSOIL_SQUISHED_3",
+      "BRUT_ROCKS_LVL1A",
+      "BRUT_ROCKS_LVL1B",
+      "BRUT_ROCKS_LVL1C",
+      "BRUT_ROCKS_LVL1D",
+      "BRUT_ROCKS_LVL1E",
+      "LOVAKENGJ_RUBBLE_01",
+      "LOVAKENGJ_RUBBLE_0_2",
+      "LOVAKENGJ_RUBBLE_03",
+      "SULPHUR_DUGUPSOIL_3",
+      "SULPHUR_DUGUPSOIL_4",
+      "SULPHUR_DUGUPSOIL_5"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.25
@@ -4306,65 +4306,65 @@
     "description": "ROCK_LIKE_OBJECT",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      84,
-      179,
-      336,
-      3703,
-      3750,
-      5955,
-      5958,
-      6672,
-      6673,
-      12578,
-      12596,
-      12705,
-      12931,
-      13415,
-      14483,
-      14492,
-      14494,
-      14495,
-      14498,
-      19390,
-      19393,
-      19397,
-      25077,
-      25078,
-      25079,
-      25080,
-      25084,
-      25085,
-      25086,
-      25102,
-      25103,
-      25104,
-      25105,
-      25106,
-      25107,
-      25108,
-      25109,
-      25110,
-      25111,
-      25112,
-      25113,
-      25114,
-      28555,
-      39742,
-      39743,
-      39744,
-      39745,
-      39746,
-      39747,
-      25080,
-      25081,
-      25082,
-      22543,
-      22542,
-      22541,
-      25083,
-      25084,
-      25085,
-      25161
+      "_00",
+      "GRAVEL_1",
+      "DUGUPSOIL2_GREY",
+      "DEATH_DUGUPSOIL_2",
+      "DUGUPSOIL2_LAWTEMPLE",
+      "DWARF_SOIL2",
+      "DWARF_SOIL5",
+      "TOG_CLIMBING_ROCKS_DOWN",
+      "TOG_CLIMBING_ROCKS_UP",
+      "STALAGMITES",
+      "DUGUPSOIL_MIDGREY2",
+      "_100_GOBLINDUGUPSOIL2_SOOT",
+      "BURGH_ROCK_DUGUPSOIL_2",
+      "_100_OSMAN_WINTER_DUGUPSOIL_2",
+      "WILD1_DUGUPSOIL_2",
+      "WILD3_DUGUPSOIL_2",
+      "WILD4_DUGUPSOIL_1",
+      "WILD4_DUGUPSOIL_2",
+      "WILD5_DUGUPSOIL_2",
+      "HUNTING_TRAIL_CLUE5_0",
+      "HUNTING_TRAIL_CLUE5_3",
+      "HUNTING_TRAIL_CLUE5_7",
+      "DRAGON_SLAYER_QIP_STALAGTITE_01",
+      "DRAGON_SLAYER_QIP_STALAGTITE_02",
+      "DRAGON_SLAYER_QIP_STALAGTITE_FALLOFF",
+      "DRAGON_SLAYER_QIP_ROCKCOLUMN1",
+      "DRAGON_SLAYER_QIP_STALAGMITE_WALL",
+      "DRAGON_SLAYER_QIP_STALAGMITE_WALL2",
+      "DRAGON_SLAYER_QIP_STALAGMITE_FLOOR",
+      "DRAGON_SLAYER_QIP_STALAGMITE_LARGE",
+      "DRAGON_SLAYER_QIP_STALAGMITE_XLARGE",
+      "DRAGON_SLAYER_QIP_STALAGMITE_XLARGE2",
+      "DRAGON_SLAYER_QIP_STALAGMITE_XLARGE3",
+      "DRAGON_SLAYER_QIP_STALAGMITE_LARGE2",
+      "DRAGON_SLAYER_QIP_STALAGMITE_MEDIUM",
+      "DRAGON_SLAYER_QIP_STALAGMITE_MEDIUM2",
+      "DRAGON_SLAYER_QIP_STALAGMITE_SMALL",
+      "DRAGON_SLAYER_QIP_STALAGMITE_SMALL2",
+      "DRAGON_SLAYER_QIP_STALAGMITE_FALLOFF",
+      "DRAGON_SLAYER_QIP_STALAGMITE_FALLOFF2",
+      "DRAGON_SLAYER_QIP_STALAGMITE_FALLOFF3",
+      "DRAGON_SLAYER_QIP_PILLAR",
+      "SULPHUR_DUGUPSOIL_2",
+      "GH_ROCKSLIDE_01",
+      "GH_ROCKSLIDE_02",
+      "GH_ROCKSLIDE_03",
+      "GH_ROCKSLIDE_04",
+      "GH_ROCKSLIDE_05",
+      "GH_ROCKSLIDE_06",
+      "DRAGON_SLAYER_QIP_ROCKCOLUMN1",
+      "DRAGON_SLAYER_QIP_ROCKCOLUMN2",
+      "DRAGON_SLAYER_QIP_ROCKCOLUMN3",
+      "GOBLIN_CAVEWALL_STALAGMITE_TWIN",
+      "GOBLIN_CAVEWALL_STALAGMITE_LARGE",
+      "GOBLIN_CAVEWALL_STALAGMITE",
+      "DRAGON_SLAYER_QIP_STAGAMITE",
+      "DRAGON_SLAYER_QIP_STALAGMITE_WALL",
+      "DRAGON_SLAYER_QIP_STALAGMITE_WALL2",
+      "DRAGON_SLAYER_QIP_STALAGTITE_JUMP"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -4374,14 +4374,14 @@
     "description": "ROCK_CAVE_ENTRANCES",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      12173,
-      30176,
-      30869,
-      11835,
-      29627,
-      6659,
-      40386,
-      26766
+      "CANOEING_CAVEENTRANCE_BROWN",
+      "SMOKEDEVIL_CAVE_ENTRANCE",
+      "FOSSIL_WYVERN_CAVE_ENTRANCE",
+      "TZHAAR_KARAMJADUNGEON_WALL_ENTRANCE",
+      "RC_ZMI_DUNGEON_WALL_CRACK_ENTRANCE_EXIT",
+      "TOG_CAVE_DOWN",
+      "WILD_CAVE_ENTRANCE_MID",
+      "WILDERNESS_GWD_ENTRANCE"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -4391,7 +4391,7 @@
     "description": "Scorpia Cavern - Entrance",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      26762
+      "WILDERNESS_SCORPION_ENTRANCE"
     ],
     "uvType": "BOX"
   },
@@ -4399,9 +4399,9 @@
     "description": "DIRT_CAVE_ENTRANCES",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      720,
-      3213,
-      40887
+      "CAVEENTRANCE3",
+      "UPASS_CAVEENTRANCE2",
+      "XMAS20_GOBLIN_CAVE_ENTRANCE"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -4411,8 +4411,8 @@
     "description": "DIRT_CAVE_ENTRANCES",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      39721,
-      44635
+      "GH_CAVE",
+      "GIANTS_FOUNDRY_ENTRANCE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -4421,7 +4421,7 @@
     "description": "SNOW_CAVE_ENTRANCES",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      8930
+      "DAGANNOTH_CAVEENTRANCE_ICE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -4430,37 +4430,37 @@
     "description": "CAVE_WALLS_BLEND",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      2606,
-      17210,
-      17211,
-      17215,
-      17216,
-      17217,
-      25099,
-      25100,
-      25101,
-      25039,
-      25049,
-      25050,
-      25051,
-      25052,
-      25059,
-      25060,
-      25061,
-      25062,
-      25063,
-      25064,
-      29634,
-      32163,
-      32164,
-      55904,
-      55906,
-      55973,
-      55988,
-      55976,
-      55977,
-      55978,
-      25140
+      "DRAGONSECRETDOOR",
+      "EYEGLO_MINE_WALL",
+      "EYEGLO_MINE_WALL_ROCKY",
+      "EYEGLO_MINE_WALL_SUPPORT_LEFT",
+      "EYEGLO_MINE_WALL_SUPPORT_RIGHT",
+      "EYEGLO_MINE_WALL_SUPPORT_MID",
+      "DRAGON_SLAYER_QIP_CHARRED_WALL",
+      "DRAGON_SLAYER_QIP_CHARRED_WALL_L",
+      "DRAGON_SLAYER_QIP_CHARRED_WALL_R",
+      "DRAGONSECRETDOOR_OPEN",
+      "DRAGON_SLAYER_QIP_MINE_WALL",
+      "DRAGON_SLAYER_QIP_MINE_WALL_BRICK",
+      "DRAGON_SLAYER_QIP_MINE_WALL_BRICK_M",
+      "DRAGON_SLAYER_MINE_WALL_ROCKY",
+      "DRAGON_SLAYER_QIP_MINE_WALL_END",
+      "DRAGON_SLAYER_QIP_MINE_WALL_END2",
+      "DRAGON_SLAYER_QIP_LAVA_WALL",
+      "DRAGON_SLAYER_QIP_LAVA_WALL_CORNER",
+      "DRAGON_SLAYER_QIP_LAVA_WALL_CORNER3",
+      "DRAGON_SLAYER_QIP_LAVA_WALL_CORNER2",
+      "RC_ZMI_DUNGEON_WALL_DOUBLE_CORNER",
+      "DRAGON_SLAYER_MINE_TUNNEL_RIGHT_NONE",
+      "DRAGON_SLAYER_MINE_TUNNEL_LEFT_NONE",
+      "WYVERN_CAVE_WALL_BROWNMUD",
+      "WYVERN_CAVE_WALLTOP_BROWNMUD",
+      "WYVERN_CAVE_WALLTOP_BROWNMUD_CONCAVE",
+      "CAVEWALL_SHORTCUT_ROYAL_TITANS_EAST",
+      "WYVERN_CAVE_ROCKS_BROWNMUD_1X1_1",
+      "WYVERN_CAVE_ROCKS_BROWNMUD_1X1_2",
+      "WYVERN_CAVE_ROCKS_BROWNMUD_1X1_3",
+      "DRAGON_SLAYER_QIP_BRICKWALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -4475,10 +4475,10 @@
     "description": "CAVE_WALLS_LANTERN",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      25053,
-      25054,
-      25055,
-      25056
+      "DRAGON_SLAYER_MINE_WALL_SUPPORT_LEFT",
+      "DRAGON_SLAYER_MINE_WALL_SUPPORT_RIGHT",
+      "DRAGON_SLAYER_MINE_WALL_LAMP_SINGLE",
+      "DRAGON_SLAYER_MINE_WALL_LAMP"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -4488,10 +4488,10 @@
     "baseMaterial": "ROCK_3_MEDIUM_DARK",
     "areas": [ "ASGARNIA_ICE_DUNGEON" ],
     "objectIds": [
-      25053,
-      25054,
-      25055,
-      25056
+      "DRAGON_SLAYER_MINE_WALL_SUPPORT_LEFT",
+      "DRAGON_SLAYER_MINE_WALL_SUPPORT_RIGHT",
+      "DRAGON_SLAYER_MINE_WALL_LAMP_SINGLE",
+      "DRAGON_SLAYER_MINE_WALL_LAMP"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -4501,7 +4501,7 @@
     "baseMaterial": "ROCK_3",
     "areas": [ "ASGARNIA_ICE_DUNGEON" ],
     "objectIds": [
-      37491
+      "CAVEWALL_TOP_SUPERBLACK"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -4515,7 +4515,7 @@
   {
     "description": "CAVE_WALLS_BLEND_TUNNEL",
     "baseMaterial": "ROCK_3",
-    "objectIds": [ 30174, 30175 ],
+    "objectIds": [ "SLAYER_CAVE_TUNNEL_RIGHT", "SLAYER_CAVE_TUNNEL_LEFT" ],
     "uvType": "BOX",
     "uvScale": 0.75
   },
@@ -4523,16 +4523,16 @@
     "description": "CAVE_WALL_ABOVE_FLOOR_TILE",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      17224,
-      25057,
-      25058
+      "EYEGLO_CAVEWALL_TOP",
+      "DRAGON_SLAYER_MINE_WALL_TOP",
+      "DRAGON_SLAYER_MINE_WALL_TOP_EDGE"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 400
   },
   {
     "description": "Hide weird wall piece above other walls in Canifis pub basement",
-    "objectIds": [ 1417 ],
+    "objectIds": [ "CAVEWALL_FACE1" ],
     "baseMaterial": "GRUNGE_1",
     "hideInAreas": [
       [ 3469, 9845 ]
@@ -4543,11 +4543,11 @@
     "description": "Obors lair exit",
     "baseMaterial": "GRUNGE_1",
     "uvType": "BOX",
-    "objectIds": [ 1423, 1424 ]
+    "objectIds": [ "CAVEWALL_DOOR1R", "CAVEWALL_DOOR1L" ]
   },
   {
     "description": "Canifis Rooftop Agility Course Tall Tree",
-    "objectIds": [ 14843 ],
+    "objectIds": [ "ROOFTOPS_CANIFIS_START_TREE" ],
     "baseMaterial": "LIGHT_BARK",
     "uvType": "BOX",
     "uvOrientation": 512
@@ -4556,25 +4556,25 @@
     "description": "ROUNDED_CAVE_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      1422,
-      1435,
-      1459,
-      1469,
-      1460,
-      1467,
-      3222,
-      4448,
-      6628,
-      9739,
-      9740,
-      16543,
-      17086,
-      17087,
-      26712,
-      35838,
-      35839,
-      35840,
-      35841
+      "CAVEWALL_FACEFORTORCH1",
+      "CAVEWALL_TOP5",
+      "CAVEWALL_FACE1_DARK",
+      "CAVEWALL_FACE1_LEV2_DARK",
+      "CAVEWALL_TOP_DARK",
+      "CAVEWALL_TOP5_DARK",
+      "CAVEWALLTUNNEL_UPASS_DOWN",
+      "CASTLEWARS_CAVEWALL_ROCKSLIDE",
+      "CAVEWALL_FACE1_FOR_LEVER",
+      "HEROES_GUILD_SHORTCUT_TO_FOUNTAIN",
+      "HEROES_GUILD_SHORTCUT_FROM_FOUNTAIN",
+      "DWARF_MINES_SC_WALL_CRACK",
+      "XBOWS_CAVE_WALL_A",
+      "XBOWS_CAVE_WALL_B",
+      "SLAYER_CAVE_PASSAGE_DARK",
+      "SOTE_WELL_CAVE_BLOCKED_INSPECT",
+      "SOTE_WELL_CAVE_BLOCKED_MINE",
+      "SOTE_WELL_CAVE_OPEN",
+      "SOTE_WELL_CAVE_EXIT"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -4584,7 +4584,7 @@
     "description": "Rounded Cave Wall Entrance with Tracks",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      6971
+      "DWARF_KELDAGRIM_CAVEWALL_TUNNEL_CART"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -4594,98 +4594,98 @@
     "description": "ROUNDED_CAVE_WALLS_TOP",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      1434
+      "CAVEWALL_TOP"
     ]
   },
   {
     "description": "TROLL_STRONGHOLD_HIDDEN_DOOR",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      3762
+      "TROLL_STRONGHOLD_ENTRANCE"
     ]
   },
   {
     "description": "LUMBRIDGE_CAVE_WALLS",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      5912,
-      5913,
-      5914,
-      5915,
-      5916,
-      5919,
-      5920,
-      5921,
-      5922,
-      5923,
-      5924,
-      5925,
-      5926,
-      5927,
-      5928,
-      5929,
-      5930,
-      5931,
-      5932,
-      5933,
-      5934,
-      5935,
-      5936,
-      5937,
-      5938,
-      5939,
-      5940,
-      5941,
-      5942,
-      5943,
-      5944,
-      5945,
-      6658,
-      6660,
-      6664,
-      6668,
-      6674,
-      6675,
-      6676,
-      6677,
-      6678,
-      6679,
-      6680,
-      6681,
-      6682,
-      6683,
-      6684,
-      6685,
-      6686,
-      6687,
-      6688,
-      6689,
-      6690,
-      6691,
-      6692,
-      6693,
-      6694,
-      6695,
-      6696,
-      6697,
-      6698,
-      6699,
-      6700,
-      6701,
-      6906,
-      6912,
-      6925,
-      6927,
-      6931,
-      6932,
-      6933,
-      6939,
-      6940,
-      6929,
-      6930,
-      5917,
-      5918,
-      6903
+      "SWAMP_CAVEWALL_OUTSIDECORNER",
+      "SWAMP_CAVEWALLINSIDECORNER",
+      "SWAMP_CAVEWALL_TOP5",
+      "SWAMP_CAVEWALL_TOP1",
+      "SWAMP_CAVEWALL1_STALAGMITE1",
+      "SWAMP_CAVEWALL1",
+      "SWAMP_CAVEWALL1_GUNGYWATER1",
+      "GOBLIN_CAVEWALL_FLOWINGGUNGYWATER",
+      "SWAMP_CAVEWALL2",
+      "SWAMP_CAVEWALL3",
+      "SWAMP_CAVEWALL4",
+      "SWAMP_CAVEWALL5",
+      "SWAMP_CAVEWALL6",
+      "SWAMP_CAVEWALL7",
+      "SWAMP_CAVEWALL8",
+      "SWAMP_CAVEWALL9",
+      "SWAMP_CAVEWALL10",
+      "SWAMP_CAVEWALL11",
+      "SWAMP_CAVEWALL12",
+      "SWAMP_CAVEWALL1_WARNING1",
+      "SWAMP_CAVEWALLMOSS1",
+      "SWAMP_CAVEWALLMOSS2",
+      "SWAMP_CAVEWALLMOSS3",
+      "SWAMP_CAVEWALLMOSS4",
+      "SWAMP_CAVEWALLMOSS5",
+      "SWAMP_CAVEWALLMOSS6",
+      "SWAMP_CAVEWALLMOSS7",
+      "SWAMP_CAVEWALLMOSS8",
+      "SWAMP_CAVEWALLMOSS9",
+      "SWAMP_CAVEWALLMOSS10",
+      "SWAMP_CAVEWALLMOSS11",
+      "SWAMP_CAVEWALLMOSS12",
+      "TOG_CAVE_UP",
+      "TOG_WEEPINGWALL",
+      "TOG_WEEPING_WALL_BACK_R",
+      "TOG_WEEPING_WALL_BACK_L",
+      "TOG_FALLOFF_1",
+      "TOG_FALLOFF2_1",
+      "TOG_FALLOFF_2R",
+      "TOG_FALLOFF_2L",
+      "TOG_FALLOFF_3",
+      "TOG_FALLOFF_4",
+      "TOG_FALLOFF_5",
+      "TOG_FALLOFF_6",
+      "TOG_FALLOFF_7R",
+      "TOG_FALLOFF_7L",
+      "TOG_FALLOFF_8",
+      "TOG_FALLOFF_9",
+      "TOG_FALLOFF_10",
+      "TOG_FALLOFF_LOW_1",
+      "TOG_FALLOFF_LOW_2R",
+      "TOG_FALLOFF_LOW_2L",
+      "TOG_FALLOFF_LOW_3",
+      "TOG_FALLOFF_LOW_4",
+      "TOG_FALLOFF_LOW_5",
+      "TOG_FALLOFF_LOW_6",
+      "TOG_FALLOFF_LOW_7R",
+      "TOG_FALLOFF_LOW_7L",
+      "TOG_FALLOFF_LOW_8",
+      "TOG_FALLOFF_LOW_9",
+      "TOG_FALLOFF_LOW_10",
+      "TOG_CAVEWALL_NO_SOIL",
+      "TOG_CAVEWALL_OUTSIDECORNER_NO_SOIL",
+      "TOG_CAVEWALLINSIDECORNER_NO_SOIL",
+      "LOST_TRIBE_CAVEWALL_HOLE",
+      "LOST_TRIBE_HOLE_2",
+      "SWAMP_CAVEWALL_FORMARKER",
+      "COLLAPSING_ROOF_LOCATION",
+      "GOBLIN_CAVEWALL_BONEARCH",
+      "GOBLIN_CAVEWALL_BONEARCH_RAGS1",
+      "GOBLIN_CAVEWALL_BONEARCH_RAGS2",
+      "GOBLIN_CAVEWALL_BONEARCH_BROKEN1",
+      "GOBLIN_CAVEWALL_BONEARCH_BROKEN2",
+      "GOBLIN_CAVEWALL_BONE_SUPPORTED1",
+      "GOBLIN_CAVEWALL_BONE_SUPPORTED2",
+      "SWAMP_CAVEWALL1_GASHOLE",
+      "SWAMP_CAVEWALL1_GASHOLE2",
+      "LOST_TRIBE_CELLAR_HOLE_BLOCKING"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -4697,7 +4697,7 @@
     "uvType": "BOX",
     "uvOrientation": 100,
     "objectIds": [
-      677
+      "CORP_BEAST_ENTRANCE"
     ]
   },
   {
@@ -4708,8 +4708,8 @@
     "uvScale": 0.75,
     "uvOrientation": 200,
     "objectIds": [
-      6820,
-      6822
+      "SLAYER_CAVEWALL_FACE1",
+      "SLAYER_MOUNTAIN_CAVEWALL_TOP"
     ]
   },
   {
@@ -4719,7 +4719,7 @@
     "uvScale": 0.75,
     "uvOrientation": 110,
     "objectIds": [
-      679
+      "CORP_CAVE_EXIT"
     ],
     "colorOverrides": [
       {
@@ -4734,8 +4734,8 @@
     "uvScale": 0.4,
     "uvType": "BOX",
     "objectIds": [
-      41015,
-      41016
+      "CORP_IRONMAN_BRAZIER_OFF",
+      "CORP_IRONMAN_BRAZIER_ON"
     ],
     "colorOverrides": [
       {
@@ -4756,8 +4756,8 @@
     "description": "Corporeal Beast Graves",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      675,
-      676
+      "CORP_BEAST_GRAVE_TOP",
+      "CORP_BEAST_GRAVE_BOTTOM"
     ],
     "colorOverrides": [
       {
@@ -4779,24 +4779,24 @@
   {
     "description": "Corporeal Beast - Darken to fit environment",
     "baseMaterial": "GRAY_75",
-    "npcIds": [ 319 ]
+    "npcIds": [ "CORP_BEAST" ]
   },
   {
     "description": "UNKNOWN_2",
     "objectIds": [
-      3089,
-      3090,
-      3091,
-      3096,
-      3097,
-      3102,
-      3103,
-      3192,
-      3111,
-      3112,
-      3113,
-      3114,
-      2569
+      "STANDARD_DUEL",
+      "WALLSTANDARD_MELEE_RED",
+      "WALLSTANDARD_RANGED_RED",
+      "WALLSTANDARD_MELEE_BLUE",
+      "WALLSTANDARD_RANGED_BLUE",
+      "WALLSTANDARD_MELEE_GREEN",
+      "WALLSTANDARD_RANGED_GREEN",
+      "INVISIBLE_TYPE8_BLOCKING_SIZE9",
+      "FLAG_ENTRANCE_ANGLED",
+      "FLAG_ENTRANCE2_ANGLED",
+      "FLAG_ENTRANCEL_ANGLED",
+      "FLAG_ENTRANCE2L_ANGLED",
+      "FAI_VARROCK_WINDMILL_MILLSAIL"
     ],
     "flatNormals": true
   },
@@ -4804,22 +4804,22 @@
     "description": "Pale rock walls",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      2141,
-      3669,
-      3737,
-      3740,
-      3759,
-      3770,
-      3772,
-      3773,
-      3774,
-      3812,
-      6820,
-      6822,
-      6824,
-      6826,
-      11656,
-      16539
+      "SLAYER_DUNGEON_EXIT",
+      "DEATH_TROLLROCKSUPPLY",
+      "DEATH_MOUNTAIN_CAVEWALL_FACE1",
+      "DEATH_MOUNTAINCAVEWALL_TOP_HIGHER",
+      "TROLL_MAD_EADGAR_ENTRANCE",
+      "TROLL_STRONGHOLD_WINDOW",
+      "TROLL_STRONGHOLD_TOP_EXIT_LEFT",
+      "TROLL_STRONGHOLD_TOP_EXIT_RIGHT",
+      "TROLL_STRONGHOLD_TOP_EXIT_MID",
+      "EADGAR_TROLL_THISTLE_BASE",
+      "SLAYER_CAVEWALL_FACE1",
+      "SLAYER_MOUNTAIN_CAVEWALL_TOP",
+      "SLAYER_MOUNTAINCAVEWALL_TOP_HIGHER",
+      "SLAYER_CAVEWALL_FACE1_SHORTER",
+      "WAA_CAVEWALL_SKULLHOLE",
+      "SLAYER_DUNGEON_2_SC_WALL_CRACK"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -4832,7 +4832,7 @@
     "uvScale": 0.7,
     "uvOrientation": 256,
     "objectIds": [
-      6825
+      "SLAYER_MOUNTAINCAVEWALL_TOP_LOWER"
     ]
   },
   {
@@ -4851,15 +4851,15 @@
       }
     ],
     "objectIds": [
-      11657
+      "WAA_PIPE"
     ]
   },
   {
     "description": "Pale rock tunnel, Keldagrim to Rellekka tunnel",
     "baseMaterial": "ROCK_3_DARK",
     "objectIds": [
-      5013,
-      5014
+      "TROLLROMANCE_PISTE_EXIT_TUNNEL_TOP",
+      "TROLLROMANCE_PISTE_EXIT_TUNNEL_BOTTOM"
     ],
     "uvType": "BOX",
     "uvScale": 0.9
@@ -4868,9 +4868,9 @@
     "description": "Pale rock walls - Top",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      3738,
-      3739,
-      6827
+      "DEATH_MOUNTAIN_CAVEWALL_TOP",
+      "DEATH_MOUNTAIN_CAVEWALL_TOP5",
+      "SLAYER_CAVEWALL_TOP_SHORTER"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 1.3
@@ -4879,8 +4879,8 @@
     "description": "BEIGE_WALLS",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      446,
-      447
+      "FAI_VARROCK_POOR_INT_FENCE_JOIN",
+      "FAI_VARROCK_POOR_INT_FENCE_JOIN_MIRROR"
     ],
     "flatNormals": true
   },
@@ -4888,19 +4888,19 @@
     "description": "Grunge Caves",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      2123,
-      4147,
-      5008,
-      5046,
-      5858,
-      5973,
-      12770,
-      26567,
-      26568,
-      26569,
-      31481,
-      31482,
-      43759
+      "SLAYER_DUNGEON_ENTRANCE",
+      "VIKING_TROLLCAVE_ENTRANCE",
+      "TROLLROMANCE_STRONGHOLD_EXIT_TUNNEL",
+      "ROUTE_CAVEWALLTUNNEL",
+      "MDAUGHTER_CAVEEXIT",
+      "DWARF_CAVEWALL_TUNNEL",
+      "BURGH_IVANDIS_TOMB_ENTRANCE",
+      "HELLHOUND_CAVE_ENTRANCE_A_01",
+      "HELLHOUND_CAVE_ENTRANCE_B_02",
+      "HELLHOUND_CAVE_ENTRANCE_C_03",
+      "FOSSIL_SHORTCUT_BASECAMP_A",
+      "FOSSIL_SHORTCUT_BASECAMP_B",
+      "MYQ5_WALL_CAVE_SHORTCUT_5"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -4908,15 +4908,15 @@
   {
     "description": "UNKNOWN_9",
     "objectIds": [
-      3110
+      "FLAG_ENTRANCEBASE"
     ],
     "flatNormals": true
   },
   {
     "description": "Guardians of the Rift entrance",
     "objectIds": [
-      43700,
-      43849
+      "GOTR_BARRIER",
+      "GOTR_BARRIER_CLOSED"
     ],
     "baseMaterial": "UNLIT",
     "castShadows": false
@@ -4924,14 +4924,14 @@
   {
     "description": "Guardians of the Rift barriers",
     "objectIds": [
-      43744,
-      43745,
-      43746,
-      43747,
-      43748,
-      43749,
-      43750,
-      43751
+      "GOTR_BARRIER_TIER1",
+      "GOTR_BARRIER_TIER1_3X3",
+      "GOTR_BARRIER_TIER2",
+      "GOTR_BARRIER_TIER2_3X3",
+      "GOTR_BARRIER_TIER3",
+      "GOTR_BARRIER_TIER3_3X3",
+      "GOTR_BARRIER_TIER4",
+      "GOTR_BARRIER_TIER4_3X3"
     ],
     "baseMaterial": "UNLIT",
     "castShadows": false
@@ -4939,8 +4939,8 @@
   {
     "description": "Tombs of Amascut Baba boulders",
     "npcIds": [
-      11782,
-      11783
+      "TOA_BABA_BOULDER",
+      "TOA_BABA_BOULDER_WEAK"
     ],
     "flatNormals": true
   },
@@ -4948,9 +4948,9 @@
     "description": "Desert Quarry Fence",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      11109,
-      11110,
-      11111
+      "ENAKH_OLDFENCING",
+      "ENAKH_OLDFENCING_2",
+      "ENAKH_OLDFENCING_3"
     ],
     "uvScale": 0.15
   },
@@ -4958,7 +4958,7 @@
     "description": "Desert Quarry Table",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      8700
+      "FARM_TABLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -4967,8 +4967,8 @@
     "description": "Desert Quarry Crates & Tent posts",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      7515,
-      14033
+      "FARMING_CRATE_INACTIVE",
+      "FISHING_CONTEST_POST"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -4978,15 +4978,15 @@
     "description": "Desert Quarry Grinder",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      26199
+      "GRINDER_MACHINE"
     ]
   },
   {
     "description": "Desert Quarry Wheelbarrow & Ladder",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11081,
-      11082
+      "ENAKH_LADDER_ON_GROUND",
+      "ENAKH_WHEEL_BARROW"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -4996,7 +4996,7 @@
     "description": "Desert Quarry Scaffold",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      11080
+      "ENAKH_SCAFFOLD"
     ],
     "uvType": "BOX",
     "uvScale": 0.15,
@@ -5006,7 +5006,7 @@
     "description": "Desert pyramid walls",
     "baseMaterial": "WALL_STONE",
     "objectIds": [
-      6617, 6618, 6539, 6540
+      "ICS_PYRAMID_WALL_FLATSKEW", "ICS_PYRAMID_WALL_FLATSKEW_CORN", "FOUR_DIAMONDS_PYRAMID_WALL", "FOUR_DIAMONDS_PYRAMID_CORNER"
     ],
     "flatNormals": true,
     "uvType": "MODEL_XZ"
@@ -5015,15 +5015,15 @@
     "description": "Desert pyramid walls - Interior",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      6505,
-      6525,
-      6526,
-      6527,
-      6529,
-      6530,
-      6531,
-      20272,
-      20337
+      "DESERTTREASURE_SARCOPHIGI_WALL",
+      "FOUR_DIAMONDS_TOMB_WALL",
+      "FOUR_DIAMONDS_TOMB_WALL_TABLET",
+      "FOUR_DIAMONDS_TOMB_WALL_LEV2",
+      "FOUR_DIAMONDS_TOMB_WALL_DAMAGE",
+      "FOUR_DIAMONDS_TOMB_BLOCKPILE1",
+      "FOUR_DIAMONDS_TOMB_WALL_TOP",
+      "CONTACT_SPEARTRAP",
+      "CONTACT_TOMB_WALL_TOP_END"
     ],
     "uvType": "BOX"
   },
@@ -5031,7 +5031,7 @@
     "description": "Desert pyramid walls - Interior - Push Trap",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      6629
+      "DESERTTREASURE_WALL_CRUSHER"
     ],
     "uvType": "BOX"
   },
@@ -5039,17 +5039,17 @@
     "description": "Desert pyramid Tunnel",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      6481
+      "DESERT_TRASURE_BACK_DOOR_SKEW"
     ]
   },
   {
     "description": "Desert pyramid Door",
     "baseMaterial": "WALL_STONE",
     "objectIds": [
-      6545,
-      6546,
-      6547,
-      6548
+      "FOUR_DIAMONDS_DOOR_1",
+      "FOUR_DIAMONDS_DOOROPEN_1",
+      "FOUR_DIAMONDS_DOOR_MIRROR",
+      "FOUR_DIAMONDS_DOOROPEN_MIRROR"
     ],
     "flatNormals": true,
     "uvType": "BOX"
@@ -5058,19 +5058,19 @@
     "description": "Sophanem pyramid door",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      6614, 19168,
-      20979, 20987, 21251,
-      21252, 21253, 21254,
-      20956, 20974, 20975,
-      20976, 20977, 20978
+      "ICTHALARINS_TEMPLE_DOOR", "CONTACT_EGYPT_COLUMN",
+      "NTK_PYRAMID_DOOR_SOUTH_ANIM", "NTK_PYRAMID_DOOR_SOUTH_NOANIM", "NTK_PYRAMID_DOOR_SOUTH_OPEN_NOANIM",
+      "NTK_PYRAMID_DOOR_WEST_ANIM", "NTK_PYRAMID_DOOR_WEST_NOANIM", "NTK_PYRAMID_DOOR_WEST_OPEN_NOANIM",
+      "NTK_PYRAMID_DOOR_NORTH_ANIM", "NTK_PYRAMID_DOOR_NORTH_NOANIM", "NTK_PYRAMID_DOOR_NORTH_OPEN_NOANIM",
+      "NTK_PYRAMID_DOOR_EAST_ANIM", "NTK_PYRAMID_DOOR_EAST_NOANIM", "NTK_PYRAMID_DOOR_EAST_OPEN_NOANIM"
     ]
   },
   {
     "description": "Pyramid Plunder Walls - Exit Doors",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      20931,
-      20932
+      "NTK_TOMB_DOOR_EXIT",
+      "NTK_ANTECHAMBER_EXIT"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -5084,16 +5084,16 @@
     "description": "Pyramid Plunder Walls - Interior",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      20933,
-      20939,
-      20937,
-      20948,
-      20949,
-      21280,
-      20934,
-      20944,
-      20943,
-      20945
+      "NTK_TOMB_WALL",
+      "NTK_TOMB_WALL_TOP",
+      "NTK_TOMB_WALL_DAMAGE",
+      "NTK_TOMB_DOOR_NOANIM",
+      "NTK_TOMB_DOOR_ANIM",
+      "NTK_SPEARTRAP_INMOTION",
+      "NTK_TOMB_WALL_TABLET",
+      "NTK_TOMB_WALLTOP_STRAIGHT",
+      "NTK_TOMB_WALLTOP_CORNER",
+      "NTK_TOMB_WALLTOP_INNER_CORNER"
     ],
     "uvType": "BOX"
   },
@@ -5101,10 +5101,10 @@
     "description": "Pyramid Plunder Obelisk, Busts and Wall symbol",
     "baseMaterial": "MARBLE_1_GLOSS",
     "objectIds": [
-      20955,
-      20954,
-      20953,
-      20941
+      "NTK_OBELISK",
+      "NTK_STAND_BUST2",
+      "NTK_STAND_BUST1",
+      "NTK_TOMB_WALL_EYE"
     ],
     "uvType": "BOX",
     "uvScale": 1.2
@@ -5112,12 +5112,12 @@
   {
     "description": "Pyramid Plunder Metallic Objects",
     "objectIds": [
-      21263,
-      21267,
-      21262,
-      21266,
-      21261,
-      21265
+      "NTK_URN3_CLOSED",
+      "NTK_URN3_OPEN",
+      "NTK_URN2_CLOSED",
+      "NTK_URN2_OPEN",
+      "NTK_URN1_CLOSED",
+      "NTK_URN1_OPEN"
     ],
     "colorOverrides": [
       {
@@ -5129,8 +5129,8 @@
   {
     "description": "Pyramid Plunder Gold Chest",
     "objectIds": [
-      20946,
-      20947
+      "NTK_GOLDEN_CHEST_CLOSED",
+      "NTK_GOLDEN_CHEST_OPEN"
     ],
     "colorOverrides": [
       {
@@ -5145,7 +5145,7 @@
     "description": "Pyramid Plunder Wall Torch",
     "baseMaterial": "MARBLE_1",
     "objectIds": [
-      20942
+      "NTK_TOMB_WALL_TORCH"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -5161,8 +5161,8 @@
     "description": "Pyramid Plunder Sarcophagus",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      21255,
-      21257
+      "NTK_SARCOPHAGUS",
+      "NTK_SARCOPHAGUS_ANIM"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -5173,8 +5173,8 @@
     "description": "Pyramid Plunder Sarcophagus Opened",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      21256,
-      21259
+      "NTK_SARCOPHAGUS_OPEN",
+      "NTK_SARCOPHAGUS_OPEN_DECAY"
     ],
     "uvType": "BOX",
     "uvScale": 1.2,
@@ -5184,15 +5184,15 @@
     "description": "Pyramid Plunder Pot",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      21268
+      "NTK_URN_ROUGH_OPEN"
     ]
   },
   {
     "description": "Lighthouse Walls",
     "baseMaterial": "WALL_STONE_LIGHT",
     "objectIds": [
-      4573,
-      4574
+      "HORROR_LIGHTHOUSE_WALL",
+      "HORROR_LIGHTHOUSE_WALL_SLANTED"
     ],
     "uvType": "BOX",
     "uvScale": 1.5
@@ -5201,8 +5201,8 @@
     "description": "Lighthouse Door",
     "baseMaterial": "WALL_STONE",
     "objectIds": [
-      4577,
-      4578
+      "HORROR_LIGHTHOUSE_DOORWAY",
+      "HORROR_LIGHTHOUSE_INACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 1.25
@@ -5211,16 +5211,16 @@
     "description": "Lighthouse Roof",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      4599
+      "HORROR_LIGHTHOUSE_CAP"
     ]
   },
   {
     "description": "Lighthouse Spiral Stairs",
     "baseMaterial": "WOOD_GRAIN_LIGHT",
     "objectIds": [
-      4568,
-      4569,
-      4570
+      "HORROR_LIGHTHOUSE_SPIRALSTAIRS_BASE",
+      "HORROR_LIGHTHOUSE_SPIRALSTAIRS_MIDDLE",
+      "HORROR_LIGHTHOUSE_SPIRALSTAIRS_TOP"
     ],
     "castShadows": false
   },
@@ -5228,8 +5228,8 @@
     "description": "Lighthouse Support Pillars",
     "baseMaterial": "WOOD_GRAIN_LIGHT",
     "objectIds": [
-      4596,
-      4597
+      "HORROR_EDGE_PROP",
+      "HORROR_EDGE_CORNER_PROP"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -5240,25 +5240,25 @@
     "description": "Lighthouse Metallic objects, Mechanisms and Ladders",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      4380,
-      4383,
-      4412,
-      4587,
-      4571,
-      4572,
-      4589,
-      4590,
-      4580,
-      4579,
-      4584,
-      4585,
-      4586,
-      4581,
-      4583,
-      4582,
-      21945,
-      4413,
-      30392
+      "HORROR_LADDER_DOWN",
+      "HORROR_LADDER_TOP",
+      "HORROR_LADDER_BASE",
+      "HORROR_LIGHTHOUSE_COG",
+      "HORROR_LIGHTHOUSE_GLASS",
+      "HORROR_LIGHTHOUSE_GLASS_TWOBIT",
+      "HORROR_LIGHTHOUSE_SHAFT",
+      "HORROR_LIGHTHOUSE_WINDPOWER_COG",
+      "HORROR_RAILING_Q",
+      "HORROR_RAILING",
+      "HORROR_RAILING_T",
+      "HORROR_RAILING_R",
+      "HORROR_RAILING_R_MIRROR",
+      "HORROR_RAILING_Q_MIRROR",
+      "HORROR_RAILING_Q_END_MIRROR",
+      "HORROR_RAILING_Q_END",
+      "HORROR_LIGHTHOUSE_WINDPOWER_COG_M",
+      "HORROR_LADDER_BASE2",
+      "HORROR_LADDER_TOP2_POSTQUEST"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -5266,7 +5266,7 @@
   {
     "description": "Object - Bed - Wood",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 4287, 20740 ],
+    "objectIds": [ "VIKING_BED", "BARROWS_BED" ],
     "uvScale": 0.2,
     "uvType": "BOX",
     "uvOrientation": 256
@@ -5275,7 +5275,7 @@
     "description": "Lighthouse Wooden Shelves",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4371
+      "VIKING_SHELF_BOOKS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -5286,7 +5286,7 @@
     "description": "Lighthouse Dungeon Doors",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      4543, 4544, 4545, 4546
+      "HORROR_MID_LEFT_DOOR", "HORROR_MID_RIGHT_DOOR", "HORROR_FAR_RIGHT_DOOR", "HORROR_FAR_LEFT_DOOR"
     ],
     "uvType": "BOX"
   },
@@ -5294,13 +5294,13 @@
     "description": "Lighthouse Dungeon Walls",
     "baseMaterial": "STONE_NORMALED_DARK",
     "objectIds": [
-      4315,
-      4316,
-      4542,
-      4547,
-      4548,
-      4549,
-      4486
+      "VIKING_CAVEWALL_FACE1",
+      "VIKING_CAVEWALL_TOP",
+      "HORROR_JOINT_TO_WALL_MIRROR",
+      "HORROR_WATERCAVE",
+      "HORROR_FAR_LEFT_DOOR_INACTIVE",
+      "HORROR_FAR_RIGHT_DOOR_INACTIVE",
+      "HORROR_JOINT_TO_WALL"
     ],
     "uvType": "BOX",
     "uvScale": 1.4
@@ -5309,21 +5309,21 @@
     "description": "Lighthouse Dungeon Wall Pebbles",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      4609
+      "HORROR_CAVE_DETAIL1R"
     ]
   },
   {
     "description": "Lighthouse to Barbarian Outpost - Basalt rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      4560,
-      4561,
-      4562,
-      4563,
-      4564,
-      4565,
-      4567,
-      4566
+      "HORROR_BASALT_STEP_1",
+      "HORROR_BASALT_STEP_2",
+      "HORROR_BASALT_STEP_3",
+      "HORROR_BASALT_STEP_4",
+      "HORROR_BASALT_STEP_5",
+      "HORROR_BASALT_STEP_6",
+      "HORROR_BASALT_GROUPED2",
+      "HORROR_BASALT_GROUPED"
     ],
     "uvType": "BOX"
   },
@@ -5331,11 +5331,11 @@
     "description": "WOODEN_PLANK_DOCKS",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      3123,
-      3124,
-      9513,
-      9541,
-      42349
+      "DUEL_SCAFFOLD_HILLSKEW",
+      "DUEL_SCAFFOLD_EDGE",
+      "SARIM_SEAGULL_DROPPINGS",
+      "SERIM_PIER",
+      "SKEWSTEPS_WOOD01_DEFAULT"
     ],
     "uvType": "BOX"
   },
@@ -5343,7 +5343,7 @@
     "description": "WOODEN_PLANK_DOCKS diagonal",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      9542
+      "SERIM_PIER_JOIN_CORNER"
     ],
     "uvType": "MODEL_XZ_MIRROR_A"
   },
@@ -5351,7 +5351,7 @@
     "description": "WOODEN_PLANK_DOCKS diagonal",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      9543
+      "SERIM_PIER_JOIN_CORNER_MIRROR"
     ],
     "uvType": "MODEL_XZ_MIRROR_B"
   },
@@ -5359,44 +5359,44 @@
     "description": "WOODEN_PLANK_ROUGH",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      796,
-      797,
-      798,
-      799,
-      800,
-      801,
-      802,
-      803,
-      804,
-      805,
-      806,
-      807,
-      808,
-      809,
-      810,
-      811,
-      812,
-      815,
-      10837,
-      11591,
-      11592,
-      11593,
-      11594,
-      11595,
-      11596,
-      11597,
-      12432,
-      12433,
-      12436,
-      12437,
-      15975,
-      41419,
-      25797,
-      39705,
-      39706,
-      39707,
-      39708,
-      39709
+      "PIER",
+      "PIER2",
+      "PIER3",
+      "PIER_HILLSKEW",
+      "PIER2_EDGE",
+      "PIER3_EDGE",
+      "PIER2_EDGE_MIRROR",
+      "PIER3_EDGE_MIRROR",
+      "PIER_HALF",
+      "PIER_HALF2",
+      "PIER_HALF_MIRROR",
+      "PIER_HALF2_MIRROR",
+      "PIER_BROKEN",
+      "PIER_BROKEN_MIRROR",
+      "PIER2_HILLSKEW_EDGE",
+      "PIER3_HILLSKEW_EDGE",
+      "PIER2_EDGE_HILLSKEW_MIRROR",
+      "PIER_EDGE",
+      "PIER_EDGE_MIRROR",
+      "FAI_BARBARIAN_PIER_1",
+      "FAI_BARBARIAN_PIER_2",
+      "FAI_BARBARIAN_PIER_3",
+      "FAI_BARBARIAN_PIER_EDGE_1",
+      "FAI_BARBARIAN_PIER_EDGE_2",
+      "FAI_BARBARIAN_PIER_EDGE_1_MIRROR",
+      "FAI_BARBARIAN_PIER_EDGE_2_MIRROR",
+      "GOBLIN_OUTPOST_PIER_EDGE",
+      "GOBLIN_OUTPOST_PIER_EDGE_FRONT",
+      "GOBLIN_OUTPOST_PIER_BROKEN",
+      "GOBLIN_OUTPOST_PIER",
+      "BREW_PIER_RAISED",
+      "BREW_PIER_RAISED_NOMAP",
+      "KR_PIER",
+      "WILDY_HUB_PIER",
+      "WILDY_HUB_PIER_HALF",
+      "WILDY_HUB_PIER_HALF2",
+      "WILDY_HUB_PIER_BROKEN",
+      "WILDY_HUB_PIER_BROKEN_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -5404,9 +5404,9 @@
     "description": "WOODEN_PLANK_ROUGH",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      42036,
-      42223,
-      42224
+      "SHAYZIEN_WOODEN_DECKING",
+      "SHAYZIEN_AGILITY_DECKING01",
+      "SHAYZIEN_AGILITY_DECKING_EDGE01"
     ],
     "uvType": "BOX"
   },
@@ -5414,7 +5414,7 @@
     "description": "Rough Wooden Plant - Rotated",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      42037
+      "SHAYZIEN_WOODEN_DECKING02"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -5423,10 +5423,10 @@
     "description": "DOCK_FENCES",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      814,
-      9539,
-      11598,
-      16004
+      "PIER_RAIL",
+      "SERIM_PIER_RAIL",
+      "FAI_BARBARIAN_RAIL",
+      "BREW_PIER_RAIL"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -5437,8 +5437,8 @@
     "description": "DOCK_FENCES_TAN",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      17102,
-      23053
+      "PEST_SERIM_PIER_RAIL",
+      "FRISB_PIER_RAIL"
     ],
     "flatNormals": true
   },
@@ -5446,12 +5446,12 @@
     "description": "RELLEKKA_FENCES",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4262,
-      8969,
-      8970,
-      8971,
-      25261,
-      41438
+      "VIKING_PIER_RAIL",
+      "VIKING_PIER_RAIL_BROKEN",
+      "VIKING_PIER_RAIL_CURVE_OUT",
+      "VIKING_PIER_RAIL_CURVE_IN",
+      "BRUT_PIER_RAIL",
+      "VIKING_FENCE_STILE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -5462,10 +5462,10 @@
     "description": "Rellekka Fences Gate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4311,
-      4312,
-      4313,
-      4314
+      "VIKING_FENCEGATE_L",
+      "VIKING_FENCEGATE_R",
+      "INACVIKING_FENCEGATE_L",
+      "INACVIKING_FENCEGATE_R"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -5476,7 +5476,7 @@
     "description": "PHASMATYS_DOCK_FENCES",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      5236
+      "AHOY_PIER_RAIL"
     ],
     "flatNormals": true
   },
@@ -5484,9 +5484,9 @@
     "description": "RoU_DOCK_FENCES",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      41323,
-      41324,
-      41325
+      "TEMPOROSS_LOBBY_DOCK_RAIL",
+      "TEMPOROSS_LOBBY_BANNER_LOWER_LEFT",
+      "TEMPOROSS_LOBBY_BANNER_LOWER_RIGHT"
     ],
     "flatNormals": true
   },
@@ -5494,11 +5494,11 @@
     "description": "LIGHT_WOODEN_DOCKS",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      17103,
-      17104,
-      25618,
-      25619,
-      31589
+      "PEST_SERIM_PIER_BROKEN",
+      "PEST_SERIM_PIER",
+      "PEST_SERIM_PIER_VAR2",
+      "PEST_SERIM_PIER_VAR3",
+      "PEST_SERIM_PIER_BROKEN_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -5506,7 +5506,7 @@
     "description": "LIGHT_WOODEN_DOCKS_MIRRORED",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      17106
+      "PEST_SERIM_PIER_JOIN_CORNER_MIRROR"
     ],
     "uvType": "MODEL_XZ_MIRROR_B"
   },
@@ -5514,23 +5514,23 @@
     "description": "PHASMATYS_DOCKS",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      5159,
-      5160,
-      5238,
-      5239,
-      5455,
-      5456,
-      5459,
-      5458,
-      12936,
-      12937,
-      12938,
-      12939,
-      12940,
-      13865,
-      22533,
-      22534,
-      22535
+      "FENK_BRIDGESURFACE",
+      "FENK_BRIDGEBROKEN",
+      "AHOY_PIER_BROKEN",
+      "AHOY_PIER",
+      "AHOY_PIER2",
+      "AHOY_PIER3",
+      "AHOY_PIER_EDGE_3",
+      "AHOY_PIER_EDGE_2",
+      "BURGH_PIER_EDGE_2",
+      "BURGH_PIER_EDGE_3",
+      "BURGH_PIER_EDGE_2_MIRROR",
+      "BURGH_PIER_EDGE_3_MIRROR",
+      "BURGH_PIER_BROKEN_MIRROR",
+      "AHOY_PIER_BROKEN_MIRROR",
+      "RAMBLE_BRIDGE_BEAM_FIX_1",
+      "RAMBLE_BRIDGE_BEAM_FIX_2",
+      "RAMBLE_BRIDGE_BEAM_FIX_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.88
@@ -5539,7 +5539,7 @@
     "description": "LUNAR_ISLE_DOCKS",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      16991
+      "QUEST_LUNAR_PIER1_LOW"
     ],
     "uvType": "BOX"
   },
@@ -5547,18 +5547,18 @@
     "description": "LUNAR_ISLE_DOCK_SUPPORTS",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      16966,
-      16967
+      "QUEST_LUNAR_GALLEON_PIER_LVL1_LOW",
+      "QUEST_LUNAR_GALLEON_PIER_LVL2_LOW"
     ]
   },
   {
     "description": "LUNAR_ISLE_DOCK_LADDERS",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16959,
-      16960,
-      16961,
-      16962
+      "QUEST_LUNAR_GALLEON_PIER_STAIRS_BASE",
+      "QUEST_LUNAR_GALLEON_PIER_STAIRS_BASE_LOWER",
+      "QUEST_LUNAR_GALLEON_PIER_STAIRS_TOP",
+      "QUEST_LUNAR_GALLEON_PIER_STAIRS_TOP_LOWER"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -5568,7 +5568,7 @@
     "description": "LUNAR_ISLE_BRIDGES",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      16807
+      "LUNAR_MOONCLAN_BRIDGE"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -5576,10 +5576,10 @@
     "description": "PIRATE_ISLE_DOCKS",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      16988,
-      16989,
-      16992,
-      16993
+      "QUEST_LUNAR_PIER2",
+      "QUEST_LUNAR_PIER3",
+      "QUEST_LUNAR_PIER_EDGE",
+      "QUEST_LUNAR_PIER_EDGE_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -5587,8 +5587,8 @@
     "description": "LUNAR_ISLE_DOCK_SUPPORTS",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16963,
-      16965
+      "QUEST_LUNAR_GALLEON_PIER_LVL1",
+      "QUEST_LUNAR_GALLEON_PIER_LVL2"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -5598,18 +5598,18 @@
     "description": "RELLEKKA_DOCKS",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      4256,
-      4257,
-      4258,
-      4259,
-      25253,
-      25254,
-      25255,
-      25256,
-      25257,
-      25258,
-      25259,
-      25260
+      "VIKING_PIER",
+      "VIKING_PIER2",
+      "VIKING_PIER3",
+      "VIKING_PIER_HILLSKEW",
+      "BRUT_PIER",
+      "BRUT_PIER2",
+      "BRUT_PIER3",
+      "BRUT_PIER_OPPABLE",
+      "BRUT_PIER3_OPPABLE",
+      "BRUT_PIER_HILLSKEW",
+      "BRUT_PIER2_HILLSKEW",
+      "BRUT_PIER3_HILLSKEW"
     ],
     "uvType": "BOX"
   },
@@ -5617,8 +5617,8 @@
     "description": "RoU_DOCKS",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      41320,
-      41321
+      "TEMPOROSS_LOBBY_PIER_BROKEN",
+      "TEMPOROSS_LOBBY_PIER"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -5626,35 +5626,35 @@
     "description": "Single row fences",
     "baseMaterial": "WOOD_GRAIN_3_LIGHT",
     "objectIds": [
-      2050,
-      2051,
-      2052,
-      2053,
-      2618,
-      3125,
-      3126,
-      3127,
-      5882,
-      9589,
-      12430,
-      12431,
-      20366,
-      23849,
-      23850,
-      23851,
-      23895,
-      23896,
-      23897,
-      23898,
-      23899,
-      24453,
-      24454,
-      24560,
-      24561,
-      25796,
-      29110,
-      42114,
-      44917
+      "GUIDORGATELCLOSED",
+      "GUIDORGATERCLOSED",
+      "GUIDORGATELOPEN",
+      "GUIDORGATEROPEN",
+      "GERTRUDEFENCE",
+      "DUEL_SCAFFOLD_RAIL",
+      "DUEL_SCAFFOLD_RAIL_UP",
+      "DUEL_SCAFFOLD_RAIL_UP_MIRROR",
+      "MDAUGHTER_RAIL",
+      "DWARF_HUT_PIER_RAIL",
+      "GOBLIN_OUTPOST_PIER_RAIL",
+      "GOBLIN_OUTPOST_PIER_RAIL_BROKE",
+      "CONTACT_PIER_RAIL",
+      "FAI_VARROCK_FENCE",
+      "FAI_VARROCK_FENCE_JOIN",
+      "FAI_VARROCK_FENCE_BROKEN",
+      "FAI_VARROCK_LUMBER_YARD_RAIL",
+      "FAI_VARROCK_LUMBER_YARD_RAIL_MIRRORED",
+      "FAI_VARROCK_LUMBER_YARD_RAIL_B",
+      "FAI_VARROCK_LUMBER_YARD_RAIL_B_MIRRORED",
+      "FAI_VARROCK_LUMBER_YARD_RAIL_C",
+      "VM_POSH_FENCING_TERM",
+      "VM_POSH_FENCING_TERM_MIRROR",
+      "VM_FENCEGATE_L",
+      "VM_FENCEGATE_R",
+      "KR_PIER_RAIL",
+      "BR_LOBBY_RAIL",
+      "WALLKIT_SHAYZIEN_RAIL01",
+      "PVPA_DESERTGATE_OPEN"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -5664,8 +5664,8 @@
     "description": "Single row fences - End, joining wall",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      23904,
-      23905
+      "FAI_VARROCK_CASTLE_INT_FENCE_JOIN",
+      "FAI_VARROCK_CASTLE_INT_FENCE_JOIN_MIRROR"
     ],
     "flatNormals": true
   },
@@ -5673,8 +5673,8 @@
     "description": "FENCES_3",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      994,
-      995
+      "WOODENRAILING",
+      "WOODENRAILING_HILLSKEW"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -5685,30 +5685,30 @@
     "uvType": "BOX",
     "uvScale": 1.1,
     "objectIds": [
-      27626,
-      27627,
-      27628,
-      27629,
-      27630,
-      27631,
-      27632,
-      27633,
-      27634,
-      27635,
-      27636,
-      27637,
-      27638,
-      27639,
-      27640,
-      27641,
-      27642,
-      27643,
-      27644,
-      27645,
-      27646,
-      27650,
-      27651,
-      42661
+      "PISCARILIUS_FLOOR_TILE_01",
+      "PISCARILIUS_FLOOR_TILE_02",
+      "PISCARILIUS_FLOOR_TILE_03",
+      "PISCARILIUS_FLOOR_TILE_04",
+      "PISCARILIUS_FLOOR_TILE_05",
+      "PISCARILIUS_FLOOR_TILE_06",
+      "PISCARILIUS_FLOOR_TILE_07",
+      "PISCARILIUS_FLOOR_TILE_08",
+      "PISCARILIUS_LADDER_BOTTOM",
+      "PISCARILIUS_LADDER_TOP_01",
+      "PISCARILIUS_LADDER_TOP_02",
+      "PISCARILIUS_PIER_END_01",
+      "PISCARILIUS_PIER_END_02",
+      "PISCARILIUS_PIER_SIDE_01",
+      "PISCARILIUS_PIER_SIDE_02",
+      "PISCARILIUS_PIER_SIDE_03",
+      "PISCARILIUS_PIER_SIDE_04",
+      "PISCARILIUS_PIER_SIDE_05",
+      "PISCARILIUS_PIER_SIDE_END_01",
+      "PISCARILIUS_PIER_SIDE_END_02",
+      "PISCARILIUS_PIER_SIDE_END_03",
+      "PISCARILIUS_PIER_SAND_END_02",
+      "PISCARILIUS_PIER_SAND_END_03",
+      "QUEST_START_ICON_CLIENTOFKOUREND"
     ]
   },
   {
@@ -5725,62 +5725,62 @@
       }
     ],
     "objectIds": [
-      27649,
-      27652,
-      27655,
-      29663,
-      27654,
-      29664,
-      27658,
-      27659,
-      27653,
-      27656,
-      27657,
-      27658,
-      27660
+      "PISCARILIUS_PIER_SAND_END_01",
+      "PISCARILIUS_PIER_SAND_END_04",
+      "PISCARILIUS_PIER_SAND_END_07",
+      "PISCARILIUS_PIER_SAND_END_09",
+      "PISCARILIUS_PIER_SAND_END_06",
+      "PISCARILIUS_PIER_SAND_END_10",
+      "PISCARILIUS_PIER_SAND_02",
+      "PISCARILIUS_PIER_SAND_03",
+      "PISCARILIUS_PIER_SAND_END_05",
+      "PISCARILIUS_PIER_SAND_END_08",
+      "PISCARILIUS_PIER_SAND_01",
+      "PISCARILIUS_PIER_SAND_02",
+      "PISCARILIUS_PIER_SAND_04"
     ]
   },
   {
     "description": "Picarilius docks with Carpet",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      27727,
-      27728,
-      27729,
-      27730,
-      27731,
-      27732,
-      27733,
-      27735,
-      27736,
-      27737,
-      27738,
-      27739,
-      27740,
-      27741,
-      27742,
-      27743,
-      27744,
-      27745,
-      27746,
-      27747,
-      27748,
-      27749,
-      27750,
-      27751,
-      27752,
-      27753
+      "PISCARILIUS_RUG_CENTRE_BROWN",
+      "PISCARILIUS_RUG_CENTRE_RED",
+      "PISCARILIUS_RUG_CENTRE_GREEN",
+      "PISCARILIUS_RUG_CORNER_01_BROWN",
+      "PISCARILIUS_RUG_CORNER_01_RED",
+      "PISCARILIUS_RUG_CORNER_01_GREEN",
+      "PISCARILIUS_RUG_CORNER_02_BROWN",
+      "PISCARILIUS_RUG_CORNER_02_GREEN",
+      "PISCARILIUS_RUG_OUTER_CORNER_01_BROWN",
+      "PISCARILIUS_RUG_OUTER_CORNER_01_RED",
+      "PISCARILIUS_RUG_OUTER_CORNER_01_GREEN",
+      "PISCARILIUS_RUG_OUTER_CORNER_02_BROWN",
+      "PISCARILIUS_RUG_OUTER_CORNER_02_RED",
+      "PISCARILIUS_RUG_OUTER_CORNER_02_GREEN",
+      "PISCARILIUS_RUG_SIDE_01_BROWN",
+      "PISCARILIUS_RUG_SIDE_01_RED",
+      "PISCARILIUS_RUG_SIDE_01_GREEN",
+      "PISCARILIUS_RUG_SIDE_02_BROWN",
+      "PISCARILIUS_RUG_SIDE_02_RED",
+      "PISCARILIUS_RUG_SIDE_02_GREEN",
+      "PISCARILIUS_RUG_OUTER_SIDE_01_BROWN",
+      "PISCARILIUS_RUG_OUTER_SIDE_01_RED",
+      "PISCARILIUS_RUG_OUTER_SIDE_01_GREEN",
+      "PISCARILIUS_RUG_OUTER_SIDE_02_BROWN",
+      "PISCARILIUS_RUG_OUTER_SIDE_02_RED",
+      "PISCARILIUS_RUG_OUTER_SIDE_02_GREEN"
     ]
   },
   {
     "description": "Witchaven Docks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      18193,
-      18195,
-      18196,
-      18198,
-      18199
+      "SLUG2_PIER",
+      "SLUG2_PIER2_EDGE",
+      "SLUG2_PIER2_EDGE_MIRROR",
+      "SLUG2_PIER3_EDGE",
+      "SLUG2_PIER3_EDGE_MIRROR"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -5788,23 +5788,23 @@
     "description": "Witchaven Dock Rails",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      18200
+      "SLUG2_PIER_RAIL"
     ]
   },
   {
     "description": "Fishing Platform docks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      18335,
-      18336,
-      18337,
-      18338,
-      18339,
-      18369,
-      18370,
-      18371,
-      18372,
-      18373
+      "SEASLUG_PIER",
+      "SEASLUG_PIER_LEFT_EDGE",
+      "SEASLUG_PIER_RIGHT_EDGE",
+      "SEASLUG_PIER_LEFT_CORNER_LEFT",
+      "SEASLUG_PIER_RIGHT_CORNER_RIGHT",
+      "SEASLUG_PIER_RIGHT_CORNER_RIGHT_REV",
+      "SEASLUG_PIER_RIGHT_CORNER_LEFT_REV",
+      "SEASLUG_PIER_LEFT_EDGE_TRIM",
+      "SEASLUG_PIER_RIGHT_EDGE_TRIM",
+      "SEASLUG_PIER_RIGHT_EDGE_REVERSE_TRIM"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -5812,7 +5812,7 @@
     "description": "Zeah Battlefront Docks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      15974
+      "BREW_PIER_UNDERSIDE"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -5820,9 +5820,9 @@
     "description": "White double row fence",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      25760,
-      25923,
-      25924
+      "KR_SEERS_VILLAGE_FENCING",
+      "KR_SEERS_VILLAGE_FENCING_WITH_WALL",
+      "KR_SEERS_VILLAGE_FENCING_WITH_WALL_MIRROR"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -5832,9 +5832,9 @@
     "description": "Seers village - Railing",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      25613,
-      25795,
-      25801
+      "KR_CAM_RAILING",
+      "KR_WOODENRAILING",
+      "KR_SPIRALSTAIRSTOP"
     ],
     "flatNormals": false
   },
@@ -5842,7 +5842,7 @@
     "description": "Camelot - Wooden grave",
     "baseMaterial": "WOOD_GRAIN",
     "objectIds": [
-      401
+      "POORGRAVESTONE"
     ],
     "flatNormals": true
   },
@@ -5850,10 +5850,10 @@
     "description": "Seers Village tables",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      25774,
-      25778,
-      25930,
-      25931
+      "KR_TABLE_SMALL",
+      "KR_ROUNDTABLE",
+      "KR_SEERS_TABLE2",
+      "KR_SEERS_TABLE3"
     ],
     "uvOrientation": 512,
     "uvType": "BOX",
@@ -5864,7 +5864,7 @@
     "description": "Seers village wooden posts",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      25777
+      "KR_WOODENSUPPORT1"
     ],
     "flatNormals": true,
     "uvType": "BOX"
@@ -5873,11 +5873,11 @@
     "description": "Seers village chairs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      25768,
-      25771,
-      25772,
-      25773,
-      25783
+      "KR_BENCH",
+      "KR_CHAIR",
+      "KR_SMASHEDCHAIR",
+      "KR_STOOL",
+      "KR_ROCKING_CHAIR"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -5886,12 +5886,12 @@
     "description": "Seer's Village Ladder",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      25938,
-      25939,
-      25940,
-      25941,
-      26118,
-      26119
+      "KR_LADDER",
+      "KR_LADDERTOP",
+      "KR_LADDERTOP_DIRECTIONAL",
+      "KR_LADDER_DIRECTIONAL",
+      "FAVOUR_SEER_LADDER",
+      "FAVOUR_ROOF_TRAPDOOR"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -5901,20 +5901,20 @@
     "description": "Worn Carpet",
     "baseMaterial": "CARPET",
     "objectIds": [
-      7481,
-      9680,
-      14046,
-      14047,
-      14048,
-      17992,
-      17993,
-      17994,
-      17983,
-      17984,
-      24095,
-      40233,
-      40236,
-      40240
+      "FAI_VARROCK_POOR_RUGMIDDLE",
+      "RIMMINGTON_RUG_SIDE",
+      "FISHING_CONTEST_RUG_MIDDLE",
+      "FISHING_CONTEST_RUG_SIDE",
+      "FISHING_CONTEST_RUG_CORNER",
+      "MYQ3_RUG_CORNER",
+      "MYQ3_RUG_SIDE",
+      "MYQ3_RUG_MIDDLE",
+      "SANG_MYREQUE_HIDEOUT_RUG_TRAPDOOR_HIDDEN",
+      "SANG_MYREQUE_HIDEOUT_RUG_TRAPDOOR_UNHIDDEN",
+      "FAI_FALADOR_RUG_RUGMIDDLE",
+      "DADDYSHOME_CARPET_MIDDLE_BROKEN_0OP",
+      "DADDYSHOME_CARPET_MIDDLE_BROKEN_1OP",
+      "DADDYSHOME_CARPET_MIDDLE_FIXED"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.7,
@@ -5924,14 +5924,14 @@
     "description": "Worn Carpet - Edges",
     "baseMaterial": "CARPET",
     "objectIds": [
-      7480,
-      9679,
-      9681,
-      11482,
-      15688,
-      24094,
-      40234,
-      40241
+      "FAI_VARROCK_POOR_RUGSIDE",
+      "RIMMINGTON_RUG_MIDDLE",
+      "RIMMINGTON_RUG_CORNER",
+      "DRAYNOR_POORRUG_SIDE",
+      "AIDE_POORRUG_SIDE",
+      "FAI_FALADOR_RUG_RUGSIDE",
+      "DADDYSHOME_CARPET_SIDE_BROKEN_0OP",
+      "DADDYSHOME_CARPET_SIDE_FIXED"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.7,
@@ -5941,12 +5941,12 @@
     "description": "Worn Carpet - Coners",
     "baseMaterial": "CARPET",
     "objectIds": [
-      7447,
-      11481,
-      15687,
-      24093,
-      40235,
-      40242
+      "FAI_VARROCK_POOR_RUGCORNER",
+      "DRAYNOR_POORRUG_CORNER",
+      "AIDE_POORRUG_CORNER",
+      "FAI_FALADOR_RUG_CORNER",
+      "DADDYSHOME_CARPET_CORNER_BROKEN_0OP",
+      "DADDYSHOME_CARPET_CORNER_FIXED"
     ],
     "uvType": "MODEL_XZ_MIRROR_A",
     "uvScale": 0.7,
@@ -5956,61 +5956,61 @@
     "description": "Fine Carpet",
     "baseMaterial": "CARPET",
     "objectIds": [
-      925,
-      926,
-      927,
-      928,
-      929,
-      930,
-      931,
-      932,
-      933,
-      934,
-      935,
-      936,
-      937,
-      938,
-      940,
-      941,
-      942,
-      943,
-      944,
-      945,
-      976,
-      977,
-      978,
-      6251,
-      6252,
-      6253,
-      6812,
-      6813,
-      6814,
-      7172,
-      7173,
-      7174,
-      7435,
-      7436,
-      7437,
-      11475,
-      11476,
-      11477,
-      11478,
-      11479,
-      11480,
-      17229,
-      17230,
-      17231,
-      23621,
-      23622,
-      23623,
-      25596,
-      25597,
-      25598,
-      25678,
-      25679,
-      25680,
-      41765,
-      50054
+      "RUGCORNER",
+      "RUGSIDE",
+      "RUGMIDDLE",
+      "RUGCORNER_WHITE",
+      "RUGSIDE_WHITE",
+      "RUGMIDDLE_WHITE",
+      "RUGSIDE_DARKKNIGHT",
+      "RUGMIDDLE_DARKKNIGHT",
+      "RUGCORNER_DARKKNIGHT",
+      "RUGCORNER_ORANGE",
+      "RUGSIDE_ORANGE",
+      "RUGMIDDLE_ORANGE",
+      "RUGCORNER2",
+      "RUGSIDE2",
+      "BLUERUGCORNER",
+      "BLUERUGSIDE",
+      "BLUERUGMIDDLE",
+      "GREENRUGCORNER",
+      "GREENRUGSIDE",
+      "GREENRUGMIDDLE",
+      "RUGCORNER_BLUE",
+      "RUGSIDE_BLUE",
+      "RUGMIDDLE_BLUE",
+      "FEUD_RUGCORNER_RED",
+      "FEUD_RUGSIDE_RED",
+      "FEUD_RUGMIDDLE_RED",
+      "FAI_VARROCK_ZAMORAK_RUGCORNER",
+      "FAI_VARROCK_ZAMORAK_RUGSIDE",
+      "FAI_VARROCK_ZAMORAK_RUGMIDDLE",
+      "FAI_VARROCK_RUGCORNER",
+      "FAI_VARROCK_RUGSIDE",
+      "FAI_VARROCK_RUGMIDDLE",
+      "FAI_VARROCK_POSH_RUG_CORNER",
+      "FAI_VARROCK_POSH_RUG_SIDE",
+      "FAI_VARROCK_POSH_RUG_MIDDLE",
+      "DRAYNOR_MANOR_RUG_CORNER",
+      "DRAYNOR_MANOR_RUG_SIDE",
+      "DRAYNOR_MANOR_RUG_MIDDLE",
+      "DRAYNOR_MANOR_RUG2_CORNER",
+      "DRAYNOR_MANOR_RUG2_SIDE",
+      "DRAYNOR_MANOR_RUG2_MIDDLE",
+      "EYEGLO_RUG_CORNER",
+      "EYEGLO_RUG_SIDE",
+      "EYEGLO_RUG_MIDDLE",
+      "FAI_VARROCK_JULIET_RUGCORNER",
+      "FAI_VARROCK_JULIET_RUGSIDE",
+      "FAI_VARROCK_JULIET_RUGMIDDLE",
+      "KR_CAMELOT_RUGCORNER",
+      "KR_CAMELOT_RUGSIDE",
+      "KR_CAMELOT_RUGMIDDLE",
+      "MURDER_QIP_RUGCORNER",
+      "MURDER_QIP_RUGSIDE",
+      "MURDER_QIP_RUGMIDDLE",
+      "FEUD_RUGMIDDLE_RED_SWORD",
+      "EYEGLO_RUG_SIDE_MINIGAME"
     ],
     "uvType": "WORLD_XZ",
     "flatNormals": true
@@ -6019,27 +6019,27 @@
     "description": "Dirt Cave Entrance",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      2,
-      2804,
-      2805,
-      2806,
-      2807,
-      2808,
-      2809,
-      2810,
-      4006,
-      12174,
-      26654,
-      26709,
-      30177,
-      30374,
-      31555,
-      31766,
-      35846,
-      42248,
-      47077,
-      47078,
-      51660
+      "MCANNONCAVE",
+      "SHAMANENTRANCE",
+      "SKAVID_CAVE1",
+      "SKAVID_CAVE2",
+      "SKAVID_CAVE3",
+      "SKAVID_CAVE4",
+      "SKAVID_CAVE5",
+      "SKAVID_CAVE6",
+      "REGICIDE_VOYAGE_TEMPLE_ENTRANCE",
+      "CANOEING_CAVEENTRANCE_MUDDY",
+      "MOTHERLODE_ENTRANCE",
+      "SLAYER_CAVE_ENTRANCE",
+      "SLAYER_CAVE_KRAKEN_MAINCAVE_ENTRANCE",
+      "MOTHERLODE_ENTRANCE_GUILD",
+      "WILD_CAVE_ENTRANCE_LOW",
+      "DS2_OGRE_CAVE_ENTRANCE_2",
+      "SOTE_ORB_CAVE_ENTRY",
+      "GIANTS_DEN_ENTRANCE_LADDER_HOLE",
+      "WILD_VENANATIS_ENTRANCE01",
+      "WILD_VENENATIS_SINGLES_ENTRANCE01",
+      "CAVE_ROCK02_ENTRANCE01_COLOSSAL_WYRM"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -6048,16 +6048,16 @@
     "description": "Motherlode Mine Water Wheel",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      26671,
-      26672
+      "MOTHERLODE_WHEEL_FIXED",
+      "MOTHERLODE_WHEEL_BROKEN"
     ]
   },
   {
     "description": "Motherlode Mine Water Wheel Support",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      26669,
-      26670
+      "MOTHERLODE_WHEEL_STRUT_FIXED",
+      "MOTHERLODE_WHEEL_STRUT_BROKEN"
     ],
     "colorOverrides": [
       {
@@ -6070,22 +6070,22 @@
     "description": "Motherlode Mine Walls",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      26656,
-      26658,
-      26659,
-      26660,
-      26661,
-      26665,
-      26666,
-      26667,
-      26668,
-      30368,
-      30369,
-      30370,
-      26662,
-      26663,
-      26664,
-      53244
+      "MOTHERLODE_WALL",
+      "MOTHERLODE_SUPPORT_LEFT",
+      "MOTHERLODE_SUPPORT_MIDDLE",
+      "MOTHERLODE_SUPPORT_RIGHT",
+      "MOTHERLODE_ORE_SINGLE",
+      "MOTHERLODE_DEPLETED_SINGLE",
+      "MOTHERLODE_DEPLETED_LEFT",
+      "MOTHERLODE_DEPLETED_MIDDLE",
+      "MOTHERLODE_DEPLETED_RIGHT",
+      "MGUILD_WALL",
+      "MGUILD_WALL_LEFT",
+      "MGUILD_WALL_RIGHT",
+      "MOTHERLODE_ORE_LEFT",
+      "MOTHERLODE_ORE_MIDDLE",
+      "MOTHERLODE_ORE_RIGHT",
+      "MOTHERLODE_WATER_TUNNEL"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -6095,15 +6095,15 @@
     "baseMaterial": "DIRT_2_LIGHT",
     "areas": [ "Motherlode Mine Dark Wall Fix" ],
     "objectIds": [
-      26656,
-      26661,
-      26662,
-      26663,
-      26664,
-      26665,
-      26666,
-      26667,
-      30368
+      "MOTHERLODE_WALL",
+      "MOTHERLODE_ORE_SINGLE",
+      "MOTHERLODE_ORE_LEFT",
+      "MOTHERLODE_ORE_MIDDLE",
+      "MOTHERLODE_ORE_RIGHT",
+      "MOTHERLODE_DEPLETED_SINGLE",
+      "MOTHERLODE_DEPLETED_LEFT",
+      "MOTHERLODE_DEPLETED_MIDDLE",
+      "MGUILD_WALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -6113,10 +6113,10 @@
     "baseMaterial": "DIRT_2_LIGHT",
     "areas": [ "Motherlode Mine Dark Wall Fix" ],
     "objectIds": [
-      10047,
-      26655,
-      30375,
-      53244
+      "MOTHERLODE_SHORTCUT",
+      "MOTHERLODE_EXIT",
+      "MOTHERLODE_EXIT_GUILD",
+      "MOTHERLODE_WATER_TUNNEL"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -6131,7 +6131,7 @@
     "description": "Motherlode Mine Upper Floor",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      26657
+      "MOTHERLODE_SURROUND"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.5,
@@ -6141,10 +6141,10 @@
     "description": "Amathyst mine walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      11388,
-      11389,
-      11392,
-      11393
+      "AMETHYSTROCK1",
+      "AMETHYSTROCK2",
+      "ROCKS3",
+      "AMETHYSTROCK_EMPTY"
     ],
     "uvType": "BOX"
   },
@@ -6152,8 +6152,8 @@
     "description": "Motherlode Mine Rockfall",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      26679,
-      26680
+      "MOTHERLODE_ROCKFALL_1",
+      "MOTHERLODE_ROCKFALL_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -6163,7 +6163,7 @@
     "description": "Motherlode Mine - Cogs",
     "baseMaterial": "METALLIC_1_HIGHGLOSS",
     "objectIds": [
-      13589
+      "SWAN_COGS"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -6172,11 +6172,11 @@
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "areas": [ "MOTHERLODE_MINE" ],
     "objectIds": [
-      19046,
-      19047,
-      19048,
-      19049,
-      19050
+      "MOTHERLODE_LADDER_JOIN",
+      "MOTHERLODE_LADDER_BOTTOM_ACTIVE",
+      "MOTHERLODE_LADDER_BOTTOM_INACTIVE",
+      "MOTHERLODE_LADDER_TOP_ACTIVE",
+      "MOTHERLODE_LADDER_TOP_INACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -6186,23 +6186,23 @@
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "areas": [ "MOTHERLODE_MINE" ],
     "objectIds": [
-      26681,
-      26682
+      "MOTHERLODE_PRESS_FIREBOX",
+      "MOTHERLODE_PRESS_CRUSHER"
     ]
   },
   {
     "description": "Motherlode Trough",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      3428,
-      18606,
-      18607,
-      18609,
-      26683,
-      26684,
-      26685,
-      26686,
-      53243
+      "ELEMENTAL_BORDER",
+      "ELEM_GANTRY_FLOOR_SKEW",
+      "ELEM_GANTRY_FLOOR_DIAG",
+      "ELEM2_RAIL_OPEN",
+      "ELEMENTAL_BORDER_NOBLOCK",
+      "ELEMENTAL_BORDER_OFFSET",
+      "ELEMENTAL_BORDER_OFFSET2",
+      "ELEMENTAL_BORDER_SHORTER",
+      "MOTHERLODE_LADDER_STEPS"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -6212,11 +6212,11 @@
     "baseMaterial": "METALLIC_1_HIGHGLOSS",
     "areas": [ "Motherlode Mine Dark Trough Fix" ],
     "objectIds": [
-      3428,
-      26683,
-      26684,
-      26685,
-      26686
+      "ELEMENTAL_BORDER",
+      "ELEMENTAL_BORDER_NOBLOCK",
+      "ELEMENTAL_BORDER_OFFSET",
+      "ELEMENTAL_BORDER_OFFSET2",
+      "ELEMENTAL_BORDER_SHORTER"
     ],
     "uvType": "BOX"
   },
@@ -6225,32 +6225,32 @@
     "baseMaterial": "GRAY_75",
     "areas": [ "MOTHERLODE_MINE" ],
     "npcIds": [
-      5562
+      "MOTHERLODE_MOTHER"
     ]
   },
   {
     "description": "Mining Guild statue",
     "baseMaterial": "MARBLE_1_GLOSS",
     "objectIds": [
-      568
+      "STATUE_DWARFMINER"
     ]
   },
   {
     "description": "Marble - White Knight Statue",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      24036,
-      24037
+      "FAI_FALADOR_STATUE_KNIGHT_SWORD",
+      "FAI_FALADOR_STATUE_KNIGHT_SWORD_CASTLE_WALLS"
     ]
   },
   {
     "description": "Wall decoration - Dirt clumps",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      1452,
-      1453,
-      1454,
-      1455
+      "CAVE_DETAIL1",
+      "CAVE_DETAIL1R",
+      "CAVE_DETAIL2",
+      "CAVE_DETAIL2R"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -6259,23 +6259,23 @@
     "description": "Stalagmite - Tan",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      5047,
-      12219,
-      12220,
-      12221,
-      12575,
-      12576,
-      12577,
-      18479,
-      18480,
-      37810,
-      37811,
-      37812,
-      37813,
-      37814,
-      37815,
-      37816,
-      37817
+      "ROUTE_STALAGMITE_TWIN",
+      "MOLE_STALAGTITE_01",
+      "MOLE_STALAGTITE_02",
+      "MOLE_STALAGTITE_FALLOFF",
+      "STAGAMITE_LARGE",
+      "STAGAMITE_SMALL",
+      "STAGATITE_LARGE",
+      "TOURTRAP_QIP_MINE_STALAGTITE_01",
+      "TOURTRAP_QIP_MINE_STALAGTITE_02",
+      "SANCTUARY_CAVE_ROCKS_1",
+      "SANCTUARY_CAVE_ROCKS_2",
+      "SANCTUARY_CAVE_ROCKS_3",
+      "SANCTUARY_CAVE_ROCKS_2X2_1",
+      "SANCTUARY_CAVE_ROCKS_2X2_2",
+      "SANCTUARY_CAVE_ROCKS_2X2_3",
+      "SANCTUARY_CAVE_STALAGMITE_1",
+      "SANCTUARY_CAVE_STALAGMITE_2"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -6284,7 +6284,7 @@
     "description": "Wooden Wall Supports - Mines",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      1872
+      "WALLSUPPORT"
     ],
     "flatNormals": true
   },
@@ -6292,57 +6292,57 @@
     "description": "Ladder",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2796,
-      2797,
-      2833,
-      4163,
-      4164,
-      4187,
-      4189,
-      4966,
-      4968,
-      4970,
-      8744,
-      8745,
-      8746,
-      9558,
-      9559,
-      10493,
-      10494,
-      11635,
-      11794,
-      11795,
-      11801,
-      11802,
-      12779,
-      12964,
-      12965,
-      12966,
-      14745,
-      14746,
-      17122,
-      17148,
-      17149,
-      17159,
-      17999,
-      18000,
-      18001,
-      18002,
-      19048,
-      24351,
-      24352,
-      20673,
-      24082,
-      24084,
-      25606,
-      25663,
-      25844,
-      26107,
-      50143,
-      50144,
-      15115,
-      52614,
-      52621
+      "WATCHLADDERUP",
+      "WATCHLADDERDOWN",
+      "TOWERLADDER",
+      "VIKING_SEER_UP_LADDER",
+      "VIKING_SEER_DOWN_LADDER",
+      "VIKING_WARRIOR_LADDER",
+      "VIKING_WARRIOR_LADDER_DOWN",
+      "HAUNTEDMINE_LADDER",
+      "HAUNTEDMINE_LADDER_1W",
+      "HAUNTEDMINE_LADDER_1NE",
+      "ELF_VILLAGE_LADDER",
+      "ELF_VILLAGE_LADDER_MID",
+      "ELF_VILLAGE_LADDER_TOP",
+      "PRISON_LADDER_UP",
+      "PRISON_LADDERTOP",
+      "ELID_LADDER_UP",
+      "ELID_LADDERTOP",
+      "WAA_LADDER",
+      "FAI_VARROCK_LADDER",
+      "FAI_VARROCK_LADDERTOP",
+      "FAI_VARROCK_LADDER_TALLER",
+      "FAI_VARROCK_LADDER_TALLER_TOP",
+      "BURGH_INN_BASEMENT_LADDERUP",
+      "QIP_COOK_LADDER",
+      "QIP_COOK_LADDER_MIDDLE",
+      "QIP_COOK_LADDER_TOP",
+      "WILD_LADDER",
+      "WILD_LADDERTOP",
+      "QIP_WATCHTOWER_LADDER_TOP",
+      "DK_LADDER",
+      "DK_LADDERTOP",
+      "DK_MEETING_LADDER",
+      "MYQ3_LADDER_DOWN",
+      "MYQ3_LADDER_UP",
+      "MYQ3_LADDER_DOWN_2",
+      "MYQ3_LADDER_UP_2",
+      "MOTHERLODE_LADDER_BOTTOM_INACTIVE",
+      "CANAFIS_LADDER_UP",
+      "CANAFIS_LADDERTOP",
+      "BARROWS_LADDER",
+      "FAI_FALADOR_LADDER",
+      "FAI_FALADOR_LADDER_TOP",
+      "KR_CAM_LADDERTOP",
+      "KR_UNDERGROUND_JAIL_LADDER",
+      "KR_BKF_BASEMENT_LADDER",
+      "KR_CAM_LADDER",
+      "DOV_BASE_EXIT",
+      "DOV_BASE_EXIT_UPPER",
+      "ROYAL_LADDERUP",
+      "CIVITAS_LADDER",
+      "CIVITAS_LADDER_TOP_NORIM"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -6351,25 +6351,25 @@
     "description": "Ladder, rotated UVs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11,
-      2147,
-      2148,
-      2884,
-      8785,
-      9725,
-      9726,
-      9727,
-      9728,
-      16679,
-      16683,
-      16684,
-      16685,
-      17026,
-      17028,
-      17384,
-      17385,
-      17387,
-      30367
+      "MCANNONLADDER",
+      "WIZARDS_TOWER_LADDERTOP",
+      "WIZARDS_TOWER_LADDER",
+      "EASTER25_CARROT_SCRAPS_NO_TRAIL",
+      "MOURNER_HIDEOUT_LADDER1",
+      "NEWBIELADDER1",
+      "NEWBIELADDERTOP1",
+      "NEWBIELADDER2",
+      "NEWBIELADDERTOP2",
+      "LADDERTOP",
+      "LADDER",
+      "LADDERMIDDLE",
+      "LADDERTOP_DIRECTIONAL",
+      "LADDER_DIRECTIONAL",
+      "LADDER_BROKEN",
+      "LADDER_CELLAR",
+      "LADDER_FROM_CELLAR",
+      "LADDER_FROM_CELLAR_DIRECTIONAL",
+      "MGUILD_LADDER"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -6378,8 +6378,8 @@
     "description": "Textured - Crate 1",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      354,
-      357
+      "CRATE2",
+      "CRATE2_OLD"
     ],
     "uvType": "BOX",
     "uvOrientationY": 256,
@@ -6389,8 +6389,8 @@
     "description": "Falador - Marble - Saradomin Statue",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      9241,
-      9243
+      "STATUE_PLINTH",
+      "GARDEN_SARADOMIN_STATUE"
     ],
     "flatNormals": true
   },
@@ -6398,33 +6398,33 @@
     "description": "Falador - Fountain",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      24102
+      "FAI_FALADOR_FOUNTAIN"
     ]
   },
   {
     "description": "Falador - Marble Stairs",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      24072,
-      24074
+      "FAI_FALADOR_CASTLE_SPIRALSTAIRS",
+      "FAI_FALADOR_CASTLE_SPIRALSTAIRSTOP"
     ]
   },
   {
     "description": "Falador - Wood Railing",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      9585,
-      12538
+      "SARIM_BANNISTER",
+      "FAI_WIZTOWER_SPIRALSTAIRSTOP"
     ]
   },
   {
     "description": "Falador - Light Wooden Stairs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      24077,
-      24078,
-      24079,
-      24080
+      "FAI_FALADOR_CASTLE_STAIRS",
+      "FAI_FALADOR_CASTLE_STAIRSTOP",
+      "FAI_FALADOR_STAIRS",
+      "FAI_FALADOR_STAIRSTOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.9,
@@ -6434,7 +6434,7 @@
     "description": "Falador - Tables",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      24025
+      "FAI_FALADOR_WOODEN_TABLE_SMALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -6443,8 +6443,8 @@
     "description": "Falador - Tables - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7331,
-      24081
+      "RD_WOODEN_TABLE",
+      "FAI_FALADOR_BIG_WOODEN_TABLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -6453,9 +6453,9 @@
     "description": "Generic - Table Boxed Legs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7496,
-      24086,
-      34936
+      "FARMING_COUNTER",
+      "FAI_FALADOR_COUNTER",
+      "RIMMINGTON_TABLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -6464,15 +6464,15 @@
     "description": "Wooden Benches - Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1106,
-      3632,
-      5615,
-      8772,
-      9531,
-      25601,
-      25676,
-      27511,
-      35874
+      "BENCH",
+      "FAI_VARROCK_BENCH",
+      "BENCH2",
+      "ELF_VILLAGE_BENCH",
+      "SARIM_BENCH2",
+      "KR_CAM_BENCH",
+      "MURDER_QIP_POSH_BENCH",
+      "HOS_BENCH_01",
+      "SOTE_ELF_VILLAGE_BENCH"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -6481,24 +6481,24 @@
     "description": "Courthouse Basement stairs",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      26017,
-      26018,
-      26019
+      "KR_COURTHOUSE_STAIRS_TOP",
+      "KR_COURTHOUSE_STAIRS_FALLOFF_EDGE",
+      "KR_COURTHOUSE_STAIRS_FALLOFF_CORNER"
     ]
   },
   {
     "description": "Wooden Spiral Stairs",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      25935
+      "KR_SPIRALSTAIRS"
     ]
   },
   {
     "description": "Gnome Agility Course - Rope",
     "baseMaterial": "ROPE",
     "objectIds": [
-      23557,
-      23558
+      "BALANCING_ROPE",
+      "BALANCING_ROPE_MID"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -6507,7 +6507,7 @@
     "description": "Rope Bridge - Rope",
     "baseMaterial": "ROPE",
     "objectIds": [
-      269
+      "SHIPROPE"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -6516,8 +6516,8 @@
     "description": "Rope Bridge - Anchor point",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      14932,
-      14933
+      "ROOFTOPS_SEERS_TIGHTROPE",
+      "ROOFTOPS_SEERS_TIGHTROPE_END"
     ],
     "uvType": "BOX"
   },
@@ -6525,14 +6525,14 @@
     "description": "Wooden Staircase",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2522,
-      2523,
-      15653,
-      15654,
-      18991,
-      18992,
-      25604,
-      26106
+      "PLAGUEHOUSESTAIRSDOWN",
+      "PLAGUEHOUSESTAIRSUP",
+      "WOODENSTAIRS",
+      "WOODENSTAIRSTOP",
+      "POOR_STAIRS",
+      "POOR_STAIRSTOP",
+      "KR_CAM_WOODENSTAIRSTOP",
+      "KR_CAM_WOODENSTAIRS"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -6542,25 +6542,25 @@
     "description": "Wooden - Plank - Tables",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      9614,
-      9615,
-      10490,
-      12544,
-      14762,
-      15684,
-      17145,
-      25603,
-      7446,
-      30171,
-      39928,
-      39929,
-      39930,
-      39931,
-      39932,
-      39933,
-      40226,
-      40228,
-      5349
+      "RIMMINGTON_WOODEN_TABLE",
+      "RIMMINGTON_SMALL_WOODEN_TABLE",
+      "ELID_WOODEN_TABLE",
+      "FAI_WIZTOWER_WOODEN_TABLE_SMALL",
+      "WILD_TABLE",
+      "AIDE_WOODEN_TABLE",
+      "DK_TABLE",
+      "KR_CAM_BIGTABLE",
+      "FAI_VARROCK_POOR_TABLE1X1",
+      "WILD_TABLE_INACTIVE",
+      "CON_CONTRACT_VARROCK_MID_TABLE_BROKEN",
+      "CON_CONTRACT_VARROCK_MID_TABLE_EDITABLE",
+      "CON_CONTRACT_VARROCK_MID_TABLE_REGULAR",
+      "CON_CONTRACT_VARROCK_MID_TABLE_OAK",
+      "CON_CONTRACT_VARROCK_MID_TABLE_TEAK",
+      "CON_CONTRACT_VARROCK_MID_TABLE_MAHOGANY",
+      "DADDYSHOME_TABLE_BROKEN_1OP",
+      "DADDYSHOME_TABLE_FIXED",
+      "AHOY_TABLE"
     ],
     "uvOrientationY": 512,
     "uvType": "BOX",
@@ -6571,21 +6571,21 @@
     "description": "Wooden - Plank - Tables - Rotated",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      595,
-      2649,
-      7175,
-      9613,
-      9699,
-      9700,
-      12450,
-      12543,
-      12962,
-      14851,
-      14852,
-      20058,
-      23177,
-      29334,
-      39716
+      "BIGTABLE2",
+      "FAI_VARROCK_COUNTER_TABLE",
+      "FAI_VARROCK_WOODEN_TABLE",
+      "RIMMINGTON_BIG_WOODEN_TABLE",
+      "RIMMINGTON_CHEMIST_TABLE_3",
+      "RIMMINGTON_CHEMIST_TABLE_4",
+      "GOBLIN_OUTPOST_BIG_TABLE",
+      "FAI_WIZTOWER_BIG_WOODEN_TABLE",
+      "QIP_COOK_LARGE_TABLE",
+      "FAI_VARROCK_POOR_TABLE1X2",
+      "FAI_VARROCK_POOR_TABLE2X2",
+      "QIP_WATCHTOWER_LARGE_TABLE",
+      "OLAF2_OLD_BROKEN_TABLE",
+      "FARMING_COUNTER_TABLE",
+      "WILDY_HUB_BROKEN_TABLE"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -6598,17 +6598,17 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      616,
-      25615
+      "SPOOKYTABLE",
+      "KR_CAM_SPOOKYTABLE"
     ]
   },
   {
     "description": "Wooden tables - Solid",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7401,
-      7406,
-      55033
+      "FAI_VARROCK_POSH_TABLE",
+      "FAI_VARROCK_POSH_DININGTABLE_SMALL",
+      "ALDARIN_TABLE_DEFAULT01"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -6618,9 +6618,9 @@
     "description": "Wooden Chair - Cobwebs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1111,
-      11490,
-      25616
+      "SPOOKYCHAIR",
+      "DRAYNOR_CHAIR_COBWEB",
+      "KR_CAM_SPOOKYCHAIR"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -6629,27 +6629,27 @@
     "description": "Camelot Stone",
     "baseMaterial": "STONE",
     "objectIds": [
-      759
+      "STONEDISC_DARKGREY"
     ]
   },
   {
     "description": "Camelot Castle",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      26085,
-      26089,
-      26090,
-      26091,
-      26092,
-      26093,
-      26094,
-      26095,
-      26096,
-      26097,
-      26100,
-      26101,
-      26103,
-      26105
+      "KR_CAMELOT_WALL_TOP_01",
+      "KR_CAMELOT_WALL",
+      "KR_CAMELOT_WALL_TERM_01",
+      "KR_CAMELOT_WALL_TERM_02",
+      "KR_CAMELOT_WALL_WINDOW",
+      "KR_CAMELOT_WALL_EXTERNAL",
+      "KR_CAMELOT_WALL_EXTERNAL_TERM_01",
+      "KR_CAMELOT_WALL_EXTERNAL_TERM_02",
+      "KR_CAMELOT_WALL_HELPER",
+      "KR_CAMELOT_WALL_HELPER_MIRROR",
+      "KR_CAMELOT_WALL_INTERNAL_TERM_02",
+      "KR_CAMELOT_WALL_ABOVE_PILLAR",
+      "KR_CAMELOT_BATTLEMENT",
+      "KR_CAMELOT_BATTLEMENT_HELPER_02"
     ],
     "flatNormals": true
   },
@@ -6657,11 +6657,11 @@
     "description": "Camelot Castle Pillars",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      26087,
-      26088,
-      26098,
-      26099,
-      26102
+      "KR_CAMELOT_WALL_INTERNAL_TOP_01",
+      "KR_CAMELOT_WALL_INTERNAL_TOP_02",
+      "KR_CAMELOT_WALL_INTERNAL",
+      "KR_CAMELOT_WALL_INTERNAL_TERM_01",
+      "KR_CAMELOT_PILLAR_01"
     ],
     "flatNormals": true
   },
@@ -6669,9 +6669,9 @@
     "description": "Stone block wall - Light",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      26134,
-      26135,
-      26136
+      "MURDER_QIP_DRYSTONEWALL",
+      "MURDER_QIP_DRYSTONEWALL_END",
+      "MURDER_QIP_DRYSTONEWALL_END_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -6681,10 +6681,10 @@
     "description": "West Ardougne Carpet",
     "baseMaterial": "CARPET",
     "objectIds": [
-      916,
-      917,
-      918,
-      5243
+      "POORRUG1",
+      "POORRUG1CORNER",
+      "POORRUG1SIDE",
+      "POORRUG1CENTRE2"
     ],
     "flatNormals": true,
     "uvType": "MODEL_XZ"
@@ -6702,22 +6702,22 @@
       }
     ],
     "objectIds": [
-      1602,
-      1603,
-      1606,
-      1608,
-      17349
+      "TIMBERWALL",
+      "TIMBERWALL_NO_OCCLUDE",
+      "WOODENROOF_REDSLATE",
+      "ROOF_VERYSPECIAL_THATCHED",
+      "QIP_DIGSITE_TIMBERWALL"
     ]
   },
   {
     "description": "Candelabra",
     "baseMaterial": "METALLIC_1_HIGHGLOSS",
     "objectIds": [
-      202,
-      203,
-      204,
-      7432,
-      17323
+      "CANDLES",
+      "GOLDCANDLES",
+      "BLACKCANDLES",
+      "FAI_VARROCK_POSH_CANDLESTICK",
+      "QIP_DIGSITE_CANDLES"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -6725,7 +6725,7 @@
   {
     "description": "Candelabra - Dusty",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 208 ],
+    "objectIds": [ "SPOOKYCANDLES" ],
     "uvType": "BOX",
     "uvScale": 0.4
   },
@@ -6733,27 +6733,27 @@
     "description": "Candlestick Holder",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      1897
+      "OLDCANDLES"
     ]
   },
   {
     "description": "Pillared Stone Wall",
     "baseMaterial": "STONE",
     "objectIds": [
-      982,
-      983,
-      984,
-      985,
-      986
+      "POSHWALLFENCING",
+      "POSHWALLFENCING_WITH_PLANT",
+      "POSHWALLFENCINGLEFTGATE",
+      "POSHWALLFENCINGRIGHTGATE",
+      "POSHWALLGATETOP"
     ]
   },
   {
     "description": "MARBLE_STAIRS",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      1893,
-      1894,
-      1895
+      "SKEWSTEPS2",
+      "SKEWSTEPS2_SIDE_LEFT",
+      "SKEWSTEPS2_SIDE_RIGHT"
     ],
     "flatNormals": true
   },
@@ -6761,18 +6761,18 @@
     "description": "BRIDGE_UNDERSIDE",
     "baseMaterial": "MARBLE_1",
     "objectIds": [
-      770
+      "FLOOR_DEPTH2_GREY"
     ]
   },
   {
     "description": "Decorative Armor",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      817,
-      5554,
-      15167,
-      25206,
-      25792
+      "SUITOFARMOUR",
+      "FAI_VARROCK_SUITOFARMOUR",
+      "ROYAL_DWARF_ARMOUR2",
+      "DRAGON_SLAYER_QIP_SUITOFARMOUR",
+      "KR_SUITOFARMOUR_DARKKNIGHT"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -6781,18 +6781,18 @@
     "description": "STONE_WINDOWS",
     "baseMaterial": "STONE",
     "objectIds": [
-      1646,
-      1938
+      "OLDCASTLEARROWSLIT",
+      "CASTLEARROWSLIT"
     ]
   },
   {
     "description": "WALL_TORCHES",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      196,
-      197,
-      5208,
-      38027
+      "TORCH",
+      "TORCH_GRUBBY",
+      "FENK_TORCH",
+      "MYQ5_TORCH"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -6801,7 +6801,7 @@
     "description": "WALL_SHIELD",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      840
+      "WALLSHIELD"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -6810,15 +6810,15 @@
     "description": "MARBLE_STATUE_OF_KING",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      563
+      "STATUE_KING"
     ]
   },
   {
     "description": "MARBLE_STATUE_BUST",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      574,
-      575
+      "BUST1",
+      "BUST2"
     ]
   },
   {
@@ -6834,26 +6834,26 @@
       }
     ],
     "objectIds": [
-      15645,
-      15646,
-      15648,
-      15649,
-      15650,
-      16664,
-      16665,
-      35791,
-      35792
+      "STAIRS",
+      "STAIRS_YANILLE_FIX",
+      "STAIRSTOP",
+      "STAIRS_SHALLOW_BASE",
+      "STAIRS_SHALLOW_TOP",
+      "STAIRS_CELLAR",
+      "STAIRS_FROM_CELLAR",
+      "ARDOUGNE_PRISON_ENTRY",
+      "ARDOUGNE_PRISON_EXIT"
     ]
   },
   {
     "description": "METALLIC_PAINTINGS",
     "baseMaterial": "METALLIC_1_GLOSS",
     "objectIds": [
-      890,
-      891,
-      892,
-      893,
-      894
+      "PAINTING2_KING",
+      "PAINTING2_LANDSCAPE",
+      "PAINTING2_ELF",
+      "PAINTING3_KING",
+      "PAINTING3_LANDSCAPE"
     ],
     "uvType": "BOX",
     "uvScale": 0.2
@@ -6862,8 +6862,8 @@
     "description": "Metallic Guilded Chest",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      376,
-      26273
+      "CHESTCLOSEDGOLD",
+      "NZONE_LOBBY_CHEST"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -6873,10 +6873,10 @@
     "description": "Metallic Chest",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      375,
-      11735,
-      11739,
-      11743
+      "CHESTCLOSED",
+      "TRAPCHEST1",
+      "TRAPCHEST5",
+      "INACOPENCHEST"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -6886,15 +6886,15 @@
     "description": "CANNON_BALL",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      822
+      "CANNONBALLS"
     ]
   },
   {
     "description": "CANNON",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      821,
-      7137
+      "CANNON",
+      "FAI_VARROCK_CANNON"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -6904,7 +6904,7 @@
     "description": "METAL_FLAG_POLE",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      861
+      "FLAGPOLE_KANDARIN"
     ],
     "colorOverrides": [
       {
@@ -6920,7 +6920,7 @@
     "description": "BATHTUB",
     "baseMaterial": "METALLIC_1_HIGHGLOSS",
     "objectIds": [
-      875
+      "BATH"
     ],
     "uvType": "BOX",
     "uvScale": 0.3
@@ -6929,7 +6929,7 @@
     "description": "BATH_PUMP",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      871
+      "BATHPIPES"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -6938,75 +6938,75 @@
     "description": "Metal Fence Gate",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      37,
-      39,
-      1546,
-      1547,
-      1548,
-      1549,
-      1550,
-      1551,
-      1552,
-      1554,
-      1555,
-      1568,
-      1569,
-      1571,
-      1572,
-      1573,
-      1574,
-      1570,
-      1727,
-      1728,
-      2631,
-      2058,
-      2059,
-      2060,
-      2061,
-      3444,
-      3445,
-      3446,
-      3506,
-      3507,
-      5501,
-      8788,
-      8792,
-      8820,
-      8821,
-      9544,
-      9565,
-      9717,
-      9718,
-      11449,
-      11450,
-      11721,
-      11722,
-      11726,
-      14751,
-      14752,
-      14753,
-      14754,
-      2355,
-      24291,
-      24292,
-      24293,
-      24294,
-      23866,
-      26130,
-      26131,
-      26132,
-      26133,
-      29488,
-      29489,
-      32534,
-      34844,
-      34931,
-      39685,
-      39686,
-      44050,
-      44051,
-      44052,
-      44053
+      "CTRATGATEA",
+      "CTRATGATEC",
+      "PRISONDOOR",
+      "PRISONDOOROPEN",
+      "INACTIVEPRISONDOOR",
+      "PRISONDOOR_R",
+      "PRISONDOOROPEN_R",
+      "PRISONDOOR_L",
+      "PRISONDOOROPEN_L",
+      "PORTCULLIS_1L",
+      "PORTCULLIS_1R",
+      "METALGATECLOSEDL",
+      "METALGATECLOSEDR",
+      "METALGATEOPENL",
+      "METALGATEOPENR",
+      "INACMETALGATEOPENL",
+      "INACMETALGATEOPENR",
+      "METALGATETOP",
+      "MEMBERGATEL",
+      "MEMBERGATER",
+      "DUNGEONJAIL",
+      "MOURNERQUATERS_GATEL",
+      "MOURNERQUATERS_GATELOPEN",
+      "MOURNERQUATERS_GATER",
+      "MOURNERQUATERS_GATEROPEN",
+      "PIP_UNDERGROUND_DOOR1",
+      "PIP_UNDERGROUND_DOOR2",
+      "INACPIP_UNDERGROUND_DOOR",
+      "MORTMYRE_METALGATECLOSED_L",
+      "MORTMYRE_METALGATECLOSED_R",
+      "FAVOUR_PRISONDOOR",
+      "MOURNER_HIDEOUT_DOOR3",
+      "MOURNER_HIDEOUT_DOOR3_OPEN",
+      "MOURNING_PRISONDOOR",
+      "MOURNING_PRISONDOOROPEN",
+      "PRISONBARS",
+      "PORT_SARIM_JAILDOOR",
+      "NEWBIEDOOR4L",
+      "NEWBIEDOOR4R",
+      "ERNEST_DOORCLOSED",
+      "ERNEST_DOORAJAR",
+      "PICKLOCK3_L",
+      "PICKLOCK3_R",
+      "TOOLLOCK2",
+      "WILD_DOUBLEDOOR_L",
+      "WILD_DOUBLEDOOR_R",
+      "WILD_DOUBLEDOOR_OPEN_L",
+      "WILD_DOUBLEDOOR_OPEN_R",
+      "DIGSITESACKKEY",
+      "FAI_FALADOR_PARTY_NEG_ROOM_DOOR_BARS_BIG",
+      "FAI_FALADOR_PARTY_NEG_ROOM_DOOR_BARS",
+      "FAI_FALADOR_PARTY_NEG_ROOM_DOOR_BARS_BIG_MIRROR",
+      "FAI_FALADOR_PARTY_NEG_ROOM_DOOR_BARS_MIRROR",
+      "FAI_VARROCK_PRISONBARS",
+      "MURDER_QIP_METALGATECLOSEDL",
+      "MURDER_QIP_METALGATECLOSEDR",
+      "MURDER_QIP_METALGATEOPENL",
+      "MURDER_QIP_METALGATEOPENR",
+      "HILLGIANT_BOSS_EXIT_R",
+      "HILLGIANT_BOSS_EXIT_L",
+      "GB_MOSS_DOOR_IN",
+      "HOSDUN_BURNER_DOOR",
+      "PRISONDOOR_NOOP",
+      "WILDY_HUB_DOOR_BARS",
+      "WILDY_HUB_DOOR_BARS_M",
+      "KHARIDMETALGATECLOSEDL_1OP",
+      "KHARIDMETALGATECLOSEDR_1OP",
+      "KHARIDMETALGATECLOSEDL_2OP",
+      "KHARIDMETALGATECLOSEDR_2OP"
     ],
     "uvType": "BOX",
     "uvOrientation": 463
@@ -7018,24 +7018,24 @@
     "retainVanillaUvs": false,
     "uvOrientation": 512,
     "objectIds": [
-      3460,
-      3461,
-      3462,
-      3463,
-      3464,
-      3465
+      "PRISONWALL",
+      "PRISONWALL_LEND",
+      "PRISONWALL_REND",
+      "PIP_PRISONDOOR",
+      "INACTIVE_PIPPRISONDOOR",
+      "PRISONWALL_SPARE"
     ]
   },
   {
     "description": "Metal Fence",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      2186,
-      20873,
-      20874,
-      20875,
-      24097,
-      29490
+      "TREEGNOMELOOSERAILING",
+      "PILLORY_RAILING",
+      "PILLORY_RAILING_WALL",
+      "PILLORY_RAILING_WALL_CENTER",
+      "RAILING_MODELLED",
+      "HILLGIANT_BOSS_FENCE"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -7044,9 +7044,9 @@
     "description": "Metal Fence - Darken",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      9546,
-      9563,
-      35795
+      "PRISONBARSENDLEFT",
+      "PRISONBARSDOOR_LOCKED",
+      "SOTE_PRISON_DOOR"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -7055,7 +7055,7 @@
     "description": "Marble Fountain",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      879
+      "FOUNTAIN"
     ]
   },
   {
@@ -7064,7 +7064,7 @@
     "uvType": "BOX",
     "uvScale": 0.45,
     "objectIds": [
-      3641
+      "FAI_VARROCK_FOUNTAIN_SPLASH"
     ],
     "colorOverrides": [
       {
@@ -7081,13 +7081,13 @@
     "description": "Metallic Furnace",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      4304,
-      4305,
-      6189,
-      17029,
-      24009,
-      24010,
-      24011
+      "VIKING_FURNACE",
+      "VIKING_FURNACE2",
+      "DWARF_KELDAGRIM_FURNACE",
+      "VIKING_FURNACE_DOOR_RIGHT_MIRROR",
+      "FAI_FALADOR_FURNACE",
+      "FAI_FALADOR_FURNACE_DOOR_LEFT",
+      "FAI_FALADOR_FURNACE_DOOR_RIGHT_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -7095,27 +7095,27 @@
     "description": "Mysterious Statue",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      24716
+      "GRIM_JUNGLESTATUE"
     ]
   },
   {
     "description": "Metal Lever",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      33,
-      34,
-      1814
+      "CTLEVERA",
+      "CTLEVERB",
+      "WILDINLEVER"
     ]
   },
   {
     "description": "Anvil",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      2031,
-      2097,
-      4306,
-      6150,
-      42825
+      "DORICS_ANVIL",
+      "ANVIL",
+      "VIKING_ANVIL",
+      "DWARF_KELDAGRIM_ANVIL",
+      "GIM_ANVIL"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -7125,13 +7125,13 @@
     "description": "Ground Hole Shortcuts",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      16520,
-      16529,
-      16530,
-      19484,
-      19485,
-      19486,
-      19487
+      "YANILLE_CASTLEHOLE_SC",
+      "VARROCK_SC_TUNNEL_WEST",
+      "VARROCK_SC_TUNNEL_EAST",
+      "HUNTING_TRAIL_VISIBLE",
+      "HUNTING_TRAIL6_4R",
+      "HUNTING_TRAIL6_4L",
+      "HUNTING_TRAIL6_5R"
     ]
   },
   {
@@ -7139,53 +7139,53 @@
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "uvType": "BOX",
     "objectIds": [
-      2844,
-      2845,
-      2846,
-      2847,
-      2848,
-      4924
+      "SEWERVALVE1",
+      "SEWERVALVE2",
+      "SEWERVALVE3",
+      "SEWERVALVE4",
+      "SEWERVALVE5",
+      "HAUNTEDMINE_LIFT_VALVE"
     ]
   },
   {
     "description": "Wizard Tower and Bridge",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      12662,
-      12663,
-      12664,
-      12665,
-      12666,
-      12667,
-      12668,
-      12669,
-      12670,
-      12671,
-      12672,
-      12673,
-      12674,
-      12675,
-      12676,
-      12677,
-      12678,
-      12679,
-      12680,
-      12681,
-      12682,
-      12683,
-      12684,
-      12685,
-      12686,
-      12687,
-      12688,
-      12689,
-      12690,
-      12691,
-      12692,
-      12693,
-      12694,
-      12695,
-      12696
+      "FAI_WIZTOWER_WALLS",
+      "FAI_WIZTOWER_WALLS_TERMINATOR_LEFT",
+      "FAI_WIZTOWER_WALLS_TERMINATOR_RIGHT",
+      "FAI_WIZTOWER_WALLS_L2_5_TERMINATOR_RHT",
+      "FAI_WIZTOWER_WALLS_L2_5_TERMINATOR_LFT",
+      "FAI_WIZTOWER_WALLS_3_TERMINATOR",
+      "FAI_WIZTOWER_WALLS_L2",
+      "FAI_WIZTOWER_WALLS_WINDOW",
+      "FAI_WIZTOWER_WALLS_L2_WINDOW",
+      "FAI_WIZTOWER_BATTLEMENTS",
+      "FAI_WIZTOWER_WALL_BATTLEMENTS",
+      "FAI_WIZTOWER_WALL_BATTLEMENTS2",
+      "FAI_WIZTOWER_UPPER_WALLS",
+      "FAI_WIZTOWER_UPPER_WALLS_TERMINATOR_LEFT",
+      "FAI_WIZTOWER_UPPER_WALLS_TERMINATOR_RIGHT",
+      "FAI_WIZTOWER_UPPER_WALLS_L2_5_TERMINATOR_RHT",
+      "FAI_WIZTOWER_UPPER_WALLS_L2_5_TERMINATOR_LFT",
+      "FAI_WIZTOWER_UPPER_WALLS_3_TERMINATOR",
+      "FAI_WIZTOWER_UPPER_WALLS_WINDOW",
+      "FAI_WIZTOWER_UPPER_WALLS_L2_WINDOW",
+      "FAI_WIZTOWER_BRIDGESUPPORT",
+      "FAI_WIZTOWER_BRIDGE_LINK_UNDER_POLE",
+      "FAI_WIZTOWER_BRIDGE_LINK_UNDER_POLE_MIRROR",
+      "FAI_WIZTOWER_BRIDGE_LINK_INNER",
+      "FAI_WIZTOWER_BRIDGE_LINK_INNER_MIRROR",
+      "FAI_WIZTOWER_BRIDGE_BASIC_FLOOR",
+      "FAI_WIZTOWER_BRIDGE_CUT_CORNER_FLOOR",
+      "FAI_WIZTOWER_BRIDGE_CUT_CORNER_FLOOR_MIRROR",
+      "FAI_WIZTOWER_BRIDGE_FLOOR_WALL_CORNER",
+      "FAI_WIZTOWER_BRIDGE_FLOOR_WALL_CORNER_MIRROR",
+      "FAI_WIZTOWER_BRIDGE_EDGE_FLOOR",
+      "FAI_WIZTOWER_BRIDGE_CORNER_FLOOR",
+      "FAI_WIZTOWER_BRIDGE_CORNER_FLOOR_MIRROR",
+      "FAI_WIZTOWER_INTERNAL_WALLS",
+      "FAI_WIZTOWER_BRIDGE_WALLS"
     ],
     "flatNormals": true
   },
@@ -7203,21 +7203,21 @@
       }
     ],
     "objectIds": [
-      12536,
-      11789,
-      11790,
-      11792,
-      11793,
-      12537,
-      24075
+      "FAI_WIZTOWER_SPIRALSTAIRS",
+      "VARROCK_SPIRALSTAIRS",
+      "VARROCK_SPIRALSTAIRS_TALLER",
+      "VARROCK_SPIRALSTAIRS_MIDDLE_TALLER",
+      "VARROCK_SPIRALSTAIRSTOP",
+      "FAI_WIZTOWER_SPIRALSTAIRS_MIDDLE",
+      "FAI_FALADOR_SPIRALSTAIRS"
     ]
   },
   {
     "description": "Sinclair Mansion - Marble Stairs",
     "baseMaterial": "MARBLE_2_SEMIGLOSS",
     "objectIds": [
-      25682,
-      25683
+      "MURDER_QIP_SPIRALSTAIRS",
+      "MURDER_QIP_SPIRALSTAIRSTOP"
     ]
   },
   {
@@ -7235,50 +7235,50 @@
       }
     ],
     "objectIds": [
-      9582,
-      14735,
-      17143,
-      14736,
-      14737
+      "SARIM_SPIRALSTAIRS",
+      "WILD6_SPIRALSTAIRS",
+      "DK_SPIRALSTAIRS",
+      "WILD6_SPIRALSTAIRS_MIDDLE",
+      "WILD6_SPIRALSTAIRSTOP"
     ]
   },
   {
     "description": "Metal Chimney",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      5098
+      "FAI_VARROCK_FURNACE_CHIMNEY"
     ]
   },
   {
     "description": "Black Knight Fortress Wood Rails",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      17154,
-      17155,
-      17156,
-      17157
+      "DK_SPIRALSTAIRS_FIX",
+      "DK_SPIRALSTAIRSTOP",
+      "DK_BANNISTER",
+      "DK_BANNISTER_END"
     ]
   },
   {
     "description": "Grave Dirt",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      4136,
-      4137
+      "GRAVEMOUND_TOP",
+      "GRAVEMOUND_BOT"
     ]
   },
   {
     "description": "POH entrance portals",
     "baseMaterial": "STONE",
     "objectIds": [
-      15477,
-      15478,
-      15479,
-      15480,
-      15481,
-      30172,
-      30173,
-      40475
+      "POH_TAVERLY_PORTAL",
+      "POH_RIMMINGTON_PORTAL",
+      "POH_POLLNIVNEACH_PORTAL",
+      "POH_RELLEKKA_PORTAL",
+      "POH_BRIMHAVEN_PORTAL",
+      "POH_PORTAL_OP",
+      "POH_PORTAL_NOOP",
+      "SOUL_WARS_ENCLAVE_PORTAL"
     ],
     "shadowOpacityThreshold": 0.12
   },
@@ -7286,46 +7286,46 @@
     "description": "Clocktower metal pipes",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      25,
-      26,
-      27,
-      28,
-      29,
-      30,
-      31,
-      32
+      "CLOCKPOLE_RED",
+      "CLOCKPOLE_BLACK",
+      "CLOCKPOLE_WHITE",
+      "CLOCKPOLE_BLUE",
+      "BROKECLOCKPOLE_RED",
+      "BROKECLOCKPOLE_BLACK",
+      "BROKECLOCKPOLE_WHITE",
+      "BROKECLOCKPOLE_BLUE"
     ]
   },
   {
     "description": "Metal bars in wall",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      1880,
-      1881
+      "ARCHEDCAGE_BLACKBACKA_L",
+      "ARCHEDCAGE_BLACKBACKA_R"
     ]
   },
   {
     "description": "Fire Remains",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      714
+      "FIRE_REMAINS"
     ]
   },
   {
     "description": "Metal Lanturn",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      3474,
-      4501,
-      4503,
-      24172
+      "HANGINGLANTERN",
+      "FAI_VARROCK_OILLAMP",
+      "FAI_VARROCK_SWING_LANTERN_UNLIT",
+      "FAI_FALADOR_LANTERN"
     ]
   },
   {
     "description": "Static Lantern - Brighten Glass and Texture Metal",
     "baseMaterial": "GRAY_125",
     "objectIds": [
-      205
+      "LANTERN"
     ],
     "colorOverrides": [
       {
@@ -7340,154 +7340,154 @@
     "description": "Wooden Door 1 - Fake Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      3,
-      4,
-      24,
-      81,
-      82,
-      93,
-      99,
-      102,
-      1535,
-      1536,
-      1539,
-      1732,
-      1722,
-      1726,
-      1743,
-      2034,
-      2035,
-      2036,
-      2037,
-      2038,
-      2054,
-      2069,
-      2184,
-      2337,
-      2338,
-      2339,
-      2340,
-      2427,
-      2428,
-      2429,
-      2430,
-      2431,
-      2526,
-      2527,
-      2528,
-      2529,
-      2537,
-      2528,
-      2529,
-      2621,
-      2622,
-      2626,
-      2627,
-      2628,
-      2863,
-      3270,
-      3271,
-      3745,
-      3746,
-      4465,
-      4466,
-      4467,
-      4468,
-      4962,
-      7259,
-      7260,
-      8786,
-      8787,
-      8789,
-      8790,
-      8791,
-      8793,
-      8818,
-      8819,
-      9398,
-      9709,
-      9710,
-      9716,
-      9721,
-      9722,
-      9723,
-      9724,
-      10045,
-      10260,
-      10261,
-      11483,
-      11719,
-      11720,
-      11723,
-      11725,
-      11727,
-      11728,
-      11774,
-      11775,
-      11776,
-      11777,
-      11788,
-      12349,
-      12350,
-      13001,
-      13002,
-      13094,
-      13095,
-      13096,
-      13097,
-      14749,
-      14750,
-      15759,
-      23338,
-      23339,
-      23378,
-      23379,
-      23631,
-      23972,
-      23973,
-      24050,
-      24051,
-      24052,
-      24053,
-      24054,
-      24055,
-      24056,
-      24057,
-      24058,
-      24363,
-      24366,
-      24367,
-      24368,
-      24369,
-      24958,
-      25417,
-      25418,
-      25637,
-      25716,
-      25717,
-      25819,
-      25820,
-      29066,
-      29067,
-      30164,
-      30167,
-      30364,
-      30365,
-      30366,
-      34927,
-      34929,
-      34932,
-      35932,
-      35934,
-      37940,
-      37941,
-      37961,
-      40178,
-      40353,
-      40382,
-      46253,
-      46254,
-      46563
+      "MCANNONDOOR",
+      "MCANNONDOOR1",
+      "MERLINWORKSHOP",
+      "FIGHTARENA_DOOR1",
+      "FIGHTARENA_DOOR2",
+      "IKOV_FIREWARRIORDOOR",
+      "IKOV_SHINYKEYDOOR",
+      "IKOV_LUCIENDOOR",
+      "POORDOOR",
+      "POORDOOROPEN",
+      "INACTIVEPOORDOOR",
+      "MAGICGUILD_DOOR_L",
+      "LOCKEDDOOR1",
+      "MEMBERDOOR",
+      "POORDOOROPEN_PERM",
+      "MOURNERSTEWDOORUP",
+      "MOURNERSTEWDOORUPOPEN",
+      "MOURNERSTEWDOOR",
+      "MOURNERSTEWDOOROPEN",
+      "BIOHAZARDDUMMY",
+      "ELENADOOR2",
+      "WYDINDOOR",
+      "KHAZARD_STRONGHOLD_DOOR",
+      "BKFORTRESSDOOR1",
+      "BKFORTRESSDOOR2",
+      "BKFORTRESSDOOR3",
+      "INACBKFORTRESSDOOR",
+      "FAMCREST_DOORH2",
+      "FAMCREST_DOORH2I2",
+      "FAMCREST_DOORG2H1",
+      "FAMCREST_DOORI2H1",
+      "FAMCREST_DOORH2G1",
+      "ELENAGATESHUT",
+      "ELENAGATEOPEN",
+      "BRAVEKDOORSHUT",
+      "BRAVEKDOOROPEN",
+      "REHNISONDOORSHUT",
+      "BRAVEKDOORSHUT",
+      "BRAVEKDOOROPEN",
+      "PETE_TREASUREDOOR",
+      "PETE_SIDEDOOR",
+      "GRUBORDOOR",
+      "GARVDOOR",
+      "HEROKITCHENDOOR",
+      "WITCHSHEDDOOR",
+      "CAVEWITCH_DOOR",
+      "WITCHDOOR",
+      "DEATH_SHERPA_DOOR",
+      "DEATH_SHERPA_BACKDOOR",
+      "CASTLEWARS_SARADOMIN_SIDEDOOR",
+      "CASTLEWARS_SARADOMIN_SIDEDOOR_OPEN",
+      "CASTLEWARS_ZAMORAK_SIDEDOOR",
+      "CASTLEWARS_ZAMORAK_SIDEDOOR_OPEN",
+      "HAUNTEDMINE_BOSS_DOOR",
+      "ROGUESDEN_DOOR_TO_PUB",
+      "ROGUESDEN_DOOR_TO_PUB_OPEN",
+      "MOURNER_HIDEOUT_DOOR1",
+      "MOURNER_HIDEOUT_DOOR2",
+      "MOURNER_HIDEOUT_DOOR4",
+      "MOURNER_HIDEOUT_DOOR1_OPEN",
+      "MOURNER_HIDEOUT_DOOR2_OPEN",
+      "MOURNER_HIDEOUT_DOOR4_OPEN",
+      "MOURNING_POORDOOR",
+      "MOURNING_POORDOOROPEN",
+      "NEWBIE_DOOR1",
+      "NEWBIE_DOOR2",
+      "NEWBIE_DOOR3",
+      "NEWBIE_DOOR4",
+      "NEWBIE_DOOR6",
+      "NEWBIE_DOOR7",
+      "NEWBIE_DOOR8",
+      "NEWBIE_DOOR9",
+      "FAI_VARROCK_COOK_GUILD_DOOR",
+      "MAKINGHISTORY_DOOR",
+      "MAKINGHISTORY_DOOR_OPEN",
+      "DRAYNOR_BASEMENT_DOOR_OPEN",
+      "PICKLOCK1",
+      "PICKLOCK2",
+      "PICKLOCK4",
+      "PICKLOCK6",
+      "TOOLLOCK3",
+      "TOOLLOCK5",
+      "FAI_VARROCK_DOOR_OPEN",
+      "FAI_VARROCK_DOOR",
+      "FAI_VARROCK_DOOR_OPEN_TALLER",
+      "FAI_VARROCK_DOOR_TALLER",
+      "FAI_VARROCK_BANK_LOCKED_DOOR",
+      "HUNDRED_LUMBRIDGE_DOUBLEDOORL",
+      "HUNDRED_LUMBRIDGE_DOUBLEDOORR",
+      "QIP_SHEEP_SHEARER_POORDOOR",
+      "QIP_SHEEP_SHEARER_POORDOOROPEN",
+      "POORDOOR_DOUBLE_INNER",
+      "OPENPOORDOOR_DOUBLE_INNER",
+      "POORDOOR_DOUBLER_INNER",
+      "OPENPOORDOOR_DOUBLER_INNER",
+      "WILD_DOOR",
+      "WILD_DOOR_OPEN",
+      "DTTD_HAM_DOOR",
+      "SLICE_OUTPOST_POORDOOR",
+      "SLICE_OUTPOST_OPENPOORDOOR",
+      "SLICE_DOOR",
+      "SLICE_OPENDOOR",
+      "BLACKARMDOOR_OPEN",
+      "FAI_WIZTOWER_POOR_DOOR",
+      "FAI_WIZTOWER_POOR_DOOR_OPEN",
+      "FAI_FALADOR_POOR_DOOR",
+      "FAI_FALADOR_POOR_DOOR_OPEN",
+      "FAI_FALADOR_POOR_DOOR_CLOSED_M",
+      "FAI_FALADOR_POOR_DOOR_OPEN_M",
+      "FAI_FALADOR_POOR_DOOR_RR",
+      "FAI_FALADOR_POOR_DOOR_OPEN_TALLER",
+      "FAI_FALADOR_POOR_DOOR_TALLER",
+      "FAI_FALADOR_POOR_CASTLE_DOOR",
+      "FAI_FALADOR_POOR_CASTLE_DOOR_OPEN",
+      "CANAFIS_DOOR_OPEN",
+      "CANAFIS_DOOR_OFFSET",
+      "CANAFIS_BANK_DOOR",
+      "CANAFIS_DOOR_GROUND_OPEN",
+      "CANAFIS_DOOR_GROUND",
+      "CHEFDOOR",
+      "QIP_OBS_RECEPTION_DOOR_OPEN",
+      "QIP_OBS_RECEPTION_DOOR",
+      "QIP_COOK_DOOR",
+      "KR_SIN_POORDOOR",
+      "KR_SIN_POORDOOROPEN",
+      "KR_POORDOOR",
+      "KR_POORDOOROPEN",
+      "BR_DOOR_LOCKED",
+      "BR_DOOR_FORFEIT",
+      "TUT2_SURVIVAL_ENTRY",
+      "TUT2_NAV_ENTRY",
+      "MGUILD_DOOR",
+      "MGUILD_DOOR_INNER1",
+      "MGUILD_DOOR_INNER2",
+      "POORDOOR_VIS",
+      "POORDOOR_OPEN_VIS",
+      "POORDOOR_NOOP",
+      "PLAGUEELENADOORSHUT_VIS",
+      "PLAGUEELENADOOROPEN_VIS",
+      "TUT2_NAV_EXIT",
+      "TUT2_QUEST_ENTRY",
+      "TUT2_BANK_EXIT",
+      "CON_CONTRACT_ARDY_WEST_DOOR_LOCKED",
+      "FAI_FALADOR_POOR_DOOR_INACTIVE",
+      "CANAFIS_DOOR_GROUND_NOOP",
+      "FAI_FALADOR_POOR_DOOR_FLIP",
+      "FAI_FALADOR_POOR_DOOR_OPEN_FLIP",
+      "FIGHTARENA_DOOR2_ESCAPE"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -7496,30 +7496,30 @@
     "description": "Wooden Door 2 - 4 Panel",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      22,
-      59,
-      92,
-      1540,
-      1541,
-      1542,
-      2705,
-      2706,
-      3744,
-      3747,
-      17089,
-      17090,
-      17316,
-      17317,
-      20925,
-      25642,
-      25643,
-      25718,
-      25719,
-      25799,
-      25800,
-      46862,
-      46863,
-      46864
+      "WHISTLEDOOR",
+      "JEWELLERSDOOR",
+      "IKOV_TRAPLEVERDOOR",
+      "POSHDOOR",
+      "POSHDOOROPEN",
+      "INACTIVEPOSHDOOR",
+      "COMBODOOR",
+      "TRIBALTOTEMDOOR",
+      "CASTLEDOOR_INACTIVE",
+      "DEATH_HAROLD_DOOR",
+      "XBOWS_CASTLE_DOOR",
+      "XBOWSCASTLEDOOR_OPEN",
+      "QIP_DIGSITE_POSHDOOR",
+      "QIP_DIGSITE_POSHDOOR_OPEN",
+      "FISHGUILDDOOR",
+      "KR_CAM_POSHDOOR",
+      "KR_CAM_POSHDOOR_OPEN",
+      "KR_SIN_POSHDOOR",
+      "KR_SIN_POSHDOOROPEN",
+      "KR_POSHDOOR",
+      "KR_POSHDOOROPEN",
+      "POSHDOOR_NOOP",
+      "POSHDOOR_REVERSE",
+      "POSHDOOROPEN_REVERSE"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -7529,62 +7529,62 @@
     "description": "Wooden Door 3 - Fake Plank Golden Handle",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      71,
-      72,
-      73,
-      74,
-      1521,
-      1522,
-      1524,
-      1525,
-      1527,
-      1528,
-      1529,
-      1530,
-      1733,
-      2416,
-      2417,
-      2546,
-      2547,
-      2548,
-      2549,
-      2624,
-      4963,
-      4964,
-      2625,
-      5667,
-      10262,
-      10263,
-      10264,
-      10265,
-      17091,
-      17092,
-      17093,
-      17094,
-      20197,
-      20198,
-      24123,
-      24124,
-      25825,
-      25826,
-      25827,
-      25828,
-      25748,
-      25749,
-      25750,
-      25751,
-      25788,
-      25789,
-      25790,
-      25791,
-      25802,
-      25803,
-      26205,
-      26207,
-      35935,
-      35936,
-      37963,
-      37964
+      "LEFAYEUNOPENABLEDOORL",
+      "LEFAYEUNOPENABLEDOORR",
+      "INACLEFAYEUNOPENABLEDOORL",
+      "INACLEFAYEUNOPENABLEDOORR",
+      "CASTLEDOUBLEDOORL",
+      "OPENCASTLEDOUBLEDOORL",
+      "CASTLEDOUBLEDOORR",
+      "OPENCASTLEDOUBLEDOORR",
+      "INACCASTLEDOUBLEDOORL",
+      "INACCASTLEDOUBLEDOORR",
+      "INACCASTLEDOUBLEDOORLOPEN",
+      "INACCASTLEDOUBLEDOORROPEN",
+      "MAGICGUILD_DOOR_R",
+      "KR_DOUBLEDOOR_L",
+      "KR_OPENDOUBLEDOOR_L",
+      "W_ARDOUGNEDOUBLEDOORL",
+      "W_ARDOUGNEDOUBLEDOORLOPEN",
+      "W_ARDOUGNEDOUBLEDOORR",
+      "W_ARDOUGNEDOUBLEDOORROPEN",
+      "HERODOOR_L",
+      "HAUNTEDMINE_REWARDDOOR_L",
+      "HAUNTEDMINE_REWARDDOOR_R",
+      "HERODOOR_R",
+      "KR_DOUBLEDOOR_R",
+      "MAKINGHISTORY_DOUBLEDOORL",
+      "MAKINGHISTORY_DOUBLEDOORL_OPEN",
+      "MAKINGHISTORY_DOUBLEDOORR",
+      "MAKINGHISTORY_DOUBLEDOORR_OPEN",
+      "XBOWSDOUBLEDOORL",
+      "XBOWSDOUBLEDOOR_OPENL",
+      "XBOWSDOUBLEDOORR",
+      "XBOWSDOUBLEDOOR_OPENR",
+      "BARBASSAULT_OPENDOUBLEDOORL",
+      "BARBASSAULT_OPENDOUBLEDOORR",
+      "FAI_FALADOR_BANK_DOOR_INACTIVE_L",
+      "FAI_FALADOR_BANK_DOOR_INACTIVE_R",
+      "KR_COURTHOUSE_DOUBLE_DOOR_L",
+      "KR_COURTHOUSE_DOUBLE_DOOR_L_OPEN",
+      "KR_COURTHOUSE_DOUBLE_DOOR_R",
+      "KR_COURTHOUSE_DOUBLE_DOOR_R_OPEN",
+      "KR_MANSION_DOUBLE_DOOR_L",
+      "KR_MANSION_OPEN_DOUBLE_DOOR_L",
+      "KR_MANSION_DOUBLE_DOOR_R",
+      "KR_MANSION_OPEN_DOUBLE_DOOR_R",
+      "KR_SEERS_DOUBLEDOORL",
+      "KR_SEERS_OPEN_DOUBLEDOORL",
+      "KR_SEERS_DOUBLEDOORR",
+      "KR_SEERS_OPEN_DOUBLEDOORR",
+      "KR_BANKDOOR_R_INACTIVE",
+      "KR_BANKDOOR_L_INACTIVE",
+      "WILD_DOUBLEDOOR_OPEN_L_INACTIVE",
+      "KR_OPENDOUBLEDOOR_R",
+      "W_ARDOUGNEDOUBLEDOORL_NOOP",
+      "W_ARDOUGNEDOUBLEDOORR_NOOP",
+      "TUT2_PRAYER_EXIT_L",
+      "TUT2_PRAYER_EXIT_R"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -7593,14 +7593,14 @@
     "description": "Wooden Door 4 - Fake Plank with Silver Handle",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11784,
-      11785,
-      11786,
-      11787,
-      24565,
-      24566,
-      24567,
-      24568
+      "FAI_VARROCK_MUSEUM_DOOR_INACTIVE_L",
+      "FAI_VARROCK_MUSEUM_DOOR_INACTIVE_R",
+      "FAI_VARROCK_BANK_DOOR_INACTIVE_L",
+      "FAI_VARROCK_BANK_DOOR_INACTIVE_R",
+      "FAI_VARROCK_MUSEUM_DOOR_CLOSED_L",
+      "FAI_VARROCK_MUSEUM_DOOR_OPEN_L",
+      "FAI_VARROCK_MUSEUM_DOOR_CLOSED_R",
+      "FAI_VARROCK_MUSEUM_DOOR_OPEN_R"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -7609,10 +7609,10 @@
     "description": "Wooden Door - Surprise Exam",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      9316,
-      9317,
-      9318,
-      9319
+      "PATTERN_DOOR_A",
+      "PATTERN_DOOR_B",
+      "PATTERN_DOOR_C",
+      "PATTERN_DOOR_D"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -7622,23 +7622,23 @@
     "description": "Wooden Door - Plank",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      1749,
-      2398,
-      2406,
-      11616,
-      11617,
-      11765,
-      11778,
-      11779,
-      11780,
-      11782,
-      11783,
-      15056,
-      44784,
-      44785,
-      50048,
-      50049,
-      50050
+      "AHOY_HARBOUR_DOOR_OPEN_PERM",
+      "PHOENIXDOOR2",
+      "ZANARISDOOR",
+      "FAI_BARBARIAN_POORDOOR",
+      "FAI_BARBARIAN_POORDOOROPEN",
+      "FAI_VARROCK_LOCKED_DOOR",
+      "FAI_VARROCK_POOR_DOOR_OPEN",
+      "FAI_VARROCK_POOR_DOOR_INACTIVE",
+      "FAI_VARROCK_POOR_DOOR",
+      "FAI_VARROCK_SHANTY_DOOR_OPEN",
+      "FAI_VARROCK_SHANTY_DOOR",
+      "FARMING_SHED_POORDOOR",
+      "FAI_VARROCK_POOR_DOOR_FLIPPED",
+      "FAI_VARROCK_POOR_DOOR_OPEN_FLIPPED",
+      "VMQ1_BANDIT_DOOR",
+      "VMQ1_BANDIT_DOOR_OPEN",
+      "VMQ1_BANDIT_DOOR_NOOP"
     ],
     "uvOrientation": 512,
     "uvScale": 0.4,
@@ -7648,12 +7648,12 @@
     "description": "Varrock Castle Doors",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2032,
-      2033,
-      11772,
-      11773,
-      32463,
-      32464
+      "GUIDORDOOR",
+      "GUIDORDOOROPEN",
+      "FAI_VARROCK_CASTLE_DOOR_OPEN",
+      "FAI_VARROCK_CASTLE_DOOR",
+      "DS2_VARROCK_DOOR_OPEN",
+      "DS2_VARROCK_DOOR"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -7663,7 +7663,7 @@
     "description": "Varrock Castle Railing",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      23852
+      "FAI_VARROCK_WOODENRAILING"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -7672,8 +7672,8 @@
     "description": "Varrock Castle - Juliets House - Museum Staircase",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11797,
-      11807
+      "FAI_VARROCK_STAIRS_TALLER",
+      "FAI_VARROCK_STAIRS_TALLER_NEW_FIX"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -7683,7 +7683,7 @@
     "description": "Varrock Museum Staircase",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      11798
+      "FAI_VARROCK_WOODENSTAIRS_CASTLE"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -7694,10 +7694,10 @@
     "description": "Varrock - Saw Mill Walls",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      533,
-      23900,
-      23901,
-      23902
+      "FAI_VARROCK_LUMBER_YARD_WALLS_NOBLOCKRANGE",
+      "FAI_VARROCK_LUMBER_YARD_WALLS",
+      "FAI_VARROCK_LUMBER_YARD_COUNTER",
+      "FAI_VARROCK_LUMBER_YARD_WALLS_WINDOW"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -7708,17 +7708,17 @@
     "description": "Varrock - Saw Mill floors",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      521,
-      522,
-      523,
-      524
+      "FAI_VARROCK_FLOORBOARD",
+      "FAI_VARROCK_FLOORBOARD2",
+      "FAI_VARROCK_FLOORBOARD_END",
+      "FAI_VARROCK_FLOORBOARD_OVERHANG"
     ],
     "uvType": "MODEL_XZ"
   },
   {
     "description": "Varrock Wall ivy",
     "baseMaterial": "PLANT_GRUNGE_2",
-    "objectIds": [ 5088, 5089 ],
+    "objectIds": [ "FAI_VARROCK_IVY_MEDIUM", "FAI_VARROCK_IVY_SMALL" ],
     "uvType": "MODEL_YZ",
     "uvOrientation": 144,
     "uvScale": 0.6
@@ -7727,17 +7727,17 @@
     "description": "Khandarian Eagles Landing",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      19798
+      "EAGLEPEAK_CAVEIN_DESERT"
     ]
   },
   {
     "description": "Grunge-Like Object",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6358,
-      6359,
-      6360,
-      6361
+      "GOLEM_DUGUPSOIL1",
+      "GOLEM_DUGUPSOIL2",
+      "GOLEM_DUGUPSOIL3",
+      "GOLEM_DUGUPSOIL4"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -7745,13 +7745,13 @@
     "description": "Rock-Like Object - Rubble - Tiny",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      181,
-      182,
-      5204,
-      24023,
-      25657,
-      41531,
-      41532
+      "GRAVEL_4",
+      "GRAVEL_5",
+      "FENK_SLAYER_2",
+      "FAI_FALADOR_DUGUPSOIL_2",
+      "KR_KEEP_DUGUPSOIL2",
+      "BIM_VAULT_TILE01DEBRIS01",
+      "BIM_VAULT_TILE01DEBRIS02"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.3,
@@ -7761,13 +7761,13 @@
     "description": "Rock-Like Object - Rubble - Small",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      2172,
-      5203,
-      5205,
-      24022,
-      24024,
-      25656,
-      25658
+      "DUGUPSOIL_SLAYER_1",
+      "FENK_SLAYER_1",
+      "FENK_SLAYER_3",
+      "FAI_FALADOR_DUGUPSOIL_1",
+      "FAI_FALADOR_DUGUPSOIL_3",
+      "KR_KEEP_DUGUPSOIL1",
+      "KR_KEEP_DUGUPSOIL3"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -7777,49 +7777,49 @@
     "description": "Sand clumps",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      11114,
-      11115,
-      11116,
-      11117,
-      11118,
-      11119,
-      11120,
-      11121
+      "ENAKH_BOULDERKIT_FALLOFF1_PT1",
+      "ENAKH_BOULDERKIT_FALLOFF1_PT2",
+      "ENAKH_BOULDERKIT_FALLOFF1_PT3",
+      "ENAKH_BOULDERKIT_FALLOFF1_PT4",
+      "ENAKH_BOULDERKIT_FALLOFF2_PT1",
+      "ENAKH_BOULDERKIT_FALLOFF2_PT2",
+      "ENAKH_BOULDERKIT_FALLOFF2_PT3",
+      "ENAKH_BOULDERKIT_FALLOFF2_PT4"
     ]
   },
   {
     "description": "Sand Hole",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      10953,
-      10954,
-      10955,
-      10956,
-      10957,
-      10958,
-      10959,
-      10960,
-      10961,
-      10962,
-      10963,
-      10964,
-      10965,
-      10966,
-      10967,
-      10968,
-      10969,
-      11049,
-      11050,
-      11122,
-      11123
+      "ENAKH_BIGHOLE",
+      "ENAKH_BUILDING_AREA",
+      "ENAKH_STATUE_STAGE_1",
+      "ENAKH_STATUE_STAGE_2",
+      "ENAKH_STATUE_STAGE_3",
+      "ENAKH_STATUE_LAZIM",
+      "ENAKH_STATUE_ZAMORAK",
+      "ENAKH_STATUE_ICTHLARIN",
+      "ENAKH_STATUE_CAMEL",
+      "ENAKH_STATUE_LAZIM_CRACK_1",
+      "ENAKH_STATUE_ZAMORAK_CRACK_1",
+      "ENAKH_STATUE_ICTHLARIN_CRACK_1",
+      "ENAKH_STATUE_CAMEL_CRACK_1",
+      "ENAKH_STATUE_LAZIM_CRACK_2",
+      "ENAKH_STATUE_ZAMORAK_CRACK_2",
+      "ENAKH_STATUE_ICTHLARIN_CRACK_2",
+      "ENAKH_STATUE_CAMEL_CRACK_2",
+      "ENAKH_SECRET_BOULDER_SHUT",
+      "ENAKH_SECRET_BOULDER_OPEN",
+      "ENAKH_SECRET_BOULDER_SURROUND",
+      "ENAKH_SECRET_BOULDER_SURROUND5"
     ]
   },
   {
     "description": "Sandstone Rocks",
     "baseMaterial": "STONE",
     "objectIds": [
-      3204,
-      11386
+      "ARENA_CLIFFROCK",
+      "ENAKH_SANDSTONE_ROCKS"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -7829,7 +7829,7 @@
     "description": "Granite Rocks",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      11387
+      "ENAKH_GRANITE_ROCKS"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.25
@@ -7838,12 +7838,12 @@
     "description": "Kharidian Rocks",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      11096,
-      16549,
-      16550,
-      16551,
-      26640,
-      26641
+      "ENAKH_ROCK4_SMALL",
+      "ALKHARID_MINE_SC_TOP",
+      "ALKHARID_MINE_SC_BOTTOM",
+      "ALKHARID_MINE_SC_TOP_FALLOFF",
+      "ROCKSLIDE1_DESERT",
+      "ROCKSLIDE2_DESERT"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -7852,20 +7852,20 @@
     "description": "Kharidian Sandstone",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6584,
-      6585,
-      6586,
-      6587,
-      11099,
-      11100,
-      11101,
-      11102,
-      11103,
-      11104,
-      11105,
-      11106,
-      11107,
-      11108
+      "ICTHALARINS_ROCKSLIDE1",
+      "ICTHALARINS_ROCKSLIDE2",
+      "ICTHALARINS_ROCKSLIDE3",
+      "ICTHALARINS_ROCKSLIDE4",
+      "ENAKH_SANDY_ROCK1",
+      "ENAKH_SANDY_ROCK2",
+      "ENAKH_SANDY_ROCK3",
+      "ENAKH_SANDY_ROCK4",
+      "ENAKH_SANDY_ROCKSLIDE",
+      "ENAKH_SANDY_ROCKSLIDE2",
+      "ENAKH_SANDY_ROCK1_SMALL",
+      "ENAKH_SANDY_ROCK2_SMALL",
+      "ENAKH_SANDY_ROCK3_SMALL",
+      "ENAKH_SANDY_ROCK4_SMALL"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "MODEL_XZ",
@@ -7875,18 +7875,18 @@
     "description": "GuTanoth bridges",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      2830,
-      2831,
-      20010,
-      20011,
-      20012,
-      20013,
-      20014,
-      20015,
-      20016,
-      20017,
-      20018,
-      20019
+      "TANOTHJUMP1",
+      "TANOTHJUMP2",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_1",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_1_MIRROR",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_2",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_2_MIRROR",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_3",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_3_MIRROR",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_4",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_4_MIRROR",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_5",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_FLOOR_5_MIRROR"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -7894,10 +7894,10 @@
     "description": "GuTanoth bridges rope",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      20004,
-      20005,
-      20006,
-      20007
+      "QIP_WATCHTOWER_ROPE_BRIDGE_MIDDLE",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_MIDDLE_MIRROR",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_END",
+      "QIP_WATCHTOWER_ROPE_BRIDGE_END_MIRROR"
     ],
     "uvOrientation": 512,
     "uvType": "MODEL_XY",
@@ -7907,10 +7907,10 @@
     "description": "Lighthouse broken bridge",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      3200,
-      4260,
-      4261,
-      4264
+      "HORROR_BROKEN_BRIDGE",
+      "VIKING_PIER2_HILLSKEW",
+      "VIKING_PIER3_HILLSKEW",
+      "VIKING_PIER_EDGE"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -7918,15 +7918,15 @@
     "description": "Brimstils Cave",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      17209
+      "EYEGLO_BRIMSTAILS_CAVE_ENTRANCE"
     ]
   },
   {
     "description": "Eagles Peak Cave",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      19925,
-      19926
+      "EAGLEPEAK_NEW_CAVE_ENTRANCE",
+      "EAGLEPEAK_NEW_CAVE_ENTRANCE_OPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -7935,21 +7935,21 @@
     "description": "Dagannoth Cave",
     "baseMaterial": "STONE",
     "objectIds": [
-      8929
+      "DAGANNOTH_CAVEENTRANCE_ROCK"
     ]
   },
   {
     "description": "Desert Caves",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      30180
+      "SLAYER_KAPHITE_CAVE_ENTRANCE"
     ]
   },
   {
     "description": "Lumbridge Swamp Cave Hole",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      5947
+      "GOBLIN_CAVE_ENTRANCE"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.85
@@ -7958,7 +7958,7 @@
     "description": "Lumbridge Swamp Tree/Plant",
     "baseMaterial": "BARK",
     "objectIds": [
-      1369
+      "MEDPLANT_SWAMP"
     ],
     "uvType": "BOX",
     "uvScale": 0.85,
@@ -7976,7 +7976,7 @@
     "description": "Lumbridge Swamp - Wooden Cart with Canopy",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      5578
+      "CART_WITH_DOME_ROOF"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -7994,14 +7994,14 @@
     "description": "Lumbridge Swamp - Fire with Pot",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      26577
+      "EMBERS_WITH_PANS"
     ]
   },
   {
     "description": "Wyvern Shortcut",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      53250
+      "CAVEWALL_SHORTCUT_WYVERN_WEST"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -8011,16 +8011,16 @@
     "description": "Snow Caves",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      5012,
-      5857,
-      6441,
-      6442,
-      6443,
-      6444,
-      6445,
-      6446,
-      6447,
-      40888
+      "TROLLROMANCE_PISTE_EXIT_TUNNEL_EXIT",
+      "MDAUGHTER_CAVEENTRANCE",
+      "TROLLRESCUE_TROLL_CAVE_ENTRANCE_MULTI",
+      "TROLLRESCUE_TROLL_CAVE_ENTRANCE1",
+      "TROLLRESCUE_TROLL_CAVE_ENTRANCE2",
+      "TROLLRESCUE_TROLL_CAVE_ENTRANCE3",
+      "TROLLRESCUE_TROLL_CAVE_ENTRANCE4",
+      "TROLLRESCUE_TROLL_CAVE_ENTRANCE5",
+      "TROLLRESCUE_TROLL_CAVE_EXIT",
+      "XMAS20_GOBLIN_CAVE_EXIT"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.5
@@ -8029,8 +8029,8 @@
     "description": "Overly Bright Snow Caves",
     "baseMaterial": "SNOW_2_DARK",
     "objectIds": [
-      5007,
-      5011
+      "TROLLROMANCE_CAVEENTRANCE",
+      "TROLLROMANCE_PISTE_TUNNEL_BOTTOM"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.5
@@ -8039,7 +8039,7 @@
     "description": "Objects - Ardougne Sewers - Rock Entrnace",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      2852
+      "HAZEELCULTCAVE"
     ],
     "flatNormals": true,
     "uvType": "WORLD_XZ",
@@ -8049,14 +8049,14 @@
     "description": "Stepping Stones",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      11643,
-      11768,
-      13504,
-      16466,
-      16533,
-      23645,
-      23646,
-      23647
+      "WEREWOLF_STEPING_STONE",
+      "MISC_DIARY_STEPPINGSTONE",
+      "FAIRY_ISLAND_NATURE_GROTTO_SHORTCUT",
+      "SHILO_RIVER_STEPPINGSTONE",
+      "LUMBRIDGE_SC_STEPSTONE",
+      "ZQROCKJUMP1",
+      "ZQROCKJUMP2",
+      "ZQROCKJUMP3"
     ],
     "uvType": "WORLD_XZ"
   },
@@ -8064,162 +8064,162 @@
     "description": "Objects - Rocks - Medium",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      1797,
-      3634,
-      3635,
-      3636,
-      3637,
-      3638,
-      3639,
-      3712,
-      3714,
-      3715,
-      3716,
-      3717,
-      3718,
-      3719,
-      3794,
-      3795,
-      3805,
-      3806,
-      3807,
-      3808,
-      4356,
-      4357,
-      4358,
-      4359,
-      4603,
-      4604,
-      4605,
-      4606,
-      5009,
-      5035,
-      5037,
-      5308,
-      5604,
-      5605,
-      5606,
-      5842,
-      5843,
-      5844,
-      5849,
-      5950,
-      5951,
-      5952,
-      5953,
-      5985,
-      5986,
-      5987,
-      11426,
-      11427,
-      11428,
-      11431,
-      11435,
-      12216,
-      12217,
-      12218,
-      12588,
-      12591,
-      12592,
-      12593,
-      12594,
-      12589,
-      12590,
-      12924,
-      12925,
-      12926,
-      12927,
-      14384,
-      14385,
-      14386,
-      14387,
-      14388,
-      14389,
-      14450,
-      14451,
-      14452,
-      14453,
-      14454,
-      14455,
-      14461,
-      14462,
-      14463,
-      14464,
-      14465,
-      14466,
-      15125,
-      15126,
-      15127,
-      15128,
-      15129,
-      15149,
-      15150,
-      15151,
-      15152,
-      15806,
-      15807,
-      15808,
-      15811,
-      15812,
-      17873,
-      17874,
-      17875,
-      19215,
-      19216,
-      19217,
-      19218,
-      19219,
-      19851,
-      20129,
-      20130,
-      20131,
-      20648,
-      20649,
-      20650,
-      20651,
-      20652,
-      20753,
-      20754,
-      20755,
-      20756,
-      20757,
-      22347,
-      22348,
-      22349,
-      23085,
-      23086,
-      23087,
-      26715,
-      26716,
-      27984,
-      27985,
-      27986,
-      27987,
-      27988,
-      27989,
-      30404,
-      31742,
-      31743,
-      31744,
-      31745,
-      31746,
-      31747,
-      31757,
-      31758,
-      31759,
-      31760,
-      33595,
-      33596,
-      34741,
-      42371,
-      42372,
-      42373,
-      42374,
-      42675,
-      42376,
-      50724,
-      50725,
-      50726
+      "WATERFALLSQUISHEDROCKS",
+      "FAI_VARROCK_ROCKS",
+      "FAI_VARROCK_ROCKS_LARGE",
+      "FAI_VARROCK_ROCKSLIDE_1",
+      "FAI_VARROCK_ROCKSLIDE_2",
+      "FAI_VARROCK_ROCKSLIDE_3",
+      "FAI_VARROCK_ROCKSLIDE_4",
+      "DEATH_DUGUPSOIL_SQUISHED_2",
+      "DEATH_MOUNTAINROCKS_1",
+      "DEATH_MOUNTAINROCKS_1_LARGE",
+      "DEATH_ROCKSLIDE1",
+      "DEATH_ROCKSLIDE2",
+      "DEATH_ROCKSLIDE3",
+      "DEATH_ROCKSLIDE4",
+      "TROLL_ROCKS_GRASS",
+      "TROLL_ROCKS_GRASS_FALLOFF",
+      "DEATH_MOUNTAINROCKS_2",
+      "DEATH_MOUNTAINROCKS_2_LARGE",
+      "DEATH_MOUNTAINROCKS_3",
+      "DEATH_MOUNTAINROCKS_3_LARGE",
+      "VIKING_ROCKSLIDE1",
+      "VIKING_ROCKSLIDE2",
+      "VIKING_ROCKSLIDE3",
+      "VIKING_ROCKSLIDE4",
+      "HORROR_ROCKSLIDE1",
+      "HORROR_ROCKSLIDE2",
+      "HORROR_ROCKSLIDE3",
+      "HORROR_ROCKSLIDE4",
+      "TROLLROMANCE_PISTE_TOP",
+      "TROLL_ROMANCE_ROCKNOBLOCK",
+      "TROLLRESCUE_ICY_ROCK_BIG",
+      "AHOY_SHIPWRECK_ROCKS",
+      "ROCK_POOL",
+      "ROCK_POOL_SMALL",
+      "ROCK_POOL_BITS",
+      "MDAUGHTER_CLIFF_BOULDER",
+      "MDAUGHTER_CLIFF_BOULDER_WITHROPE",
+      "MDAUGHTER_CLIFF_ROCK",
+      "MDAUGHTER_POLEROCKS",
+      "DWARF_ROCK_ROCKSLIDE1",
+      "DWARF_ROCK_ROCKSLIDE2",
+      "DWARF_ROCK_ROCKSLIDE3",
+      "DWARF_ROCK_ROCKSLIDE4",
+      "DWARF_ROCK_POOL",
+      "DWARF_ROCK_POOL_SMALL",
+      "DWARF_ROCK_POOL_BITS",
+      "ROCKSLIDE_GREY1",
+      "ROCKSLIDE_GREY2",
+      "ROCKSLIDE_GREY3",
+      "ROCKSLIDE_GREY4",
+      "ROCKSLIDE_LIGHTGREY4",
+      "MOLE_ROCKS_SMALL_01",
+      "MOLE_ROCKS_SMALL_02",
+      "MOLE_ROCKS_SMALL_03",
+      "SANDY_ROCK_POOL",
+      "ROCKSLIDE_MIDGREY1",
+      "ROCKSLIDE_MIDGREY2",
+      "ROCKSLIDE_MIDGREY3",
+      "ROCKSLIDE_MIDGREY4",
+      "SANDY_ROCK_POOL_SMALL",
+      "SANDY_ROCK_POOL_BITS",
+      "BURGH_ROCK1",
+      "BURGH_ROCK2",
+      "BURGH_ROCK3",
+      "BURGH_ROCK4",
+      "WILDERNESS_ROCKS_BIG_HARD_01",
+      "WILDERNESS_ROCKS_BIG_HARD_02",
+      "WILDERNESS_ROCKS_BIG_HARD_03",
+      "WILDERNESS_ROCKS_SMALL_HARD_01",
+      "WILDERNESS_ROCKS_SMALL_HARD_02",
+      "WILDERNESS_ROCKS_SMALL_HARD_03",
+      "WILDERNESS_ROCKS_BIG_SOFT_01",
+      "WILDERNESS_ROCKS_BIG_SOFT_02",
+      "WILDERNESS_ROCKS_BIG_SOFT_03",
+      "WILDERNESS_ROCKS_SMALL_SOFT_01",
+      "WILDERNESS_ROCKS_SMALL_SOFT_02",
+      "WILDERNESS_ROCKS_SMALL_SOFT_03",
+      "WILDERNESS_ROCKS_BIG_SHARP_01",
+      "WILDERNESS_ROCKS_BIG_SHARP_02",
+      "WILDERNESS_ROCKS_BIG_SHARP_03",
+      "WILDERNESS_ROCKS_SMALL_SHARP_01",
+      "WILDERNESS_ROCKS_SMALL_SHARP_02",
+      "WILDERNESS_ROCKS_SMALL_SHARP_03",
+      "ROYAL_ROCKS_1",
+      "ROYAL_ROCKS_1_LARGE",
+      "ROYAL_MINING_STONE_PICKAXE",
+      "ROYAL_MINING_STONE",
+      "ROYAL_SPADE",
+      "ROYAL_ROCK1",
+      "ROYAL_ROCK2",
+      "ROYAL_ROCK3",
+      "ROYAL_ROCK4",
+      "LOTR_MINE_ROCKS_BIG_01",
+      "LOTR_MINE_ROCKS_BIG_02",
+      "LOTR_MINE_ROCKS_BIG_03",
+      "LOTR_MINE_ROCKS_SMALL_02",
+      "LOTR_MINE_ROCKS_SMALL_03",
+      "AREA_SANGUINE_MINE_ROCKS_SMALL_01",
+      "AREA_SANGUINE_MINE_ROCKS_SMALL_02",
+      "AREA_SANGUINE_MINE_ROCKS_SMALL_03",
+      "HUNTING_DEADFALL_BOULDER",
+      "HUNTING_DEADFALL_SETTING",
+      "HUNTING_DEADFALL_TRAP",
+      "HUNTING_DEADFALL_TRAPPING_SPIKE",
+      "HUNTING_DEADFALL_TRAPPING_SPIKE_M",
+      "HUNTING_DEADFALL_TRAPPING_SABRE",
+      "HUNTING_DEADFALL_TRAPPING_BARBED",
+      "HUNTING_DEADFALL_TRAPPING_BARBED_M",
+      "HUNTING_DEADFALL_TRAPPING_CLAW",
+      "HUNTING_DEADFALL_FULL_SPIKE",
+      "HUNTING_DEADFALL_FULL_SABRE",
+      "HUNTING_DEADFALL_FULL_BARBED",
+      "HUNTING_DEADFALL_FULL_CLAW",
+      "HUNTING_DEADFALL_FAILING",
+      "BARROWS_MOUNTAINROCKS_1",
+      "BARROWS_MOUNTAINROCKS_1_LARGE",
+      "BARROWS_ROCKSLIDE1",
+      "BARROWS_ROCKSLIDE2",
+      "BARROWS_ROCKSLIDE3",
+      "BRAIN_ROCK_POOL",
+      "BRAIN_ROCK_POOL_SMALL",
+      "BRAIN_ROCK_POOL_BITS",
+      "SUROK_TUNNEL_ROCKS_SMALL_01",
+      "SUROK_TUNNEL_ROCKS_SMALL_02",
+      "SUROK_TUNNEL_ROCKS_SMALL_03",
+      "SLAYER_CAVE_POOLROCK_1",
+      "SLAYER_CAVE_POOLROCK_2",
+      "ARCHEUUS_RUNESTONE_SHORTCUT_GREY_TOP",
+      "ARCHEUUS_RUNESTONE_SHORTCUT_GREY_BOTTOM",
+      "ARCHEUUS_RUNESTONE_SHORTCUT_GREY_MIDDLE",
+      "ARCHEUUS_RUNESTONE_SHORTCUT_MIDGREY_TOP",
+      "ARCHEUUS_RUNESTONE_SHORTCUT_MIDGREY_BOTTOM",
+      "ARCHEUUS_RUNESTONE_SHORTCUT_MIDGREY_MIDDLE",
+      "ARCHEUUS_RUNESTONE_ROCKS_GREY",
+      "DS2_CORSAIR_COVE_ROCKS_SMALL_01",
+      "DS2_CORSAIR_COVE_ROCKS_SMALL_02",
+      "DS2_CORSAIR_COVE_ROCKS_SMALL_03",
+      "DS2_CORSAIR_COVE_ROCKS_BIG_01",
+      "DS2_CORSAIR_COVE_ROCKS_BIG_02",
+      "DS2_CORSAIR_COVE_ROCKS_BIG_03",
+      "DS2_CORSAIR_COVE_SHORTCUT",
+      "DS2_CORSAIR_SHORTCUT_BOTTOM",
+      "DS2_CORSAIR_SHORTCUT_TOP",
+      "DS2_CORSAIR_ROCKS",
+      "ARCQUEST_ROCKS_2_OP",
+      "ARCQUEST_ROCKS_2_NOOP",
+      "ARCHEUUS_RUNESTONE_SHORTCUT_GREY_SHORTCUT_NORTH",
+      "ROCKS_SEAROCK_SEAWEED01",
+      "ROCKS_SEAROCK_BARE01",
+      "ROCKS_SEAROCK_SEAWEED02",
+      "ROCKS_SEAROCK_BARE02",
+      "QUEST_START_ICON_DIGSITE",
+      "ROCKS_SEAROCK_BARE03",
+      "HUNTING_DEADFALL_TRAPPING_FENNEC",
+      "HUNTING_DEADFALL_TRAPPING_FENNEC_M",
+      "HUNTING_DEADFALL_FULL_FENNEC"
     ],
     "uvType": "BOX",
     "uvScale": 0.32
@@ -8228,17 +8228,17 @@
     "description": "Objects - Climbing Rocks - Medium",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      2231,
-      2232,
-      2233,
-      3724,
-      3748,
-      16521,
-      16522,
-      16523,
-      16524,
-      16464,
-      19065
+      "ZQCLIMBINGROCKS",
+      "ZQCLIMBINGROCKS_INACTIVE",
+      "ZQCLIMBINGROCKS_FALLOFF",
+      "DEATH_CLIMBINGROCKS_FALLOFF",
+      "TROLL_CLIMBINGROCKS",
+      "ASC_TROLL_MOUNTAIN_CLIMBROCK_1",
+      "ASC_TROLL_MOUNTAIN_CLIMBROCK_2",
+      "ASC_TROLL_MOUNTAIN_CLIMBROCK_3",
+      "ASC_TROLL_MOUNTAIN_CLIMBROCK_4",
+      "DIARY_TROLL_CLIMBINGROCKS",
+      "DIARY_TROLL_CLIMBINGROCKS_INACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -8247,16 +8247,16 @@
     "description": "Inconspicuous Rocks",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      16014,
-      16015,
-      16022,
-      16023,
-      28938,
-      28939,
-      28946,
-      28947,
-      28954,
-      28955
+      "HIDEY_UNBUILT_ROCK_EASY",
+      "HIDEY_ROCK_EASY",
+      "HIDEY_UNBUILT_ROCK_MEDIUM",
+      "HIDEY_ROCK_MEDIUM",
+      "HIDEY_UNBUILT_ROCK_HARD",
+      "HIDEY_ROCK_HARD",
+      "HIDEY_UNBUILT_ROCK_ELITE",
+      "HIDEY_ROCK_ELITE",
+      "HIDEY_UNBUILT_ROCK_MASTER",
+      "HIDEY_ROCK_MASTER"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -8266,16 +8266,16 @@
     "description": "Inconspicuous Crate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16016,
-      16017,
-      16024,
-      28933,
-      28940,
-      28941,
-      28948,
-      28949,
-      28956,
-      28957
+      "HIDEY_UNBUILT_CRATE_EASY",
+      "HIDEY_CRATE_EASY",
+      "HIDEY_UNBUILT_CRATE_MEDIUM",
+      "HIDEY_CRATE_MEDIUM",
+      "HIDEY_UNBUILT_CRATE_HARD",
+      "HIDEY_CRATE_HARD",
+      "HIDEY_UNBUILT_CRATE_ELITE",
+      "HIDEY_CRATE_ELITE",
+      "HIDEY_UNBUILT_CRATE_MASTER",
+      "HIDEY_CRATE_MASTER"
     ],
     "uvType": "BOX"
   },
@@ -8284,26 +8284,26 @@
     "baseMaterial": "ROCK_1",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      5847,
-      11425,
-      27899,
-      29856,
-      29857,
-      29858,
-      30519,
-      30521,
-      30522,
-      31781,
-      31782,
-      31785,
-      31786,
-      31787,
-      40552,
-      40553,
-      40554,
-      40555,
-      40556,
-      40557
+      "MDAUGHTER_ROCKSLIDE",
+      "SWAMP_MOSS_COVERED_ROCK_2",
+      "ARCHEUUS_ROCKS_GREEN_01",
+      "RAIDS_ROCKS_FLOOR1",
+      "RAIDS_ROCKS_FLOOR2",
+      "RAIDS_ROCKS_FLOOR3",
+      "HUNTING_TRAIL_SPAWN_FOSSIL1",
+      "HUNTING_TRAIL_SPAWN_FOSSIL3",
+      "HUNTING_TRAIL_SPAWN_FOSSIL4",
+      "DS2_OGRE_ROCKS_1X1_1",
+      "DS2_OGRE_ROCKS_1X1_2",
+      "DS2_OGRE_ROCKS_1X3_02",
+      "DS2_OGRE_ROCKS_2X1_01",
+      "DS2_OGRE_ROCKS_2X1_02",
+      "SNP_MOSS_ROCKS_SMALL_01",
+      "SNP_MOSS_ROCKS_SMALL_02",
+      "SNP_MOSS_ROCKS_SMALL_03",
+      "SNP_MOSS_ROCKS_BIG_01",
+      "SNP_MOSS_ROCKS_BIG_02",
+      "SNP_MOSS_ROCKS_BIG_03"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -8313,7 +8313,7 @@
     "description": "Objects - Mossy Rock - Rectangle",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      31784
+      "DS2_OGRE_ROCKS_1X3_01"
     ],
     "uvType": "BOX",
     "uvScale": 0.35
@@ -8322,9 +8322,9 @@
     "description": "Objects - Mossy Rock - Large",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      31783,
-      31788,
-      31789
+      "DS2_OGRE_ROCKS_1X1_3",
+      "DS2_OGRE_ROCKS_2X2_01",
+      "DS2_OGRE_ROCKS_2X2_02"
     ],
     "uvType": "BOX",
     "uvScale": 0.44
@@ -8333,8 +8333,8 @@
     "description": "Ground Decoration - Ash Pile - Small",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      14457,
-      14460
+      "WILDERNESS_ROCKS_FLOOR_SOFT_02",
+      "WILDERNESS_ROCKS_FLOOR_SOFT_05"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.9
@@ -8343,7 +8343,7 @@
     "description": "Objects - Ash Pile - Medium",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      30985
+      "FOSSIL_ASHPILE"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.5
@@ -8352,9 +8352,9 @@
     "description": "Objects - Seaweed Rock - Medium",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      25158,
-      25159,
-      25160
+      "DRAGON_SLAYER_QIP_SEAROCK_LARGE",
+      "DRAGON_SLAYER_QIP_SEAROCK_1",
+      "DRAGON_SLAYER_QIP_SEAROCK_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.25
@@ -8363,16 +8363,16 @@
     "description": "Ogre Benches",
     "baseMaterial": "STONE",
     "objectIds": [
-      3376
+      "CHOMPYBIRD_ROCKBENCH"
     ]
   },
   {
     "description": "Ground Decoration - Dirt Clump - Tiny - Uncolored",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      4343,
-      5520,
-      17227
+      "VIKING_DUGUPSOIL_BROWN_2",
+      "FAVOUR_DUGUPSOIL_2",
+      "EYEGLO_DUGUPSOIL_2"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.65,
@@ -8388,8 +8388,8 @@
     "description": "Ground Decoration - Dirt Clump - Tiny - Colored",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      185,
-      325
+      "DUGUPSOIL2_UPASS",
+      "DUGUPSOIL2_LIGHT2"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "WORLD_XZ",
@@ -8400,27 +8400,27 @@
     "description": "Ground Decoration - Dirt Clump - Small - Uncolored",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      186,
-      321,
-      4342,
-      4344,
-      5517,
-      5519,
-      5521,
-      11084,
-      11085,
-      11086,
-      11087,
-      11093,
-      11094,
-      11095,
-      11097,
-      11098,
-      17226,
-      17228,
-      18474,
-      18478,
-      22350
+      "DUGUPSOIL3_UPASS",
+      "DUGUPSOIL3_LIGHT",
+      "VIKING_DUGUPSOIL_BROWN_1",
+      "VIKING_DUGUPSOIL_BROWN_3",
+      "FAVOUR_ROCKSLIDE5",
+      "FAVOUR_DUGUPSOIL_1",
+      "FAVOUR_DUGUPSOIL_3",
+      "ENAKH_ROCK1",
+      "ENAKH_ROCK2",
+      "ENAKH_ROCK3",
+      "ENAKH_ROCK4",
+      "ENAKH_ROCK1_SMALL",
+      "ENAKH_ROCK2_SMALL",
+      "ENAKH_ROCK3_SMALL",
+      "ENAKH_MINING_STONE",
+      "ENAKH_MINING_STONE2",
+      "EYEGLO_DUGUPSOIL_1",
+      "EYEGLO_DUGUPSOIL_3",
+      "TOURTRAP_QIP_MINE_ROCKS_SMALL_02",
+      "TOURTRAP_QIP_MINE_ROCKS_BIG_03",
+      "BRAIN_MUD_DUGUPSOIL_06"
     ],
     "uvType": "BOX",
     "uvScale": 0.65,
@@ -8435,16 +8435,16 @@
     "description": "Ground Decoration - Dirt Clump - Small - Colored",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      324,
-      326,
-      2376,
-      2377,
-      2378,
-      11088,
-      11089,
-      11090,
-      11091,
-      11092
+      "DUGUPSOIL1_LIGHT2",
+      "DUGUPSOIL3_LIGHT2",
+      "DIGDUGUPSOIL1",
+      "DIGDUGUPSOIL2",
+      "DIGDUGUPSOIL3",
+      "ENAKH_ROCKSLIDE",
+      "ENAKH_ROCKSLIDE2",
+      "ENAKH_ROCK_DUGUPSOIL_1",
+      "ENAKH_ROCK_DUGUPSOIL_2",
+      "ENAKH_ROCK_DUGUPSOIL_3"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "BOX",
@@ -8454,24 +8454,24 @@
     "description": "Objects - Dirt Piles - Medium",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      2217,
-      2634,
-      5511,
-      5512,
-      5824,
-      10785,
-      11604,
-      11605,
-      11931,
-      11932,
-      11933,
-      11934,
-      18892,
-      18893,
-      18894,
-      18895,
-      25347,
-      25348
+      "AHZARHOON_ENTRANCE",
+      "HEROROCKSLIDE",
+      "FAVOUR_MOUNTAINROCKS",
+      "FAVOUR_MOUNTAINROCKS_LARGE",
+      "FAVOUR_NOBLOCK_ROCKS",
+      "ROCKSLIDE_SMALL3",
+      "FAI_BARBARIAN_ROCKS_1",
+      "FAI_BARBARIAN_ROCKS_1_LARGE",
+      "ROCKSLIDE_DBROWN1",
+      "ROCKSLIDE_DBROWN2",
+      "ROCKSLIDE_DBROWN3",
+      "ROCKSLIDE_DBROWN4",
+      "TOURTRAP_QIP_ROCKSLIDE1",
+      "TOURTRAP_QIP_ROCKSLIDE2",
+      "TOURTRAP_QIP_ROCKSLIDE3",
+      "TOURTRAP_QIP_ROCKSLIDE4",
+      "BRUT_SHORE_ROCKS1",
+      "BRUT_SHORE_ROCKS2"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -8480,14 +8480,14 @@
     "description": "Ground Decoration - Grunge - Tiny - Uncolored",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      320,
-      2382,
-      3709,
-      3949,
-      7106,
-      13831,
-      13832,
-      13833
+      "DUGUPSOIL2_LIGHT",
+      "SWAMP_DIGDUGUPSOIL2",
+      "DEATH_DUGUPSOIL_LIGHT_2",
+      "DUGUPSOIL2_BROWNMUD",
+      "FAI_VARROCK_PATHS_MUD_DUGUPSOIL_2",
+      "TEMPLETREK_SWAMP_EVADE_PATH",
+      "TEMPLETREK_SWAMP_SUCCESS_PATH",
+      "TEMPLETREK_SWAMP_FAIL_PATH"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.68,
@@ -8497,9 +8497,9 @@
     "description": "Ground Decoration - Grunge - Tiny - Colored",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      315,
-      729,
-      4340
+      "DUGUPSOIL2",
+      "SAND_DETAIL2",
+      "VIKING_DUGUPSOIL_2"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "WORLD_XZ",
@@ -8510,19 +8510,19 @@
     "description": "Ground Decoration - Grunge - Small - Uncolored",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      319,
-      3705,
-      3706,
-      3707,
-      3708,
-      3710,
-      3803,
-      3804,
-      3948,
-      3950,
-      12910,
-      12911,
-      12912
+      "DUGUPSOIL1_LIGHT",
+      "DEATH_DUGUPSOIL_DARK_1",
+      "DEATH_DUGUPSOIL_DARK_2",
+      "DEATH_DUGUPSOIL_DARK_3",
+      "DEATH_DUGUPSOIL_LIGHT_1",
+      "DEATH_DUGUPSOIL_LIGHT_3",
+      "TROLL_MOUNTAIN_SHORTCUT_CLIMBINGROCKS1",
+      "TROLL_MOUNTAIN_SHORTCUT_CLIMBINGROCKS2",
+      "DUGUPSOIL1_BROWNMUD",
+      "DUGUPSOIL3_BROWNMUD",
+      "BURGH_DUGUPSOIL_1",
+      "BURGH_DUGUPSOIL_2",
+      "BURGH_DUGUPSOIL_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.74
@@ -8531,15 +8531,15 @@
     "description": "Ground Decoration - Grunge - Small - Colored",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      728,
-      730,
-      4339,
-      4341,
-      4607,
-      4608,
-      7105,
-      7107,
-      11418
+      "SAND_DETAIL1",
+      "SAND_DETAIL3",
+      "VIKING_DUGUPSOIL_1",
+      "VIKING_DUGUPSOIL_3",
+      "HORROR_ROCKSLIDE5",
+      "HORROR_ROCKSLIDE6",
+      "FAI_VARROCK_PATHS_MUD_DUGUPSOIL_1",
+      "FAI_VARROCK_PATHS_MUD_DUGUPSOIL_3",
+      "PLAGUE_MUD"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "WORLD_XZ",
@@ -8549,9 +8549,9 @@
     "description": "Ground Decoration - Rock - Tiny - Colored",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      14501,
-      15630,
-      20295
+      "WILD6_DUGUPSOIL_2",
+      "DUGUPSOIL2_MACROMAZE",
+      "CONTACT_DUGUPSOIL_2"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "WORLD_XZ",
@@ -8562,13 +8562,13 @@
     "description": "Ground Decoration - Rock - Tiny - Uncolored",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      6398,
-      12050,
-      14486,
-      20762,
-      25834,
-      41517,
-      43627
+      "DUGUPSOIL2_VDARKBROWN",
+      "FAIRY_DUGUPSOIL_2",
+      "WILD2_DUGUPSOIL_2",
+      "BARROWS_DUGUPSOIL_2_PURPLE",
+      "KR_BKF_BASEMENT_DUGUPSOIL2",
+      "BIM_RUINS_DUGUPSOIL5",
+      "GOTR_DUGUPSOIL_2"
     ],
     "uvType": "WORLD_XZ",
     "uvOrientation": 512,
@@ -8579,17 +8579,17 @@
     "description": "Ground Decoration - Rock - Small - Colored",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      14500,
-      14502,
-      15629,
-      17864,
-      17865,
-      17868,
-      17869,
-      17870,
-      20294,
-      20296,
-      41514
+      "WILD6_DUGUPSOIL_1",
+      "WILD6_DUGUPSOIL_3",
+      "DUGUPSOIL1_MACROMAZE",
+      "AREA_SANGUINE_MINE_DUGUPSOIL_01",
+      "AREA_SANGUINE_MINE_DUGUPSOIL_02",
+      "AREA_SANGUINE_MINE_DUGUPSOIL_05",
+      "AREA_SANGUINE_MINE_DUGUPSOIL_06",
+      "AREA_SANGUINE_MINE_DUGUPSOIL_07",
+      "CONTACT_DUGUPSOIL_1",
+      "CONTACT_DUGUPSOIL_3",
+      "BIM_RUINS_DUGUPSOIL2"
     ],
     "inheritTileColorType": "OVERLAY",
     "uvType": "WORLD_XZ",
@@ -8599,60 +8599,60 @@
     "description": "Ground Decoration - Rock - Small - Uncolored",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      526,
-      527,
-      528,
-      529,
-      531,
-      2381,
-      2383,
-      6397,
-      6399,
-      7113,
-      7114,
-      7115,
-      7119,
-      12049,
-      12051,
-      12706,
-      14482,
-      14485,
-      17929,
-      17930,
-      17933,
-      20761,
-      20763,
-      22341,
-      22342,
-      23080,
-      23081,
-      23082,
-      23083,
-      23084,
-      25833,
-      25835,
-      41513,
-      41515,
-      41516,
-      43626,
-      43628,
-      43724,
-      43725,
-      43726,
-      43727,
-      43728,
-      44730,
-      44733,
-      44734,
-      44735,
-      44736,
-      46822,
-      46821,
-      49645,
-      49646,
-      49647,
-      49648,
-      49649
+      "FAI_VARROCK_RUBBLES1",
+      "FAI_VARROCK_RUBBLES2",
+      "FAI_VARROCK_RUBBLES3",
+      "FAI_VARROCK_RUBBLES4",
+      "FAI_VARROCK_RUBBLES_LARGE",
+      "SWAMP_DIGDUGUPSOIL1",
+      "SWAMP_DIGDUGUPSOIL3",
+      "DUGUPSOIL1_VDARKBROWN",
+      "DUGUPSOIL3_VDARKBROWN",
+      "FAI_VARROCK_DUGUPSOIL_01",
+      "FAI_VARROCK_DUGUPSOIL_02",
+      "FAI_VARROCK_DUGUPSOIL_03",
+      "FAI_VARROCK_DUGUPSOIL_07",
+      "FAIRY_DUGUPSOIL_1",
+      "FAIRY_DUGUPSOIL_3",
+      "_100_GOBLINDUGUPSOIL3_SOOT",
+      "WILD1_DUGUPSOIL_1",
+      "WILD2_DUGUPSOIL_1",
+      "MYQ3_LAB_ROCKS_FLOOR_SOFT_01",
+      "MYQ3_LAB_ROCKS_FLOOR_SOFT_02",
+      "MYQ3_LAB_ROCKS_FLOOR_SOFT_05",
+      "BARROWS_DUGUPSOIL_1_PURPLE",
+      "BARROWS_DUGUPSOIL_3_PURPLE",
+      "BRAIN_ROCK_DUGUPSOIL_02",
+      "BRAIN_ROCK_DUGUPSOIL_03",
+      "SUROK_TUNNEL_DUGUPSOIL_01",
+      "SUROK_TUNNEL_DUGUPSOIL_02",
+      "SUROK_TUNNEL_DUGUPSOIL_03",
+      "SUROK_TUNNEL_DUGUPSOIL_04",
+      "SUROK_TUNNEL_DUGUPSOIL_05",
+      "KR_BKF_BASEMENT_DUGUPSOIL1",
+      "KR_BKF_BASEMENT_DUGUPSOIL3",
+      "BIM_RUINS_DUGUPSOIL1",
+      "BIM_RUINS_DUGUPSOIL3",
+      "BIM_RUINS_DUGUPSOIL4",
+      "GOTR_DUGUPSOIL_1",
+      "GOTR_DUGUPSOIL_3",
+      "GOTR_AGILITY_SHORTCUT_TOP",
+      "GOTR_AGILITY_SHORTCUT_MIDDLE",
+      "GOTR_AGILITY_SHORTCUT_BOTTOM",
+      "GOTR_AGILITY_SHORTCUT_TOP_NOOP",
+      "GOTR_AGILITY_SHORTCUT_BOTTOM_NOOP",
+      "GIANTS_FOUNDRY_DUGUPSOIL_01",
+      "GIANTS_FOUNDRY_DUGUPSOIL_04",
+      "GIANTS_FOUNDRY_DUGUPSOIL_05",
+      "GIANTS_FOUNDRY_DUGUPSOIL_06",
+      "GIANTS_FOUNDRY_DUGUPSOIL_07",
+      "MY2ARM_CAVE_ROCKS02",
+      "MY2ARM_CAVE_ROCKS01",
+      "POG_DUGUPSOIL_02",
+      "POG_DUGUPSOIL_03",
+      "POG_DUGUPSOIL_04",
+      "POG_DUGUPSOIL_05",
+      "POG_DUGUPSOIL_06"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.74
@@ -8661,12 +8661,12 @@
     "description": "barbarian - Walls - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      9587,
-      9588,
-      11558,
-      11559,
-      11560,
-      11561
+      "DWARF_HUT_WALL",
+      "DWARF_HUT_WALL_WINDOW",
+      "FAI_BARBARIAN_ABODE_WALL",
+      "FAI_BARBARIAN_ABODE_WINDOW",
+      "FAI_BARBARIAN_ABODE_WINDOW_SHORTER",
+      "FAI_BARBARIAN_ABODE_WALL_SHORTER"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -8676,9 +8676,9 @@
     "description": "Barbarian Hall - Walls - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      11562,
-      11563,
-      11564
+      "FAI_BARBARIAN_LONGHALL_WALL",
+      "FAI_BARBARIAN_LONGHALL_WALL_SUPPORT",
+      "FAI_BARBARIAN_LONGHALL_WALL_WINDOW"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -8688,13 +8688,13 @@
     "description": "Barbarian Hall - Roof - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      9590,
-      9591,
-      11565,
-      11566,
-      11567,
-      11568,
-      11878
+      "DWARFHUT_WOODEN_ROOF",
+      "DWARFHUT_WOODEN_ROOF1",
+      "FAI_BARBARIAN_LONGHALL_ROOF1",
+      "FAI_BARBARIAN_LONGHALL_ROOF2",
+      "FAI_BARBARIAN_LONGHALL_ROOF3",
+      "FAI_BARBARIAN_LONGHALL_ROOF4",
+      "FAI_DWARFHUT_WOODEN_ROOF2"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -8704,25 +8704,25 @@
     "description": "Barbarian Hall - Roof Corners - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      9593,
-      9594,
-      11569,
-      11570,
-      11571,
-      11572,
-      11573,
-      11574,
-      11576,
-      11577,
-      11578,
-      11579,
-      11580,
-      11581,
-      11582,
-      11583,
-      11584,
-      11879,
-      11880
+      "DWARFHUT_WOODEN_ROOF_EDGE",
+      "DWARFHUT_WOODEN_ROOF_EDGE_MIRROR",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE1",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE2",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE3",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE4",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE1_MIRROR",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE2_MIRROR",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE4_MIRROR",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE1_NEW",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE1_NEW_MIRROR",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE2_NEW",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE2_NEW_MIRROR",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE3_NEW",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE3_NEW_MIRROR",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE4_NEW",
+      "FAI_BARBARIAN_LONGHALL_ROOF_EDGE4_NEW_MIRROR",
+      "DWARFHUT_WOODEN_ROOF_EDGE_2",
+      "DWARFHUT_WOODEN_ROOF_EDGE_2_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -8733,15 +8733,15 @@
     "description": "Round Rug",
     "baseMaterial": "CARPET",
     "objectIds": [
-      2455,
-      2456,
-      2457,
-      4687,
-      4688,
-      4689,
-      25124,
-      25125,
-      25126
+      "FAI_VARROCK_GYPSY_RUG1",
+      "FAI_VARROCK_GYPSY_RUG2",
+      "FAI_VARROCK_GYPSY_RUG3",
+      "MISC_RUGCORNER",
+      "MISC_RUGSIDE",
+      "MISC_RUGMIDDLE",
+      "DRAGON_SLAYER_QIP_RUG_CENTRE",
+      "DRAGON_SLAYER_QIP_RUG_EDGE",
+      "DRAGON_SLAYER_QIP_RUG_CORNER"
     ],
     "uvType": "WORLD_XZ",
     "flatNormals": true
@@ -8750,9 +8750,9 @@
     "description": "PHASMATYS - Stone - Walls",
     "baseMaterial": "STONE",
     "objectIds": [
-      5452,
-      5361,
-      5362
+      "AHOY_TOWN_WALL_STANDARDWALL",
+      "AHOY_TOWER_EXTERIOR_WALL",
+      "AHOY_TOWER_EXTERIOR_WALL_LVL2"
     ],
     "flatNormals": true
   },
@@ -8760,11 +8760,11 @@
     "description": "PHASMATYS - House - Walls",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      5440,
-      5441,
-      5442,
-      5443,
-      5444
+      "AHOY_HARBOURWALLS",
+      "AHOY_HARBOURWALL_CRUMBLY_1",
+      "AHOY_HARBOURWALL_CRUMBLY_2",
+      "AHOY_HARBOURWALL_CRUMBLY_1_MIRROR",
+      "AHOY_HARBOURWALL_CRUMBLY_2_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.83
@@ -8773,9 +8773,9 @@
     "description": "PHASMATYS - Stone - Rubble - Small",
     "baseMaterial": "STONE",
     "objectIds": [
-      5301,
-      5302,
-      5303
+      "POOR_ROOF_TILEPILE1",
+      "POOR_ROOF_TILEPILE2",
+      "POOR_ROOF_TILEPILE3"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.76
@@ -8784,20 +8784,20 @@
     "description": "PHASMATYS - Stone - Rubble - Medium",
     "baseMaterial": "STONE",
     "objectIds": [
-      5447,
-      5448
+      "AHOY_HARBOURWALL_CRUMBLY_PILE_1",
+      "AHOY_HARBOURWALL_CRUMBLY_PILE_2"
     ]
   },
   {
     "description": "Stone - Steps",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      5307,
-      5460,
-      20436,
-      30599,
-      30600,
-      30601
+      "AHOY_SKEWSTEPS",
+      "AHOY_WOOD_SKEWSTEPS",
+      "LOTR_SKEWSTEPS1_UPASS",
+      "FOSSILQUEST_SKEWSTEPS",
+      "FOSSILQUEST_SKEWSTEPS1",
+      "FOSSILQUEST_SKEWSTEPS2"
     ],
     "uvType": "BOX",
     "uvOrientation": 602,
@@ -8807,7 +8807,7 @@
     "description": "Stone - Stairs - Stone Brick",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      16646
+      "AHOY_TOWER_STAIRS_LV1"
     ],
     "uvType": "VANILLA"
   },
@@ -8815,23 +8815,23 @@
     "description": "Phasmatys - Slime",
     "baseMaterial": "SLIME_GRUNGE",
     "objectIds": [
-      5377,
-      5378,
-      5379,
-      5380,
-      5381,
-      5382,
-      5383
+      "AHOY_ECTO_WALLDECOR1",
+      "AHOY_ECTO_WALLDECOR2",
+      "AHOY_ECTO_WALLDECOR3",
+      "AHOY_ECTO_WALLDECOR4",
+      "AHOY_ECTO_WALLDECOR_CRUMBLY1",
+      "AHOY_ECTO_WALLDECOR_CRUMBLY2",
+      "AHOY_ECTO_WALLDECOR_CRUMBLY1_MIRROR"
     ]
   },
   {
     "description": "Objects - Swamp Root - Small",
     "baseMaterial": "BARK",
     "objectIds": [
-      1366,
-      1367,
-      1368,
-      3960
+      "SWAMP_ROOTS_1",
+      "SWAMP_ROOTS_2",
+      "SWAMP_ROOTS_3",
+      "REGICIDE_SWAMP_ROOT3"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -8841,10 +8841,10 @@
     "description": "Objects - Swamp Root - Large",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      1363,
-      1364,
-      3958,
-      3959
+      "LARGE_SWAMP_ROOT",
+      "SWAMP_ROOT",
+      "REGICIDE_SWAMP_ROOT1",
+      "REGICIDE_SWAMP_ROOT2"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -8854,8 +8854,8 @@
     "description": "Fence Gate - Static",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      44922,
-      44923
+      "PVPA_ACCESS_GATE_L_OPEN",
+      "PVPA_ACCESS_GATE_R_OPEN"
     ],
     "flatNormals": true
   },
@@ -8863,58 +8863,58 @@
     "description": "Objects - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2620,
-      5106,
-      5107,
-      5110,
-      5113,
-      5115,
-      5330,
-      7514,
-      10374,
-      10378,
-      10379,
-      10381,
-      11331,
-      11228,
-      12442,
-      12443,
-      14395,
-      15692,
-      16251,
-      16252,
-      16560,
-      16561,
-      16887,
-      17305,
-      17655,
-      17656,
-      17657,
-      17658,
-      17905,
-      17906,
-      17907,
-      17908,
-      20429,
-      20430,
-      24344,
-      24088,
-      25655,
-      25660,
-      25661,
-      25836,
-      25837,
-      27754,
-      27756,
-      34508,
-      34510,
-      41452,
-      41738,
-      42066,
-      44854,
-      49641,
-      49642,
-      55048
+      "GERTRUDEEMPTY_CRATE",
+      "FAI_VARROCK_LARGE_CRATE",
+      "FAI_VARROCK_LARGE_CRATES",
+      "FAI_VARROCK_SMALL_CRATES",
+      "FAI_VARROCK_RED_CRATE",
+      "FAI_VARROCK_GREEN_CRATE",
+      "AHOY_BOXES_1",
+      "FARMING_CRATE",
+      "FARMING_CRATES",
+      "ELID_CRATE",
+      "ELID_CRATES",
+      "ELID_SMALL_CRATES",
+      "FEVER_CRATES_STACKED",
+      "FEVER_CRATE",
+      "GOBLIN_OUTPOST_LARGE_CRATE",
+      "GOBLIN_OUTPOST_LARGE_CRATES",
+      "DWARF_KELDAGRIM_WOODEN_BOXES_NO_OPS",
+      "AIDE_CRATES_STACKED",
+      "FAIRY_CRATE_2_BLUE",
+      "FAIRY_CRATE_BLUE",
+      "GOBLIN_OUTPOST_LARGE_CRATE_ARMOUR2",
+      "GOBLIN_OUTPOST_LARGE_CRATE_ARMOUR3",
+      "LUNAR_PIRATE_WOODENCHEST",
+      "QIP_DIGSITE_CRATE_STACKED",
+      "MYQ3_HIDEOUT_CRATES_SMALL",
+      "MYQ3_HIDEOUT_CRATES_2",
+      "MYQ3_HIDEOUT_CRATES_SMALL2",
+      "MYQ3_HIDEOUT_CRATE",
+      "MYQ3_LAB_CRATES_SMALL",
+      "MYQ3_LAB_CRATES_2",
+      "MYQ3_LAB_CRATES_SMALL2",
+      "MYQ3_LAB_CRATE",
+      "LOTR_MINE_CRATE",
+      "LOTR_MINE_CRATE_STACKED",
+      "CANAFIS_CRATE",
+      "FAI_FALADOR_SMALL_CRATES",
+      "KR_MERLINCRATE_EMPTY2",
+      "KR_UNDERGROUND_JAIL_CRATE",
+      "KR_UNDERGROUND_JAIL_CRATES_STACKED",
+      "KR_BKF_BASEMENT_CRATE",
+      "KR_BKF_BASEMENT_CRATES_STACKED",
+      "PISCARILIUS_CRATE_01",
+      "PISCARILIUS_CRATE_03",
+      "FGUILD_BOOK_HERBS_LOC",
+      "FGUILD_BOOK_FRUIT_LOC",
+      "BIM_SUPPLY_CRATE_2",
+      "FAI_VARROCK_LARGE_CRATE_INACTIVE",
+      "SHAYZIEN_CRATE_01_DARK",
+      "ARENA_DESERT01_CRATE01",
+      "POG_CRATE",
+      "POG_CRATES_STACKED",
+      "CRATE_ALDARIN01_SINGLE01"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -8923,27 +8923,27 @@
     "description": "Objects - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1,
-      3813,
-      3814,
-      3815,
-      6176,
-      6177,
-      9533,
-      12961,
-      12977,
-      12978,
-      15030,
-      15599,
-      15600,
-      17033,
-      20367,
-      25775,
-      25776,
-      25928,
-      30810,
-      30812,
-      30814
+      "MCANNONCRATEBOY",
+      "EADGAR_TROLL_CRATE",
+      "EADGAR_TROLL_CRATES",
+      "EADGAR_TROLL_CRATES_2",
+      "DWARF_KELDAGRIM_WOODEN_BOXES",
+      "DWARF_KELDAGRIM_CRATE",
+      "SARIM_CRATE",
+      "QIP_COOK_CRATE",
+      "QIP_SHEEP_SHEARER_CRATE_SINGLE",
+      "QIP_SHEEP_SHEARER_CRATE_STACKED",
+      "POTATO_CRATE",
+      "MCANNON_CRATES2",
+      "MCANNON_CRATES3",
+      "XBOWS_DWARF_MARKET_CRATE",
+      "CONTACT_CRATE_SINGLE",
+      "KR_CRATE",
+      "KR_CRATES",
+      "KR_SEERS_TABLE",
+      "FOSSIL_CRATE1",
+      "FOSSIL_CRATE3",
+      "FOSSIL_CRATE_STACKED"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -8953,28 +8953,28 @@
     "description": "Objects - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2071,
-      3394,
-      3395,
-      3398,
-      3400,
-      3401,
-      9534,
-      9064,
-      10662,
-      11485,
-      11486,
-      12547,
-      12548,
-      15031,
-      14739,
-      18506,
-      18507,
-      27223,
-      27224,
-      27225,
-      27757,
-      41450
+      "GROCERYCRATE",
+      "ELEMENTAL_WORKSHOP_BOX_1",
+      "ELEMENTAL_WORKSHOP_BOX_2",
+      "ELEMENTAL_WORKSHOP_BOX_5",
+      "ELEMENTAL_WORKSHOP_BOX_7",
+      "ELEMENTAL_WORKSHOP_BOX_8",
+      "SARIM_CRATE2",
+      "ROGUETRADER_ALI_M_CRATE",
+      "SNAKEBOSS_CRATE",
+      "DRAYNOR_CRATE",
+      "DRAYNOR_CRATES",
+      "FAI_WIZTOWER_CRATE2",
+      "FAI_WIZTOWER_CRATE3",
+      "CABBAGE_CRATE",
+      "WILD_CRATE",
+      "ELEM_CRATE_1",
+      "ELEM_CRATE_2",
+      "SHAYZIEN_CRATE_01",
+      "SHAYZIEN_CRATE_02",
+      "SHAYZIEN_CRATE_03",
+      "PISCARILIUS_CRATE_04",
+      "BIM_SUPPLY_CRATE"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -8985,11 +8985,11 @@
     "description": "Objects - Wooden - Crate - Angled",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      9535,
-      27755,
-      34509,
-      41739,
-      42069
+      "SARIM_CRATE3",
+      "PISCARILIUS_CRATE_02",
+      "FGUILD_BOOK_TREES_LOC",
+      "FAI_VARROCK_LARGE_CRATES_INACTIVE",
+      "SHAYZIEN_CRATE_02_INACTIVE_DARK"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -9000,7 +9000,7 @@
   {
     "description": "Objects - Wooden - Open Crate",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 16888, 22277 ],
+    "objectIds": [ "LUNAR_PIRATE_WOODENCHEST_OPEN", "BRAIN_BOAT_LOC_CRATE" ],
     "uvType": "BOX",
     "flatNormals": true,
     "uvOrientationX": 512,
@@ -9010,11 +9010,11 @@
     "description": "Objects - Wooden - Stack of crates",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      6178,
-      9536,
-      12545,
-      12963,
-      14741
+      "DWARF_KELDAGRIM_CRATES",
+      "SARIM_BOXES",
+      "FAI_WIZTOWER_BOXES",
+      "QIP_COOK_CRATE_STACKED",
+      "WILD_SMALL_CRATES"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -9026,15 +9026,15 @@
     "description": "Objects - Wooden - Stack of crates - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      3397,
-      3399,
-      7513,
-      14742,
-      15693,
-      18508,
-      42068,
-      42070,
-      55049
+      "ELEMENTAL_WORKSHOP_BOX_4",
+      "ELEMENTAL_WORKSHOP_BOX_6",
+      "FARMING_SMALL_CRATES",
+      "WILD_CRATE_PILE",
+      "AIDE_SMALL_CRATES",
+      "ELEM_CRATE_3",
+      "SHAYZIEN_CRATE_02_DARK",
+      "SHAYZIEN_CRATE_03_DARK",
+      "CRATE_ALDARIN01_STACK01"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -9046,8 +9046,8 @@
     "description": "Objects - Wooden - Boxes",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      10380,
-      20369
+      "ELID_BOXES",
+      "CONTACT_CRATE_MANY"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -9056,11 +9056,11 @@
     "description": "Stacks of wooden boxes - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      5111,
-      11487,
-      15598,
-      24087,
-      40284
+      "FAI_VARROCK_BOXES",
+      "DRAYNOR_BOXES",
+      "MCANNON_CRATES",
+      "FAI_FALADOR_BOXES",
+      "FAI_FALADOR_BOXES_NOOP"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -9071,7 +9071,7 @@
   {
     "description": "Objects - Wooden - Doublewide Crate",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 16863, 16864, 16865 ],
+    "objectIds": [ "LUNAR_PIRATE_CRATE_LONG_HIGH", "LUNAR_PIRATE_CRATE_LONG_SMALL_ONTOP", "LUNAR_PIRATE_CRATE_LONG" ],
     "uvType": "BOX",
     "uvOrientationZ": 512,
     "uvOrientationX": 512,
@@ -9081,8 +9081,8 @@
     "description": "Fossil Island - Objects - Wooden - Boxes",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      30816,
-      30817
+      "FOSSIL_BOXES1",
+      "FOSSIL_BOXES2"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -9094,11 +9094,11 @@
     "description": "Wall - Decoration - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      10130,
-      10131,
-      10132,
-      10133,
-      10134
+      "DEAL_WINDOW_BOARD1",
+      "DEAL_WINDOW_BOARD2",
+      "DEAL_WINDOW_BOARD3",
+      "DEAL_WINDOW_BOARD4",
+      "DEAL_WINDOW_BOARD5"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -9108,7 +9108,7 @@
     "description": "Wooden Crate",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      22426
+      "BRAIN_MILL_CRATE"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -9117,8 +9117,8 @@
     "description": "Wooden Crate - Rotated Texture 90 Degrees",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      16564,
-      16565
+      "AGGIE_COURTYARD_CRATE",
+      "AGGIE_COURTYARD_CRATES_STACKED"
     ],
     "uvOrientation": 512,
     "uvScale": 0.75,
@@ -9128,7 +9128,7 @@
     "description": "Wooden Crate - Stacked with Mismatching Top Faces",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      10161
+      "DEAL_BOXES"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -9138,7 +9138,7 @@
     "description": "Objects - Wooden - Barrel with Metal Band",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      16566
+      "AGGIE_COURTYARD_BARREL"
     ],
     "uvOrientation": 100,
     "uvType": "BOX",
@@ -9153,10 +9153,10 @@
     "description": "Metallic - Ground - Armor",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      825,
-      826,
-      827,
-      828
+      "DAMAGEDARMOUR1",
+      "DAMAGEDARMOUR2",
+      "DAMAGEDARMOUR3",
+      "DAMAGEDARMOUR4"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -9166,19 +9166,19 @@
     "description": "Objects - Metallic - Chair - Broken",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      19929
+      "EP_CHAIR_BROKEN01"
     ]
   },
   {
     "description": "Objects - Metallic - Range",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      114,
-      7183,
-      7184,
-      25730,
-      40149,
-      40164
+      "COOKSQUESTRANGE",
+      "FAI_VARROCK_RANGE",
+      "FAI_VARROCK_RANGE_WITH_PIPE",
+      "KR_SIN_RANGE",
+      "CON_CONTRACT_FALADOR_SOUTH_RANGE_FIXED",
+      "CON_CONTRACT_ARDY_WEST_HOTSPOT1"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -9187,14 +9187,14 @@
     "description": "Wall - Decoration - Metallic - Sword and Shield",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      10515
+      "ELID_WALLSHIELD"
     ]
   },
   {
     "description": "Wall - Wooden - Post",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      10106
+      "DEAL_SUPPORT_WALL"
     ],
     "uvScale": 0.4,
     "uvType": "BOX",
@@ -9205,15 +9205,15 @@
     "description": "Objects - Metallic - Pots",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      5609,
-      5610,
-      6179,
-      6180,
-      10504,
-      10505,
-      17561,
-      17562,
-      17647
+      "POTSANDPANS1",
+      "POTSANDPANS2",
+      "DWARF_KELDAGRIM_POTSANDPANS1",
+      "DWARF_KELDAGRIM_POTSANDPANS2",
+      "ELID_POTSANDPANS1",
+      "ELID_POTSANDPANS2",
+      "AREA_SANGUINE_GHETTO_POTS1",
+      "AREA_SANGUINE_GHETTO_POTS2",
+      "MYQ3_SICKLE_LOGO_WALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -9223,7 +9223,7 @@
     "description": "Objects - Metallic - Panning Tray",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      17560
+      "AREA_SANGUINE_GHETTO_PANNINGTRAY2"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -9232,7 +9232,7 @@
     "description": "Objects - Metallic - Iron Billets",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      2140
+      "FAI_VARROCK_IRON_PILE"
     ],
     "uvType": "BOX"
   },
@@ -9240,7 +9240,7 @@
     "description": "Ground - Wooden - Plank Steps",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      4303
+      "VIKING_WOOD_SKEWSTEPS"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -9250,38 +9250,38 @@
     "description": "Walls - Stone - Giants Foundry",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      44639,
-      44640,
-      44641,
-      44642,
-      44644,
-      44645,
-      44646,
-      44647,
-      44648,
-      44649,
-      44650,
-      44651,
-      44652,
-      44681,
-      44682,
-      44684,
-      44713,
-      44714,
-      44715,
-      44717,
-      44719,
-      44720,
-      44751,
-      44752,
-      44753,
-      44754,
-      44755,
-      44756,
-      44757,
-      44758,
-      44759,
-      44760
+      "GIANTS_FOUNDRY_WALL_LVL0",
+      "GIANTS_FOUNDRY_WALL_LVL0_CAVETOP01",
+      "GIANTS_FOUNDRY_WALL_LVL1",
+      "GIANTS_FOUNDRY_WALL_LVL1_CAVETOP01",
+      "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP02",
+      "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP03",
+      "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP04",
+      "GIANTS_FOUNDRY_WALL_LVL0_LAVA",
+      "GIANTS_FOUNDRY_WALL_LVL0_LAVA_CONNECT",
+      "GIANTS_FOUNDRY_WALL_LVL0_LAVA_CONNECT_MIRROR",
+      "GIANTS_FOUNDRY_WALL_LVL0_WATER",
+      "GIANTS_FOUNDRY_WALL_LVL0_WATER_TRANS",
+      "GIANTS_FOUNDRY_WALL_LVL0_WATER_TRANS_M",
+      "GIANTS_FOUNDRY_EXIT_NOOP",
+      "GIANTS_FOUNDRY_EXIT_NOOP_STONE",
+      "GIANTS_FOUNDRY_ARCH01",
+      "GIANTS_FOUNDRY_PLATFORM_WALL01",
+      "GIANTS_FOUNDRY_PLATFORM_WALL02",
+      "GIANTS_FOUNDRY_PLATFORM_ARCH01",
+      "GIANTS_FOUNDRY_PLATFORM_ARCH02",
+      "GIANTS_FOUNDRY_PLATFORM_TUNNEL01",
+      "GIANTS_FOUNDRY_PLATFORM_TUNNEL02",
+      "GIANTS_FOUNDRY_WATERFALL_WALL_FADE01",
+      "GIANTS_FOUNDRY_WATERFALL_WALL_FADE02",
+      "GIANTS_FOUNDRY_WATERFALL_WALL_FADE03",
+      "GIANTS_FOUNDRY_WALL_LVL1_CAVETOP01_FADE01",
+      "GIANTS_FOUNDRY_WALL_LVL1_CAVETOP01_FADE02",
+      "GIANTS_FOUNDRY_WALL_LVL1_CAVETOP01_FADE03",
+      "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP02_FADE01",
+      "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP02_FADE02",
+      "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP02_FADE03",
+      "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP04_FADE01"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -9291,8 +9291,8 @@
     "description": "Ground Decoration - Flat Stone - Small - Uncolored",
     "baseMaterial": "SNOW_3",
     "objectIds": [
-      5850,
-      5851
+      "MDAUGHTER_FLATSTONE1",
+      "MDAUGHTER_FLATSTONE2"
     ],
     "uvType": "WORLD_XZ"
   },
@@ -9300,15 +9300,15 @@
     "description": "Walls - Grunge - Generic",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      4374
+      "DEATH_CAVEWALL_FACE1_NOMINIMAP"
     ]
   },
   {
     "description": "Objects - Stone - Dwarf Statues",
     "baseMaterial": "STONE",
     "objectIds": [
-      7002,
-      7003
+      "DWARF_KELDAGRIM_BIG_STATUE_CRUMBLE_ENTRANCE_TO",
+      "DWARF_KELDAGRIM_BIG_STATUE_CRUMBLE_ENTRANCE_TO_MIRROR"
     ],
     "flatNormals": true
   },
@@ -9316,24 +9316,24 @@
     "description": "Objects - Stone - Stalagmite",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      4600,
-      4602,
-      5231,
-      5232,
-      15813,
-      15814,
-      17876,
-      17877,
-      42263,
-      42264,
-      43874,
-      43875,
-      44744,
-      44745,
-      46408,
-      46409,
-      50928,
-      50929
+      "HORROR_STALAGMITE_TWIN_GREY",
+      "HORROR_STALAGMITE_SMALL_GREY",
+      "FENK_STAGAMITE_LARGE",
+      "FENK_STAGAMITE_SMALL",
+      "LOTR_MINE_STALAGTITE_01",
+      "LOTR_MINE_STALAGTITE_02",
+      "AREA_SANGUINE_MINE_STALAGTITE_01",
+      "AREA_SANGUINE_MINE_STALAGTITE_02",
+      "STALAGMITE_ROCK01_DEFAULT01",
+      "STALAGMITE_ROCK01_DEFAULT02",
+      "STALAGMITE_ROCK01_TOP01",
+      "STALAGMITE_ROCK01_TOP02",
+      "GIANTS_FOUNDRY_STALAGTITE_01",
+      "GIANTS_FOUNDRY_STALAGTITE_02",
+      "TGOD_GARDEN_TEMPLE_STALAGTITE_01",
+      "TGOD_GARDEN_TEMPLE_STALAGTITE_02",
+      "STALAGMITE_ROCK01_DEFAULT01_DARK02",
+      "STALAGMITE_ROCK01_DEFAULT02_DARK02"
     ],
     "uvType": "BOX"
   },
@@ -9341,8 +9341,8 @@
     "description": "Objects - Stone - Mountain Daughter Burial",
     "baseMaterial": "STONE",
     "objectIds": [
-      5862,
-      5863
+      "MDAUGHTER_BURIALMOUND",
+      "MDAUGHTER_BURIALCAIRN"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -9350,7 +9350,7 @@
     "description": "Mortton - Objects - Stone - Funeral Pyre",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      4093
+      "TEMPLE_PYRE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -9359,7 +9359,7 @@
     "description": "Mortton - Objects - Stone - Stone Stand",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      4065
+      "PYRE_STAND"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -9371,7 +9371,7 @@
     "description": "Mortton - Objects - Stone - Temple Walls",
     "baseMaterial": "STONE",
     "objectIds": [
-      4089
+      "TEMPLEWALLCORNER_10"
     ],
     "uvType": "MODEL_XY"
   },
@@ -9379,7 +9379,7 @@
     "description": "Mortton - Objects - Stone - Temple Walls - Mirrored",
     "baseMaterial": "STONE",
     "objectIds": [
-      4078
+      "TEMPLEWALL_10"
     ],
     "uvType": "MODEL_XY_MIRROR_B"
   },
@@ -9387,13 +9387,13 @@
     "description": "Mortton Shade Catacombs - Walls - Stone",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      17900,
-      17901,
-      38020,
-      38021,
-      38023,
-      38024,
-      40470
+      "MYQ3_LAB_WALL",
+      "MYQ3_LAB_WALL_EXPOSED_PLASTER",
+      "MYQ5_WALL_JOIN_R",
+      "MYQ5_WALL_JOIN_L",
+      "MYQ5_WALL_CAVE_SUPPORT_RIGHT",
+      "MYQ5_WALL_CAVE_SUPPORT_LEFT",
+      "MYQ5_WALL_CAVE_MID"
     ],
     "uvType": "MODEL_XY",
     "uvScale": 0.46,
@@ -9403,14 +9403,14 @@
     "description": "Mortton Shade Catacombs  - Walls - Metallic - Doors",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      4106,
-      4107,
-      4108,
-      4109,
-      18147,
-      18148,
-      18149,
-      18150
+      "SHADELAIR_BRONZEDOOR",
+      "SHADELAIR_STEELDOOR",
+      "SHADELAIR_BLACKDOOR",
+      "SHADELAIR_SILVERDOOR",
+      "SHADELAIR_BRONZEDOOR_INACTIVE",
+      "SHADELAIR_STEELDOOR_INACTIVE",
+      "SHADELAIR_BLACKDOOR_INACTIVE",
+      "SHADELAIR_SILVERDOOR_INACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -9419,8 +9419,8 @@
     "description": "Mortton Shade Catacombs  - Objects - Stone - Grave Stone",
     "baseMaterial": "STONE",
     "objectIds": [
-      40471,
-      40472
+      "TEMPLE_COFFIN_2X1",
+      "TEMPLE_COFFIN_2X2"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9428,7 +9428,7 @@
     "description": "Mortton Shade Catacombs  - Objects - Stone - Altar",
     "baseMaterial": "STONE",
     "objectIds": [
-      41222
+      "SHADE_LAIR_TEMPLE_ALTAR"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9436,18 +9436,18 @@
     "description": "Ground Decoration - Mortton Catacombs & Sisterhood Sanctuary - Rock Light - Small - Uncolored",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      37800,
-      37801,
-      37802,
-      37803,
-      37804,
-      37805,
-      37806,
-      37807,
-      37808,
-      37809,
-      37862,
-      37863
+      "SANCTUARY_CAVE_EDGE_HALF1",
+      "SANCTUARY_CAVE_EDGE_HALF2",
+      "SANCTUARY_CAVE_EDGE_FULL1",
+      "SANCTUARY_CAVE_EDGE_FULL2",
+      "SANCTUARY_CAVE_EDGE_JOIN1",
+      "SANCTUARY_CAVE_EDGE_JOIN2",
+      "SANCTUARY_CAVE_CORNER_SMALL",
+      "SANCTUARY_CAVE_CORNER_INNER",
+      "SANCTUARY_CAVE_CORNER",
+      "SANCTUARY_CAVE_PLANE",
+      "SANCTUARY_CAVE_WALL_FALLOFF",
+      "SANCTUARY_CAVE_WALL_FALLOFF_ALT"
     ],
     "uvType": "BOX",
     "uvScale": 0.74
@@ -9456,14 +9456,14 @@
     "description": "Objects - Vines",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      41201,
-      41202,
-      41203,
-      41204,
-      41205,
-      41207,
-      41208,
-      41209
+      "TEMPLE_VINE_STRAIGHT",
+      "TEMPLE_VINE_CORNER",
+      "TEMPLE_VINE_JUNCTION",
+      "TEMPLE_VINE_DIAG1",
+      "TEMPLE_VINE_DIAG2",
+      "TEMPLE_VINE_DIAGFILLER",
+      "TEMPLE_VINE_END",
+      "TEMPLE_VINE_END_DIAG"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9484,24 +9484,24 @@
       }
     ],
     "objectIds": [
-      1222,
-      1223,
-      1224,
-      1225,
-      1226,
-      1227,
-      1228,
-      1229,
-      1230
+      "GREENVINE_STRAIGHT",
+      "GREENVINE_CORNER",
+      "GREENVINE_JUNCTION",
+      "GREENVINE_DIAG1",
+      "GREENVINE_DIAG2",
+      "GREENVINE_DIAG3",
+      "GREENVINE_DIAGFILLER",
+      "GREENVINE_END",
+      "GREENVINE_END_DIAG"
     ]
   },
   {
     "description": "Objects - White Mushrooms - Medium",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      22796,
-      22797,
-      22798
+      "DORGESH_MUSHROOM1",
+      "DORGESH_MUSHROOM2",
+      "DORGESH_MUSHROOM3"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9509,7 +9509,7 @@
     "description": "Objects - Mushroom, Red with white spots",
     "baseMaterial": "GRAY_70",
     "objectIds": [
-      7135
+      "FAI_VARROCK_RED_MUSHROOMS"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9517,7 +9517,7 @@
     "description": "Mortton Shade Catacombs - Decoration - Stone - Brick rubble",
     "baseMaterial": "STONE",
     "objectIds": [
-      38028
+      "MYQ5_LAB_CRUMBLED_WALL"
     ],
     "uvType": "MODEL_XZ_MIRROR_B"
   },
@@ -9525,7 +9525,7 @@
     "description": "Mortton Shade Catacombs - Objects - Stone - Brick rubble",
     "baseMaterial": "STONE",
     "objectIds": [
-      20733
+      "BARROWS_BRICKS_PILE_1"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9533,9 +9533,9 @@
     "description": "Mortton Shade Catacombs  - Walls - Metallic - Fence",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      37773,
-      37774,
-      37775
+      "SANCTUARY_TALL_SPIKES",
+      "SANCTUARY_TALL_SPIKES_JOIN",
+      "SANCTUARY_TALL_SPIKES_JOIN_M"
     ],
     "uvType": "MODEL_XY"
   },
@@ -9543,10 +9543,10 @@
     "description": "Objects - Fungus - Medium",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      1171,
-      1172,
-      21742,
-      21743
+      "NASTYFUNGUS_DARK",
+      "WILDERNESSFUNGUS",
+      "NEW_NASTYFUNGUS_DARK",
+      "NEW_NASTYFUNGUS_SMALL_DARK"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -9555,11 +9555,11 @@
     "description": "Objects - Huge Mushroom - Medium",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      4055,
-      4056,
-      4057,
-      46344,
-      46346
+      "MUSHROOM_MASSIVE1",
+      "MUSHROOM_MASSIVE2",
+      "MUSHROOM_MASSIVE3",
+      "TGOD_GARDEN_MUSHROOM_1_NOOP",
+      "TGOD_GARDEN_MUSHROOM_2_NOOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -9568,11 +9568,11 @@
     "description": "Mortton - Objects - Shade Chests - Medium - Bronze",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      4111,
-      4112,
-      4113,
-      4114,
-      4115
+      "SHADECHEST_BRONZE_BLOODRED",
+      "SHADECHEST_BRONZE_BROWN",
+      "SHADECHEST_BRONZE_CRIMSON",
+      "SHADECHEST_BRONZE_BLACK",
+      "SHADECHEST_BRONZE_PURPLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -9581,11 +9581,11 @@
     "description": "Mortton - Objects - Shade Chests - Medium - Steel",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      4116,
-      4117,
-      4118,
-      4119,
-      4120
+      "SHADECHEST_STEEL_BLOODRED",
+      "SHADECHEST_STEEL_BROWN",
+      "SHADECHEST_STEEL_CRIMSON",
+      "SHADECHEST_STEEL_BLACK",
+      "SHADECHEST_STEEL_PURPLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -9594,11 +9594,11 @@
     "description": "Mortton - Objects - Shade Chests - Medium - Black",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      4121,
-      4122,
-      4123,
-      4124,
-      4125
+      "SHADECHEST_BLACK_BLOODRED",
+      "SHADECHEST_BLACK_BROWN",
+      "SHADECHEST_BLACK_CRIMSON",
+      "SHADECHEST_BLACK_BLACK",
+      "SHADECHEST_BLACK_PURPLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -9607,11 +9607,11 @@
     "description": "Mortton - Objects - Shade Chests - Medium - Silver",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      4126,
-      4127,
-      4128,
-      4129,
-      4130
+      "SHADECHEST_SILVER_BLOODRED",
+      "SHADECHEST_SILVER_BROWN",
+      "SHADECHEST_SILVER_CRIMSON",
+      "SHADECHEST_SILVER_BLACK",
+      "SHADECHEST_SILVER_PURPLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -9620,14 +9620,14 @@
     "description": "Morytania - Walls - Triple Slat Fence",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      5417,
-      5432,
-      5433,
-      5434,
-      5435,
-      5436,
-      5437,
-      5438
+      "AHOY_GHOSTSHIPLADDER_BRIDGE_LEDGE",
+      "AHOY_OLDFENCING",
+      "AHOY_OLDFENCING_2",
+      "AHOY_OLDFENCING_3",
+      "AHOY_OLDFENCING_4",
+      "AHOY_OLDFENCING_4_MIRROR",
+      "AHOY_OLDFENCING_5",
+      "AHOY_OLDFENCING_6"
     ],
     "uvType": "BOX",
     "uvScale": 0.78
@@ -9636,11 +9636,11 @@
     "description": "Morytania - Walls - Triple Slat Fence Gate",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      12816,
-      12817,
-      12818,
-      12819,
-      12776
+      "BURGH_FENCEGATE_L",
+      "BURGH_FENCEGATE_R",
+      "BURGH_OPENFENCEGATE_L",
+      "BURGH_OPENFENCEGATE_R",
+      "BURGH_AGILITY_SHORTCUT_FENCE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9648,36 +9648,36 @@
     "description": "Morytania - Walls - Wooden - Plank - Burgh De Rott",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      12821,
-      12822,
-      12823,
-      12824,
-      12825,
-      12826,
-      12827,
-      12828,
-      12829,
-      12830,
-      12831,
-      12832,
-      12833,
-      12913,
-      12914,
-      12915,
-      12916,
-      12917,
-      12918,
-      12919,
-      12920,
-      12921,
-      12922,
-      12923,
-      17713,
-      17714,
-      17715,
-      17716,
-      17717,
-      17718
+      "BURGH_ABODE_WALL",
+      "BURGH_ABODE_WALL_WINDOW",
+      "BURGH_ABODE_WALL_CRUMBLY_LEFT",
+      "BURGH_ABODE_WALL_CRUMBLY_RIGHT",
+      "BURGH_ABODE_WALL_CRUMBLY2_LEFT",
+      "BURGH_ABODE_WALL_CRUMBLY2_RIGHT",
+      "BURGH_ABODE_WALL_CRUMBLY2_RIGHT_MIRRORED",
+      "BURGH_ABODE_WALL_CRUMBLY_RIGHT_MIRRORED",
+      "BURGH_ABODE_WALL_DAMAGED",
+      "BURGH_ABODE_WALL_DAMAGED2",
+      "BURGH_ABODE_WALL_DAMAGED3",
+      "BURGH_ABODE_WALL_CRUMBLY_DAMAGED_LEFT",
+      "BURGH_ABODE_WALL_CRUMBLY_DAMAGED_RIGHT",
+      "BURGH_ABODE_WALL_LV2",
+      "BURGH_ABODE_WALL_WINDOW_LV2",
+      "BURGH_ABODE_WALL_CRUMBLY_LEFT_LV2",
+      "BURGH_ABODE_WALL_CRUMBLY_RIGHT_LV2",
+      "BURGH_ABODE_WALL_CRUMBLY2_LEFT_LV2",
+      "BURGH_ABODE_WALL_CRUMBLY2_RIGHT_LV2",
+      "BURGH_ABODE_WALL_DAMAGED_LV2",
+      "BURGH_ABODE_WALL_DAMAGED2_LV2",
+      "BURGH_ABODE_WALL_DAMAGED3_LV2",
+      "BURGH_ABODE_WALL_CRUMBLY_DAMAGED_LEFT_LV2",
+      "BURGH_ABODE_WALL_RUMBLY_DAMAGED_RIGHT_LV2",
+      "AREA_SANGUINE_OUTER_WOOD1",
+      "AREA_SANGUINE_OUTER_WOOD2",
+      "AREA_SANGUINE_OUTER_WOOD3",
+      "AREA_SANGUINE_OUTER_WOOD4",
+      "AREA_SANGUINE_OUTER_WOOD4_MIRROR",
+      "AREA_SANGUINE_OUTER_WOOD5"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -9687,25 +9687,25 @@
     "description": "Morytania - Floor - Wooden - Plank - Burgh De Rott",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      12898,
-      12899,
-      12900,
-      12901,
-      12902,
-      12903,
-      12904,
-      12905,
-      12906,
-      12949,
-      12950,
-      12948,
-      12951,
-      12952,
-      12953,
-      12957,
-      12958,
-      12959,
-      12960
+      "BURGH_FLOORBOARD",
+      "BURGH_FLOORBOARD_EDGE",
+      "BURGH_FLOORBOARD_CORNER_L",
+      "BURGH_FLOORBOARD_CORNER_R",
+      "BURGH_FLOORBOARD_JOIST",
+      "BURGH_FLOORBOARD_JOIST2",
+      "BURGH_FLOORBOARD_JOIST3",
+      "BURGH_FLOORBOARD_HOLE",
+      "BURGH_FLOORBOARD_HATCH",
+      "SANG_BOATHOUSE_FLOORBOARD_LEFT",
+      "SANG_BOATHOUSE_FLOORBOARD_RIGHT",
+      "SANG_BOATHOUSE_FLOORBOARD_BOTTOM",
+      "SANG_BOATHOUSE_FLOORBOARD_TOP",
+      "SANG_BOATHOUSE_FLOORBOARD_TOP_LEFT",
+      "SANG_BOATHOUSE_FLOORBOARD_TOP_RIGHT",
+      "SANG_FLOORBOARD_BOAT_SUPPORT_BL",
+      "SANG_FLOORBOARD_BOAT_SUPPORT_BR",
+      "SANG_FLOORBOARD_BOAT_SUPPORT_TL",
+      "SANG_FLOORBOARD_BOAT_SUPPORT_TR"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -9713,19 +9713,19 @@
     "description": "Morytania - Floor - Wooden - Ladder - Burgh De Rott - Meiyerditch",
     "baseMaterial": "WOOD_GRAIN",
     "objectIds": [
-      12780,
-      12781,
-      12907,
-      17974,
-      17975
+      "BURGH_LADDER_GENERALSTORE_UP",
+      "BURGH_LADDER_GENERALSTORE_DOWN",
+      "BURGH_LADDER_HATCH_UP",
+      "AREA_SANGUINE_GHETTO_LADDER_UP",
+      "AREA_SANGUINE_GHETTO_LADDER_DOWN"
     ]
   },
   {
     "description": "Morytania - Wall Decoration - Wooden - Plank - Burgh De Rott",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      12852,
-      12853
+      "BURGH_BOARED_UP_WINDOWS",
+      "BURGH_BOARED_UP_WINDOWS_MIRROR"
     ],
     "uvType": "BOX",
     "uvOrientation": 560,
@@ -9735,7 +9735,7 @@
     "description": "Morytania - Wall  - Wooden - Plank - Repaired Wall - Burgh De Rott",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      12786
+      "BURGH_BOARED_UP_WALL"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -9745,10 +9745,10 @@
     "description": "Morytania - Wall  - Wooden - Plank - Door",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      5244,
-      5245,
-      7503,
-      20773
+      "AHOY_HARBOUR_DOOR",
+      "AHOY_HARBOUR_DOOR_OPEN",
+      "FARMING_INACTIVE_SHOP_DOOR",
+      "BARROWS_LOCKED_DOOR"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -9758,25 +9758,25 @@
     "description": "Morytania - Wall  - Stone - Stone Brick Wall - Burgh De Rott",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      12737,
-      12834,
-      12835,
-      12836,
-      12837,
-      12838,
-      12839,
-      12840,
-      12841,
-      12842,
-      12843,
-      12845,
-      12846,
-      12847,
-      12848,
-      12849,
-      12850,
-      12851,
-      12859
+      "BURGH_INN_CLIMB_OVER",
+      "BURGH_STONE",
+      "BURGH_STONE_VARI",
+      "BURGH_STONE_CRUMBLY_RIGHT",
+      "BURGH_STONE_CRUMBLY_LEFT",
+      "BURGH_STONE_CRUMBLY_HALF_RIGHT",
+      "BURGH_STONE_CRUMBLY_HALF_LEFT",
+      "BURGH_STONE_CRUMBLY_LOW_LEFT",
+      "BURGH_STONE_CRUMBLY_LOW_RIGHT",
+      "BURGH_STONE_CRUMBLY_LOW2_LEFT",
+      "BURGH_STONE_WINDOW",
+      "BURGH_DUNGEON",
+      "BURGH_DUNGEON_EXPOSED_PLASTER",
+      "BURGH_STONE_CRUMBLY_RIGHT_LEV2",
+      "BURGH_STONE_CRUMBLY_LEFT_LEV2",
+      "BURGH_STONE_CRUMBLY_HALF_RIGHT_LEV2",
+      "BURGH_STONE_CRUMBLY_HALF_LEFT_LEV2",
+      "BURGH_STONE_LEV2",
+      "BURGH_STONE_WALL_BROKEN"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -9786,14 +9786,14 @@
     "description": "Morytania - Objects  - Stone - Stone Brick Wall Rubble",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6389,
-      6390,
-      12739,
-      12740,
-      12844,
-      20734,
-      20765,
-      20766
+      "CAVEWALL_FACE1_VDARKBROWN",
+      "CAVEWALL_TOP_VDARKBROWN",
+      "BURGH_INN_RUBBLE_BLOCKED",
+      "BURGH_INN_RUBBLE_CLEARED",
+      "BURGH_STONE_PILE_OF_BICKS",
+      "BARROWS_BRICKS_PILE_2",
+      "BARROWS_BRICKS_PILE_1_PURPLE",
+      "BARROWS_BRICKS_PILE_2_PURPLE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9801,10 +9801,10 @@
     "description": "Morytania - Ground  - Wooden - Boat Launch - Burgh De Rott",
     "baseMaterial": "DOCK_FENCE_DARK",
     "objectIds": [
-      12946,
-      17924,
-      17956,
-      17957
+      "SANG_BOATHOUSE_CHUTE",
+      "SANG_BOATHOUSE_CHUTE_MIRROR",
+      "SANG_BOATHOUSE_CHUTE_BROKEN",
+      "SANG_BOATHOUSE_CHUTE_FIXED"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9812,7 +9812,7 @@
     "description": "Burgh De Rott - Objects - Dirt - Rubble Pile",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      12749
+      "BURGH_OUTSIDE_RUBBLE_PILE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9820,8 +9820,8 @@
     "description": "Morytania - Objects - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12877,
-      12879
+      "BURGH_CRATES_2",
+      "BURGH_CRATE"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -9831,7 +9831,7 @@
     "description": "Morytania - Objects - Wooden - Stacked Crate - Angled",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12876
+      "BURGH_CRATES_SMALL"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -9843,7 +9843,7 @@
     "description": "Morytania - Objects - Wooden - Stacked Tri Crate - Angled ",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12878
+      "BURGH_CRATES_SMALL2"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -9855,9 +9855,9 @@
     "description": "Morytania - Ground  - Water - Puddles - Burgh De Rott",
     "baseMaterial": "WATER_PUDDLE",
     "objectIds": [
-      12860,
-      12861,
-      12862
+      "BURGH_MUD_1",
+      "BURGH_MUD_2",
+      "BURGH_MUD_3"
     ],
     "uvType": "MODEL_XZ",
     "flatNormals": true,
@@ -9867,16 +9867,16 @@
     "description": "Chaos Tunnel - Walls - Cave Walls",
     "baseMaterial": "STONE",
     "objectIds": [
-      23068,
-      23069,
-      23070,
-      23071,
-      23072,
-      23075,
-      23076,
-      23077,
-      23078,
-      23079
+      "SUROK_TUNNEL_WALL",
+      "SUROK_TUNNEL_WALL_SUPPORT_LEFT",
+      "SUROK_TUNNEL_WALL_SUPPORT_RIGHT",
+      "SUROK_TUNNEL_WALL_SUPPORT_MID",
+      "SUROK_TUNNEL_WALL_LAMP",
+      "SUROK_TUNNEL_WALL_TOP",
+      "SUROK_TUNNEL_WALL_TOP5",
+      "SUROK_TUNNEL_WALL_LVL1",
+      "SUROK_TUNNEL_WALL_TOP_LVL1",
+      "SUROK_TUNNEL_WALL_TOP5_LVL1"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9884,8 +9884,8 @@
     "description": "Chaos Tunnel - Objects - Stairs",
     "baseMaterial": "STONE",
     "objectIds": [
-      23073,
-      23074
+      "SUROK_TUNNEL_WALL_STEPS",
+      "SUROK_TUNNEL_STEPS"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9893,9 +9893,9 @@
     "description": "Objects - Rock - Staglagmite - Non Interactable",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      23088,
-      23089,
-      23090
+      "SUROK_TUNNEL_STALAGTITE_01",
+      "SUROK_TUNNEL_STALAGTITE_02",
+      "SUROK_TUNNEL_STALAGTITE_FALLOFF"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9903,13 +9903,13 @@
     "description": "Objects - Bed - Bedroll",
     "baseMaterial": "CARPET",
     "objectIds": [
-      422,
-      423,
-      4288,
-      23067,
-      27664,
-      35797,
-      35798
+      "POORBED",
+      "POORBED2",
+      "VIKING_POORBED",
+      "SUROK_TUNNEL_BED",
+      "PISCARILIUS_BED_02",
+      "REHNISON_BED_TRAPDOOR_NOOP",
+      "REHNISON_BED_TRAPDOOR_OP"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.60
@@ -9918,7 +9918,7 @@
     "description": "Objects - Locker - Wooden - Non Interactable",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      23064
+      "SUROK_TUNNEL_LOCKER"
     ],
     "uvType": "GEOMETRY"
   },
@@ -9926,33 +9926,33 @@
     "description": "Objects - Stool - Wooden – Generic",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1102,
-      7167,
-      7168,
-      11603,
-      12407,
-      12440,
-      14764,
-      14872,
-      15039,
-      15093,
-      15679,
-      16246,
-      16875,
-      17306,
-      17551,
-      17552,
-      17667,
-      17909,
-      17910,
-      20059,
-      23065,
-      23179,
-      24089,
-      39718,
-      42092,
-      43766,
-      49654
+      "STOOL",
+      "FAI_VARROCK_STOOL_1",
+      "FAI_VARROCK_POOR_STOOL2",
+      "FAI_BARBARIAN_STOOL",
+      "_100_GOBLIN_STUBBY_STOOL",
+      "GOBLIN_OUTPOST_STOOL",
+      "WILD_STOOL",
+      "QIP_COOK_STOOL",
+      "PIRATETREASURE_STOOL",
+      "ROYAL_BAR_STOOL",
+      "AIDE_STOOL",
+      "FAIRY2_MAP_TABLE_STOOL",
+      "LUNAR_PIRATE_LOW_STOOL",
+      "QIP_DIGSITE_STOOL",
+      "AREA_SANGUINE_GHETTO_STOOL1",
+      "AREA_SANGUINE_GHETTO_STOOL2",
+      "MYQ3_HIDEOUT_STOOL",
+      "MYQ3_LAB_STOOL",
+      "MYQ3_LAB_STOOL_BROKEN",
+      "QIP_WATCHTOWER_STOOL",
+      "SUROK_TUNNEL_STOOL",
+      "OLAF2_OLD_BROKEN_STOOL",
+      "FAI_FALADOR_STOOL",
+      "WILDY_HUB_BROKEN_STOOL",
+      "SHAYZIEN_STOOL",
+      "TOTE_PORTAL_TO_GOTR_CHILD_HIDDEN",
+      "POG_STOOL"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -9962,8 +9962,8 @@
     "description": "Objects - Stool - Wooden – Generic - Broken",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7482,
-      40215
+      "FAI_VARROCK_POOR_STOOL1",
+      "DADDYSHOME_STOOL_BROKEN_0OP"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -9973,21 +9973,21 @@
     "description": "Objects - Table - Single - Wooden – Plank - Generic",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7169,
-      11627,
-      12892,
-      14051,
-      14163,
-      14763,
-      20351,
-      23066,
-      24360,
-      39966,
-      39967,
-      39968,
-      39969,
-      39970,
-      39971
+      "FAI_VARROCK_WOODEN_TABLE_SMALL",
+      "FAI_BARBARIAN_SMALL_WOODEN_TABLE",
+      "BURGH_SMALL_WOODEN_TABLE_SMALL",
+      "FISHING_CONTEST_SMALL_WOODEN_TABLE",
+      "ROYAL_TABLE_SMALL",
+      "WILD_TABLE_SMALL",
+      "CONTACT_TABLE_SMALL",
+      "SUROK_TUNNEL_SMALL_TABLE",
+      "CANAFIS_TABLE_SMALL",
+      "CON_CONTRACT_VARROCK_SOUTH_SMALL_TABLE_BROKEN",
+      "CON_CONTRACT_VARROCK_SOUTH_SMALL_TABLE_EDITABLE",
+      "CON_CONTRACT_VARROCK_SOUTH_SMALL_TABLE_REGULAR",
+      "CON_CONTRACT_VARROCK_SOUTH_SMALL_TABLE_OAK",
+      "CON_CONTRACT_VARROCK_SOUTH_SMALL_TABLE_TEAK",
+      "CON_CONTRACT_VARROCK_SOUTH_SMALL_TABLE_MAHOGANY"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -9996,10 +9996,10 @@
     "description": "Objects - Table - Single - Wooden – Plank - Generic - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      594,
-      602,
-      624,
-      12734
+      "BIGTABLE",
+      "TABLE",
+      "BEDSIDETABLE",
+      "BURGH_QUEST_FOOD_TABLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -10009,8 +10009,8 @@
     "description": "Objects - Table - Single - Wooden – Plank - Generic",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      15044,
-      17662
+      "PIRATETREASURE_WOODEN_TABLE_SMALL",
+      "MYQ3_HIDEOUT_SMALL_TABLE"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -10019,17 +10019,17 @@
     "description": "Ground - Chaos Altar - Path -  Wooden – Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2669,
-      4033,
-      11557,
-      11915,
-      11916,
-      11917,
-      11918,
-      11919,
-      11554,
-      11555,
-      11556
+      "DECKING_CORNER_C_CHAOS",
+      "DECKING_CORNER_B_CHAOS",
+      "GREATRUNESTONE_DECKING_6",
+      "GREATRUNESTONE_DECKING_BROKEN",
+      "GREATRUNESTONE_DECKING_CORNER_A",
+      "GREATRUNESTONE_DECKING_CORNER_B",
+      "GREATRUNESTONE_DECKING_CORNER_C",
+      "GREATRUNESTONE_DECKING_CORNER_D",
+      "GREATRUNESTONE_DECKING",
+      "GREATRUNESTONE_DECKING_2",
+      "GREATRUNESTONE_DECKING_5"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512
@@ -10038,7 +10038,7 @@
     "description": "Chaos Altar - Walls - Path -  Wooden – Plank",
     "baseMaterial": "STONE",
     "objectIds": [
-      169
+      "DECKING_BORDER"
     ],
     "uvType": "MODEL_XY",
     "uvOrientation": 512
@@ -10047,7 +10047,7 @@
     "description": "Objects - Standing Torch -  Wood",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      724
+      "STANDING_TORCH"
     ],
     "uvType": "BOX",
     "uvScale": 1.1
@@ -10056,10 +10056,10 @@
     "description": "Objects - Stone - Stalagmites - Limestone",
     "baseMaterial": "STONE",
     "objectIds": [
-      11945,
-      11950,
-      11946,
-      12568
+      "STALAGTITE_SMALL_GREY",
+      "STALAGTITE_TWIN_GREY",
+      "STALAGMITE_TWIN_GREY",
+      "STAGAMITE_SMALL_GREY"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10067,21 +10067,21 @@
     "description": "Lunar Isle - Walls - Stone - Northern Mine",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      14999,
-      15000,
-      15001,
-      15002,
-      15003,
-      15004,
-      15005,
-      15006,
-      15007,
-      15008,
-      15009,
-      15026,
-      15028,
-      15022,
-      11399
+      "LUNAR_MINE_FACE1_L2",
+      "LUNAR_MINE_PITTED_FACE1_L2",
+      "LUNAR_MINE_PITTED_FACE1_GLOW_L2",
+      "LUNAR_MINE_WATERY_FACE1_GLOW_L2",
+      "LUNAR_MINE_TORCH_FACE1_L2",
+      "LUNAR_MINE_TORCH_FACE1_GLOW_L2",
+      "LUNAR_MINE_ANIMATED_WATER_L2",
+      "LUNAR_MINE_FACE1_GLOW_L2",
+      "LUNAR_MINE_FACE1_FALLOFF_L2",
+      "LUNAR_MINE_CONCAVE_FACE1_L2",
+      "LUNAR_MINE_CONCAVE_FACE1_GLOW_L2",
+      "LUNAR_MINE_FACE1_SHORTER",
+      "LUNAR_MINE_TOP_SHORTER",
+      "LUNAR_MINE_CAVEWALL_TOP",
+      "DREAM_CAVE_WALL_ENTRANCE"
     ],
     "uvType": "VANILLA"
   },
@@ -10089,8 +10089,8 @@
     "description": "Lunar Isle - Objects - Limestone - Stalagmites - Mineable",
     "baseMaterial": "STONE",
     "objectIds": [
-      15250,
-      15251
+      "LUNAR_MINE_STALAGMITE_TWIN",
+      "LUNAR_MINE_STALAGMITE_SMALL"
     ],
     "uvType": "VANILLA"
   },
@@ -10098,8 +10098,8 @@
     "description": "Lunar Isle - Objects - Ice - Ice Chunks - Small",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      6476,
-      6477
+      "TROLLRESCUE_ICESLIDE5",
+      "TROLLRESCUE_ICESLIDE6"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.8
@@ -10108,8 +10108,8 @@
     "description": "Lunar Island - Walls - Wooden - Plank - Ruined",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      4281,
-      4282
+      "VIKING_FROZEN_WALL",
+      "VIKING_FROZEN_WALL2"
     ],
     "uvType": "MODEL_XY",
     "uvOrientation": 512,
@@ -10119,7 +10119,7 @@
     "description": "Lunar Island - Objects - Bark - Windswept Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      16639
+      "LUNAR_WINDSWEPT_TREE"
     ],
     "uvType": "BOX",
     "uvOrientation": 64,
@@ -10129,8 +10129,8 @@
     "description": "Lunar Island - Objects - Wooden - Chair",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16743,
-      16744
+      "LUNAR_MOONCLAN_CHAIR_2",
+      "LUNAR_MOONCLAN_CHAIR"
     ],
     "flatNormals": true,
     "uvType": "MODEL_XZ"
@@ -10139,7 +10139,7 @@
     "description": "Lunar Island - Objects - Wooden - Bench",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      16706
+      "LUNAR_MOONCLAN_BENCH"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -10147,7 +10147,7 @@
     "description": "Lunar Island - Objects - Wooden - Stool",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16745
+      "LUNAR_MOONCLAN_STOOL"
     ],
     "flatNormals": true,
     "uvType": "MODEL_XZ"
@@ -10156,7 +10156,7 @@
     "description": "Lunar Island - Objects - Wooden - Table - Round",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      16742
+      "LUNAR_MOONCLAN_TABLE_ROUND"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -10165,16 +10165,16 @@
     "description": "Lunar Island - Objects - Wooden - Hat Rack",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      16692
+      "LUNAR_MOONCLAN_HAT_EMPTY"
     ]
   },
   {
     "description": "Lunar Island - Ground - Carpet",
     "baseMaterial": "CARPET",
     "objectIds": [
-      16709,
-      16710,
-      16718
+      "LUNAR_MOONCLAN_RUG_PINK",
+      "LUNAR_MOONCLAN_RUG",
+      "LUNAR_MOONCLAN_RUG_MIRROR"
     ],
     "uvType": "WORLD_XZ",
     "flatNormals": true
@@ -10183,8 +10183,8 @@
     "description": "Lunar Island - Wooden - Ladder",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      16735,
-      16736
+      "LUNAR_MOONCLAN_LADDER",
+      "LUNAR_MOONCLAN_LADDER_TOP"
     ],
     "uvType": "MODEL_XY_MIRROR_B"
   },
@@ -10192,13 +10192,13 @@
     "description": "Objects - Wooden - Plank tables - Medium",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12884,
-      12972,
-      14044,
-      14049,
-      16974,
-      24333,
-      49653
+      "BURGH_WOODEN_TABLE",
+      "QIP_SHEEP_SHEARER_SMALL_TABLE",
+      "FISHING_CONTEST_WOODEN_TABLE",
+      "FISHING_CONTEST_JACK_TABLE",
+      "QUEST_LUNAR_TABLE_SMALL",
+      "CANAFIS_TABLE",
+      "POG_WOODEN_TABLE"
     ],
     "uvType": "BOX"
   },
@@ -10206,7 +10206,7 @@
     "description": "Objects - Wooden - Plank tables - Long",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12971
+      "QIP_SHEEP_SHEARER_LARGE_TABLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -10215,7 +10215,7 @@
     "description": "Objects - Wooden - Plank tables - Wide",
     "baseMaterial": "WOOD_GRAIN_2_WIDE",
     "objectIds": [
-      12280
+      "_100_DAVE_BIG_WOODEN_TABLE"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -10224,8 +10224,8 @@
     "description": "Objects - Wooden - Plank tables - Wide - Rotated",
     "baseMaterial": "WOOD_GRAIN_2_WIDE",
     "objectIds": [
-      12386,
-      12387
+      "_100_GOBLIN_LARGE_TABLE",
+      "_100_GOBLIN_LARGE_TABLE_BLASTED"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -10236,8 +10236,8 @@
     "description": "Lunar Isles - Objects - Wooden - Tables - Fine",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16737,
-      16738
+      "LUNAR_MOONCLAN_TABLE_RECTANGLE",
+      "LUNAR_MOONCLAN_TABLE_RECTANGLE_SCALES"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -10247,7 +10247,7 @@
     "description": "Lunar Isles - Objects - Wooden - Table with hats",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16740
+      "LUNAR_MOONCLAN_TABLE_RECTANGLE_CLOTHS"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -10258,9 +10258,9 @@
     "description": "Lunar Isles - Objects - Wooden staircase",
     "baseMaterial": "HD_WOOD_PLANKS_2",
     "objectIds": [
-      16732,
-      16733,
-      16734
+      "LUNAR_MOONCLAN_STAIRS_TOP",
+      "LUNAR_MOONCLAN_STAIRS_TOP_WEST",
+      "LUNAR_MOONCLAN_STAIRS"
     ],
     "uvType": "BOX"
   },
@@ -10268,10 +10268,10 @@
     "description": "Lunar Isles - WALLS - Wooden Railing",
     "baseMaterial": "HD_WOOD_PLANKS_2",
     "objectIds": [
-      16761,
-      16762,
-      16763,
-      16767
+      "LUNAR_MOONCLAN_FENCE_LOW",
+      "LUNAR_MOONCLAN_FENCE_LOW_END",
+      "LUNAR_MOONCLAN_FENCE_LOW_END_MIRROR",
+      "LUNAR_MOONCLAN_DOOR_LOW"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -10280,16 +10280,16 @@
     "description": "Lunar Isles - WALLS - Wooden - Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16746,
-      16747,
-      16748,
-      16749,
-      16750,
-      16759,
-      16760,
-      16770,
-      16771,
-      16772
+      "LUNAR_MOONCLAN_BASIC_WALL",
+      "LUNAR_MOONCLAN_WALL",
+      "LUNAR_MOONCLAN_DOOR_SUPPORT",
+      "LUNAR_MOONCLAN_WALL_FLUSH",
+      "LUNAR_MOONCLAN_WALL_WITH_SUPPORT",
+      "LUNAR_MOONCLAN_LINKING_CORNER_RAISED",
+      "LUNAR_MOONCLAN_LINKING_CORNER_RAISED_MIRROR",
+      "LUNAR_MOONCLAN_FIRSTFLOOR_WALL_BASIC",
+      "LUNAR_MOONCLAN_FIRSTFLOOR_WALL",
+      "LUNAR_MOONCLAN_FIRSTFLOOR_WALL_FLUSH"
     ],
     "uvType": "BOX"
   },
@@ -10297,11 +10297,11 @@
     "description": "Lunar Isles - WALLS - Wooden - Plank - Windows",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16751,
-      16752,
-      16753,
-      16768,
-      16769
+      "LUNAR_MOONCLAN_WALL_WINDOW",
+      "LUNAR_MOONCLAN_WALL_OPEN_WINDOW",
+      "LUNAR_MOONCLAN_WALL_CLOSED_WINDOW",
+      "LUNAR_MOONCLAN_FIRSTFLOOR_WALL_WINDOW_HOLE",
+      "LUNAR_MOONCLAN_FIRSTFLOOR_WALL_WINDOW_OPEN"
     ],
     "uvType": "BOX"
   },
@@ -10309,8 +10309,8 @@
     "description": "Lunar Isles - WALLS - Wooden - Plank - Door",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16776,
-      16777
+      "LUNAR_MOONCLAN_DOOR",
+      "LUNAR_MOONCLAN_DOOR_OPEN"
     ],
     "uvType": "BOX"
   },
@@ -10318,9 +10318,9 @@
     "description": "Lunar Isles - WALLS - Wooden - Door - Window",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16775,
-      16778,
-      16779
+      "LUNAR_MOONCLAN_DOOR_BABA_YAGA_INAC",
+      "LUNAR_MOONCLAN_DOOR_ASIAN",
+      "LUNAR_MOONCLAN_DOOR_ASIAN_CLOSED"
     ],
     "uvType": "BOX"
   },
@@ -10328,9 +10328,9 @@
     "description": "Lunar Isles - WALLS - Wooden - Railing - Window",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16757,
-      16758,
-      16773
+      "LUNAR_MOONCLAN_BALCONY_RAISED_MEETSWALL",
+      "LUNAR_MOONCLAN_BALCONY_RAISED_MEETSWALL_MIRROR",
+      "LUNAR_MOONCLAN_FIRSTFLOOR_BALCONY"
     ],
     "uvType": "MODEL_XY",
     "uvOrientation": 512
@@ -10339,9 +10339,9 @@
     "description": "Ice Queens Dungeon - Walls - Snow",
     "baseMaterial": "SNOW_COLORED",
     "objectIds": [
-      1440,
-      1441,
-      1442
+      "CAVEWALL_FACE1_WHITE",
+      "CAVEWALL_TOP_WHITE",
+      "CAVEWALL_TOP5_WHITE"
     ],
     "uvType": "BOX",
     "uvScale": 1.2,
@@ -10351,8 +10351,8 @@
     "description": "Ice Queens Dungeon - Objects - Icicle - Ice",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      554,
-      555
+      "ICICLE_LARGE_UP",
+      "ICICLE_SMALL_UP"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10360,9 +10360,9 @@
     "description": "Ice Queens Dungeon - Decorations - Wall - White Object - Snow",
     "baseMaterial": "SNOW_3",
     "objectIds": [
-      1445,
-      1446,
-      1447
+      "CAVE_DETAIL1R_WHITE",
+      "CAVE_DETAIL2_WHITE",
+      "CAVE_DETAIL2R_WHITE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10370,11 +10370,11 @@
     "description": "Objects - Rockslide - Snow Drift - Snow - Medium",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      11920,
-      11921,
-      33184,
-      33185,
-      33220
+      "ROCKSLIDE_WHITE1",
+      "ROCKSLIDE_WHITE2",
+      "MY2ARM_CLIFF_SHORTCUT_1",
+      "MY2ARM_CLIFF_SHORTCUT_2",
+      "MY2ARM_SNOW_COVERED_ROCKS_01"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -10383,9 +10383,9 @@
     "description": "Objects - Rockslide - Snow Drift - Snow - Small",
     "baseMaterial": "SNOW_3",
     "objectIds": [
-      11922,
-      11923,
-      33221
+      "ROCKSLIDE_WHITE3",
+      "ROCKSLIDE_WHITE4",
+      "MY2ARM_SNOW_SMALLER_ROCKS_01"
     ],
     "uvType": "BOX"
   },
@@ -10393,7 +10393,7 @@
     "description": "Ice Queens Dungeon - Objects - Ice Column - Ice",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      11930
+      "ICE_COLUMN"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10401,7 +10401,7 @@
     "description": "Ice Queens Dungeon - Objects - Ice Throne - Ice",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      1114
+      "ICE_THRONE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10409,7 +10409,7 @@
     "description": "Ice Queens Dungeon - Objects - Ice Light - Ice",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      210
+      "ICE_LIGHT"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10417,7 +10417,7 @@
     "description": "ROUNDED_CAVE_WALLS_WITH_PIPE",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      16509
+      "TAVERLY_DUNGEON_PIPE_SC"
     ],
     "uvType": "BOX"
   },
@@ -10425,7 +10425,7 @@
     "description": "Objects - Rock Stairs - Large",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      30189
+      "TAVERLEY_DRAGON_STEPS_UP"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -10435,16 +10435,16 @@
     "description": "Objects - Rockslide - Brown Rock - Rock - Medium",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      154,
-      11190,
-      11191,
-      11192,
-      11195,
-      11193,
-      12582,
-      12583,
-      12584,
-      12585
+      "TAVERLEY_DRAGON_JUMPUP",
+      "ROCKSLIDE1",
+      "ROCKSLIDE2",
+      "ROCKSLIDE3",
+      "ROCKSLIDE6",
+      "ROCKSLIDE4",
+      "ROCKSLIDE1_UPASS",
+      "ROCKSLIDE2_UPASS",
+      "ROCKSLIDE3_UPASS",
+      "ROCKSLIDE4_UPASS"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -10453,21 +10453,21 @@
     "description": "Objects - Rockslide - Gray Rock - Rock - Medium",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      3657,
-      3658,
-      3659,
-      3660,
-      3661,
-      33191,
-      37395,
-      37396,
-      46818,
-      46819,
-      46820,
-      47161,
-      47162,
-      47163,
-      47164
+      "DEATH_CAMPWALL1",
+      "DEATH_CAMPWALL2",
+      "DEATH_CAMPWALL3",
+      "DEATH_CAMPWALL1_SUPPORT",
+      "DEATH_CAMPWALL1_CORNER",
+      "MY2ARM_CLIFF_SHORTCUT_5",
+      "VIKINGEXILE_ROCKS_OP",
+      "VIKINGEXILE_ROCKS_NOOP",
+      "MY2ARM_CAVE_ROCKS_SMALL_01",
+      "MY2ARM_CAVE_ROCKS_SMALL_02",
+      "MY2ARM_CAVE_ROCKS_SMALL_03",
+      "WILD_ESCAPECAVE_ROCKSLIDE1",
+      "WILD_ESCAPECAVE_ROCKSLIDE2",
+      "WILD_ESCAPECAVE_ROCKSLIDE3",
+      "WILD_ESCAPECAVE_ROCKSLIDE4"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -10476,9 +10476,9 @@
     "description": "Objects - Rockslide - Darker Gray Rock - Rock - Medium",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      51795,
-      51796,
-      51797
+      "AVIUM_ROCKSLIDE_MUDDY02",
+      "AVIUM_ROCKSLIDE_MUDDY03",
+      "AVIUM_ROCKSLIDE_MUDDY04"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -10487,11 +10487,11 @@
     "description": "Objects - Rockslide - Orange Rock - Rock - Medium",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      51850,
-      51851,
-      51847,
-      51849,
-      51848
+      "STONECUTTER_ROCKSLIDE3",
+      "STONECUTTER_ROCKSLIDE4",
+      "STONECUTTER_DUGUPSOIL1_LIGHT",
+      "STONECUTTER_DUGUPSOIL3_LIGHT",
+      "STONECUTTER_DUGUPSOIL2_LIGHT"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -10500,11 +10500,11 @@
     "description": "Big Crack Near Pyre Foxes",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      51857,
-      51858,
-      51860,
-      51862,
-      51864
+      "CAVEKIT_MUD01_FALLOFF01_LEDGE01",
+      "DECOKIT_MUD01_MIDDLE01",
+      "DECOKIT_MUD01_CORNER01",
+      "DECOKIT_MUD01_CORNER03",
+      "DECOKIT_MUD01_EDGE02"
     ],
     "uvType": "BOX",
     "upwardsNormals": true,
@@ -10514,9 +10514,9 @@
     "description": "Objects - Stone - Column - Limestone",
     "baseMaterial": "STONE",
     "objectIds": [
-      11937,
-      11938,
-      11939
+      "ROCKCOLUMN1_GREY",
+      "ROCKCOLUMN2_GREY",
+      "ROCKCOLUMN3_GREY"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10524,7 +10524,7 @@
     "description": "Objects - Stone - Counter",
     "baseMaterial": "STONE",
     "objectIds": [
-      2876
+      "ROCKCOUNTER_GREY"
     ],
     "uvType": "GEOMETRY"
   },
@@ -10532,15 +10532,15 @@
     "description": "Walls - Rock Cave Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      1489,
-      1490,
-      1491,
-      1492,
-      1494,
-      1495,
-      5962,
-      26763,
-      26767
+      "CAVEWALL_FACE1_GREY",
+      "CAVEWALL_TOP_GREY",
+      "CAVEWALL_FACE1_LEV2_DARK_GREY",
+      "CAVEWALL_TOP5_GREY",
+      "CAVEWALL_FACEFORDOORR_GREY",
+      "CAVEWALL_FACEFORDOORL_GREY",
+      "CAVEWALL_FACE1_FOR_LEVER_GREY",
+      "WILDERNESS_SCORPION_EXIT",
+      "WILDERNESS_GWD_CREVICE"
     ],
     "uvOrientation": 768,
     "uvType": "BOX"
@@ -10549,15 +10549,15 @@
     "description": "Wilderness Ditch",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      23261,
-      23262,
-      23263,
-      23264,
-      23265,
-      23266,
-      23267,
-      23268,
-      23271
+      "DITCH_WILDERNESS1_GROUND",
+      "DITCH_WILDERNESS1A_GROUND",
+      "DITCH_WILDERNESS3_GROUND",
+      "DITCH_WILDERNESS3A_GROUND",
+      "DITCH_WILDERNESS4_GROUND",
+      "DITCH_WILDERNESS4A_GROUND",
+      "DITCH_WILDERNESSE_GROUND",
+      "DITCH_WILDERNESSEA_GROUND",
+      "DITCH_WILDERNESS_COVER"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -10578,16 +10578,16 @@
       }
     ],
     "objectIds": [
-      23269,
-      23270
+      "DITCH_WILDERNESS_END_NORTH",
+      "DITCH_WILDERNESS_END_SOUTH"
     ]
   },
   {
     "description": "Wilderness Ditch Dirt clumps",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      23272,
-      23273
+      "DITCH_SOIL_SOFT1",
+      "DITCH_SOIL_SOFT2"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.75
@@ -10596,28 +10596,28 @@
     "description": "Wilderness - Basalt rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      11176,
-      11177,
-      11178,
-      11179,
-      11180,
-      11181
+      "BASALT_FLOOR_DETAIL_1",
+      "BASALT_FLOOR_DETAIL_2",
+      "BASALT_STEP_1",
+      "BASALT_STEP_2",
+      "BASALT_STEP_3",
+      "BASALT_STEP_4"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Wilderness God Wars Dungeon - Boulder and Jutting Wall",
     "baseMaterial": "STONE",
-    "objectIds": [ 26768 ],
-    "npcIds": [ 6621, 6622 ],
+    "objectIds": [ "WILDERNESS_GWD_AGILITYOBSTACLE" ],
+    "npcIds": [ "WILDERNESS_GWD_BOULDER", "WILDERNESS_GWD_BOULDER_MOVING" ],
     "uvType": "GEOMETRY"
   },
   {
     "description": "Mage Arena - Objects - Stone - Sparkling Pool",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      2878,
-      2879
+      "MAGEARENA_WATERPORTAL1",
+      "MAGEARENA_WATERPORTAL2"
     ],
     "uvType": "VANILLA",
     "castShadows": false
@@ -10626,9 +10626,9 @@
     "description": "Mage Arena - Objects - God Statues",
     "baseMaterial": "MARBLE_3_GLOSS",
     "objectIds": [
-      2873,
-      2874,
-      2875
+      "MAGEARENA_STATUE_SARADOMIN",
+      "MAGEARENA_STATUE_ZAMORAK",
+      "MAGEARENA_STATUE_GUTHIX"
     ],
     "uvType": "VANILLA"
   },
@@ -10636,8 +10636,8 @@
     "description": "Deep Wilderness Dungeon - Agility Shortcut and Cave Web",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      727,
-      19043
+      "CAVE_EXIT",
+      "WILDERNESS_DEEP_CREVICE"
     ],
     "uvType": "BOX"
   },
@@ -10645,7 +10645,7 @@
     "description": "Deep Wilderness Dungeon - Mysterious Pool",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      30395
+      "WILDERNESS_CHAOSCAVE_WELL"
     ],
     "uvType": "BOX"
   },
@@ -10653,7 +10653,7 @@
     "description": "Wilderness - Rouges' Castle - Bed",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      14771
+      "WILD_BED"
     ],
     "uvType": "BOX"
   },
@@ -10661,7 +10661,7 @@
     "description": "Wilderness - Spear wall",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      3664
+      "DEATH_TROLL_SPEARWALL_STRAIGHT"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -10671,20 +10671,20 @@
     "description": "Wilderness - Roots",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      10064,
-      10065,
-      10066,
-      14568,
-      14569,
-      14570,
-      14640,
-      14759,
-      14760,
-      14761,
-      14598,
-      14597,
-      39683,
-      39684
+      "ROTTEN_ROOTS_1",
+      "ROTTEN_ROOTS_2",
+      "ROTTEN_ROOTS_3",
+      "WILD2_ROOT_1",
+      "WILD2_ROOT_2",
+      "WILD2_ROOT_3",
+      "WILD4_ROOT_2",
+      "WILD_WATER_ROOT_1",
+      "WILD_WATER_ROOT_2",
+      "WILD_WATER_ROOT_3",
+      "WILD3_ROOT_2",
+      "WILD3_ROOT_1",
+      "WILDY_HUB_ROOTS_1",
+      "WILDY_HUB_ROOTS_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -10693,13 +10693,13 @@
     "description": "Wilderness - Teleport Obelisk",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      14825,
-      14826,
-      14827,
-      14828,
-      14829,
-      14830,
-      14831
+      "WILDERNESS_PORTAL_STONE_GLOWING",
+      "WILDERNESS_PORTAL_STONE_0",
+      "WILDERNESS_PORTAL_STONE_1",
+      "WILDERNESS_PORTAL_STONE_2",
+      "WILDERNESS_PORTAL_STONE_3",
+      "WILDERNESS_PORTAL_STONE_4",
+      "WILDERNESS_PORTAL_STONE_5"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -10708,27 +10708,27 @@
     "description": "Wilderness - Venenatis/Spindel Lair - Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46999,
-      47000,
-      47001,
-      47002,
-      47003,
-      47004,
-      47016,
-      47017,
-      47018,
-      47019,
-      47020,
-      47028,
-      47029,
-      47030,
-      47031,
-      47032,
-      47033,
-      47034,
-      47035,
-      47036,
-      47037
+      "WILD_VENANATIS_EXIT_NOOP",
+      "WILD_VENANATIS_EXIT",
+      "WILD_VENANATIS_CAVEWALLA",
+      "WILD_VENANATIS_CAVEWALLB",
+      "WILD_VENANATIS_CAVEWALLC",
+      "WILD_VENANATIS_FALLOFF",
+      "WILD_VENANATIS_CAVETOP",
+      "WILD_VENANATIS_CAVETOP_WALLTOP01",
+      "WILD_VENANATIS_CAVETOP_WALLTOP02",
+      "WILD_VENANATIS_CAVETOP_WALLTOP03",
+      "WILD_VENANATIS_CAVETOP_WALLTOP04",
+      "WILD_VENANATIS_ANCHOR01",
+      "WILD_VENANATIS_ANCHOR02",
+      "WILD_VENANATIS_ANCHOR03",
+      "WILD_VENANATIS_ANCHOR04",
+      "WILD_VENANATIS_ANCHOR05",
+      "WILD_VENANATIS_ANCHOR06",
+      "WILD_VENANATIS_ANCHOR07",
+      "WILD_VENANATIS_ANCHOR08",
+      "WILD_VENANATIS_ANCHOR09",
+      "WILD_VENANATIS_ANCHOR10"
     ],
     "uvType": "BOX"
   },
@@ -10736,17 +10736,17 @@
     "description": "Wilderness - Venenatis/Spindel Lair - Dirt Trim",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      47005,
-      47006,
-      47007,
-      47008,
-      47009,
-      47010,
-      47011,
-      47012,
-      47013,
-      47014,
-      47015
+      "WILD_VENANATIS_EDGE_HALF1",
+      "WILD_VENANATIS_EDGE_HALF2",
+      "WILD_VENANATIS_EDGE_FULL1",
+      "WILD_VENANATIS_EDGE_FULL2",
+      "WILD_VENANATIS_EDGE_JOIN1",
+      "WILD_VENANATIS_EDGE_JOIN2",
+      "WILD_VENANATIS_CORNER_SMALL",
+      "WILD_VENANATIS_CORNER_INNER",
+      "WILD_VENANATIS_CORNER",
+      "WILD_VENANATIS_PLANE",
+      "WILD_VENANATIS_PLANE_SB"
     ],
     "uvType": "BOX",
     "uvScale": 0.66
@@ -10755,13 +10755,13 @@
     "description": "Wilderness - Venenatis/Spindel Lair - Web Sacks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      47021,
-      47022,
-      47023,
-      47068,
-      47069,
-      47070,
-      47071
+      "WILD_VENANATIS_STALAGMITE_WEBBED_LARGE",
+      "WILD_VENANATIS_STALAGMITE_WEBBED_SMALL",
+      "WILD_VENANATIS_STALAGMITE_WEBBED_CORNER",
+      "WILD_VENANATIS_WEBSACK_LAYING01",
+      "WILD_VENANATIS_WEBSACK_LAYING02",
+      "WILD_VENANATIS_WEBSACK_HANGING01",
+      "WILD_VENANATIS_WEBSACK_HANGING02"
     ],
     "uvType": "BOX",
     "uvScale": 0.66
@@ -10770,13 +10770,13 @@
     "description": "Wilderness - Vet'ion/Calvar'ion Lair - Arched Pillars",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      46926,
-      46927,
-      46928,
-      46929,
-      46930,
-      46931,
-      46932
+      "CAVEKIT_ROCK03_PILLAR01_LOWER01",
+      "CAVEKIT_ROCK03_PILLAR01_UPPER01",
+      "CAVEKIT_ROCK03_PILLAR01_LOWER01_MIRROR",
+      "CAVEKIT_ROCK03_PILLAR01_LOWER02",
+      "CAVEKIT_ROCK03_PILLAR01_LOWER02_MIRROR",
+      "CAVEKIT_ROCK03_PILLAR01_UPPER02",
+      "CAVEKIT_ROCK03_PILLAR01_UPPER02_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -10784,13 +10784,13 @@
     "description": "Wilderness - Vet'ion/Calvar'ion Lair - Dirt Wall",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      46914,
-      46915,
-      46916,
-      46917,
-      46918,
-      46919,
-      46920
+      "CAVEKIT_ROCK03_HIGH01",
+      "CAVEKIT_ROCK03_HIGH01_NOSHADOW",
+      "CAVEKIT_ROCK03_HIGH02",
+      "CAVEKIT_ROCK03_HIGH01_DARK",
+      "CAVEKIT_ROCK03_HIGH02_DARK",
+      "CAVEKIT_ROCK03_LOW01",
+      "CAVEKIT_ROCK03_LOW02"
     ],
     "uvType": "BOX"
   },
@@ -10798,11 +10798,11 @@
     "description": "Wilderness - Vet'ion/Calvar'ion Lair - Dirt Wall - Arch",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46921,
-      46922,
-      46923,
-      46924,
-      46925
+      "CAVEKIT_ROCK03_ARCH01",
+      "CAVEKIT_ROCK03_ARCH01_MIRROR",
+      "CAVEKIT_ROCK03_ARCH02",
+      "CAVEKIT_ROCK03_ARCH02_MIRROR",
+      "WILD_VETION_EXIT01"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -10811,8 +10811,8 @@
     "description": "Wilderness - Vet'ion/Calvar'ion Lair - Wall with Banner",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      46933,
-      46934
+      "CAVEKIT_ROCK03_FLAG01",
+      "CAVEKIT_ROCK03_FLAG01_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -10820,9 +10820,9 @@
     "description": "Wilderness - Vet'ion/Calvar'ion Lair - Altar",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      43108,
-      46910,
-      46911
+      "WILD_VETION_COFFIN01",
+      "WILD_VETION_COFFIN02",
+      "WILD_VETION_COFFIN03"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -10831,15 +10831,15 @@
     "description": "Wilderness - Vet'ion/Calvar'ion Lair - Carpet",
     "baseMaterial": "CARPET",
     "objectIds": [
-      46982,
-      46983,
-      46984,
-      46985,
-      46986,
-      46987,
-      46988,
-      46989,
-      46990
+      "TILEKIT_BRICK01_CARPET01",
+      "TILEKIT_BRICK01_CARPET02",
+      "TILEKIT_BRICK01_CARPET03",
+      "TILEKIT_BRICK01_CARPET04",
+      "TILEKIT_BRICK01_CARPET05",
+      "TILEKIT_BRICK01_FABRIC01",
+      "TILEKIT_BRICK01_FABRIC02",
+      "TILEKIT_BRICK01_FABRIC03",
+      "TILEKIT_BRICK01_FABRIC04"
     ],
     "uvType": "BOX"
   },
@@ -10847,7 +10847,7 @@
     "description": "Wilderness - Vet'ion/Calvar'ion Lair - Banner",
     "baseMaterial": "CARPET",
     "objectIds": [
-      46991
+      "WILD_VETION_FLAG01"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -10856,7 +10856,7 @@
     "description": "Wilderness - Vet'ion's Lair - Entrance",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46995
+      "WILD_VETION_ENTRANCE01"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -10865,11 +10865,11 @@
     "description": "Wilderness - Graveyard of Shadows - Gravestone",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      14765,
-      14766,
-      14767,
-      14768,
-      14769
+      "WILD_GRAVESTONE1",
+      "WILD_GRAVESTONE2",
+      "WILD_GRAVESTONE3",
+      "WILD_GRAVESTONE4",
+      "WILD_GRAVESTONE5"
     ],
     "uvType": "BOX"
   },
@@ -10877,7 +10877,7 @@
     "description": "Wilderness - Graveyard of Shadows - Calvar'ion Lair Entrance",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46996
+      "WILD_VETION_SINGLES_ENTRANCE01"
     ],
     "uvType": "VANILLA"
   },
@@ -10885,8 +10885,8 @@
     "description": "Wilderness - Artio/Callisto Lair Entrance",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      47140,
-      47141
+      "WILD_CALLISTO_ENTRANCE01",
+      "WILD_CALLISTO_SINGLES_ENTRANCE01"
     ],
     "uvType": "BOX"
   },
@@ -10894,13 +10894,13 @@
     "description": "Wilderness - Artio/Callisto Trees and Roots",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      47087,
-      47088,
-      47089,
-      47090,
-      47091,
-      47097,
-      47098
+      "TREE_PETRIFIED01_DEFAULT01",
+      "TREE_PETRIFIED01_DEFAULT02",
+      "TREE_PETRIFIED01_DEFAULT03",
+      "TREE_PETRIFIED01_DEFAULT04",
+      "TREE_PETRIFIED01_STUMP01",
+      "TREE_PETRIFIED01_ROOT03",
+      "TREE_PETRIFIED01_ROOT03_DARK"
     ],
     "uvType": "BOX",
     "uvScale": 0.76
@@ -10909,26 +10909,26 @@
     "description": "Wilderness - Artio/Callisto Walls and Rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      47092,
-      47093,
-      47094,
-      47095,
-      47096,
-      47099,
-      47135,
-      47136,
-      47137,
-      47138,
-      47139,
-      47142,
-      47143,
-      47144,
-      47116,
-      47118,
-      47119,
-      47120,
-      47121,
-      47122
+      "TREE_PETRIFIED01_ROOT01",
+      "TREE_PETRIFIED01_ROOT01_DARK",
+      "TREE_PETRIFIED01_ROOT02",
+      "TREE_PETRIFIED01_ROOT02_DARK",
+      "TREE_PETRIFIED01_ROOT02_LIGHT",
+      "TREE_PETRIFIED01_ROOT04",
+      "WILD_CALLISTO_ROCKS01",
+      "WILD_CALLISTO_ROCKS02",
+      "WILD_CALLISTO_ROCKS03",
+      "WILD_CALLISTO_ROCKS04",
+      "WILD_CALLISTO_ROCKS05",
+      "WILD_CALLISTO_ROCKS02_DARK",
+      "WILD_CALLISTO_ROCKS04_DARK",
+      "WILD_CALLISTO_ROCKS03_DARK",
+      "CAVEKIT_ROCK02_LOW01",
+      "CAVEKIT_ROCK02_LOW03",
+      "CAVEKIT_ROCK02_LOW04",
+      "CAVEKIT_ROCK02_LOW05",
+      "CAVEKIT_ROCK02_LOW06",
+      "WILD_CALLISTO_EXIT01"
     ],
     "uvType": "BOX"
   },
@@ -10936,7 +10936,7 @@
     "description": "Wilderness - Escape Caves - Entrance",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      47175
+      "WILD_CAVE_EXIT01"
     ],
     "uvType": "BOX"
   },
@@ -10944,7 +10944,7 @@
     "description": "Wilderness - Prayer Training Chaos Temple - Stained Glass Window",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      1849
+      "ELFCHURCHWINDOW"
     ],
     "uvType": "BOX"
   },
@@ -10952,9 +10952,9 @@
     "description": "Wilderness - Ladder",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      14758,
-      18987,
-      18989
+      "WILD_LADDERTOP_DUNGEON",
+      "WILDYMIRRORLADDERTOP1",
+      "WILDYMIRRORLADDERTOP2"
     ],
     "uvType": "BOX"
   },
@@ -10962,7 +10962,7 @@
     "description": "Wilderness - Revanant Caves - Cavern entrance",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      31556
+      "WILD_CAVE_ENTRANCE_HIGH"
     ],
     "uvType": "BOX"
   },
@@ -10970,7 +10970,7 @@
     "description": "Wilderness - Revanant Caves - Trapdoor Exit",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      31557
+      "WILD_CAVE_EXIT_SURFACE"
     ],
     "uvType": "BOX"
   },
@@ -10978,7 +10978,7 @@
     "description": "Wilderness - Chaos Dwarf Decorative Caves",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      719
+      "CAVEENTRANCE4"
     ],
     "uvType": "BOX"
   },
@@ -10986,7 +10986,7 @@
     "description": "Wilderness - Corporeal Beast Cave",
     "baseMaterial": "ROCK_3_DARK",
     "objectIds": [
-      678
+      "CORP_CAVE_ENTRANCE"
     ],
     "uvType": "BOX"
   },
@@ -10995,18 +10995,18 @@
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "areas": [ "Wilderness - Zombie Pirate Boat" ],
     "objectIds": [
-      22174, 22175, 22176, 22177, 22178, 22179, 22180, 22181, 22182,
-      22183, 22184, 22185, 22186, 22187, 22188, 22189, 22190, 22191,
-      22192, 22193, 22194, 22195, 22196, 22197, 22198, 22200, 22201,
-      22204, 22205, 22206, 22207, 22208, 22209, 22210, 22211, 22212,
-      22213, 22214, 22215, 22216, 22217, 22220, 22224, 22226, 22227,
-      22228, 22229, 22230, 22231, 22232, 22233, 22234, 22235, 22236,
-      22237, 22238, 22239, 22240, 22241, 22242, 22245, 22246, 22249,
-      22249, 22251, 22255, 22256, 22257, 22258, 22259, 22262, 22263,
-      22264, 22265, 22266, 22267, 22268, 22269, 22274, 22275, 22276,
-      22281, 22282, 22283, 22284, 22285, 22286, 22287, 22288, 22289,
-      22290, 22291, 22292, 22293, 22294, 22295, 22296, 22297, 22485,
-      22486, 22487, 22488, 53219, 53220, 53221
+      "BRAIN_BOAT_HULL_01", "BRAIN_BOAT_HULL_02", "BRAIN_BOAT_HULL_01_MIRROR", "BRAIN_BOAT_HULL_02_MIRROR", "BRAIN_BOAT_HULL_01_BROKEN", "BRAIN_BOAT_HULL_02_BROKEN", "BRAIN_BOAT_HULL_01_TOP", "BRAIN_BOAT_HULL_02_TOP", "BRAIN_BOAT_HULL_NOARCH",
+      "BRAIN_BOAT_HULL_NOARCH_MIRROR", "BRAIN_BOAT_HULL_REAR_CORNER", "BRAIN_BOAT_HULL_REAR_CORNER_MIRROR", "BRAIN_BOAT_HULL_BACK_01", "BRAIN_BOAT_HULL_BACK_01_MIRROR", "BRAIN_BOAT_HULL_BACK_02", "BRAIN_BOAT_HULL_BACK_02_MIRROR", "BRAIN_BOAT_HULL_BACK_03", "BRAIN_BOAT_EDGE_01",
+      "BRAIN_BOAT_EDGE_02", "BRAIN_BOAT_EDGE_03", "BRAIN_BOAT_EDGE_01_MIRROR", "BRAIN_BOAT_EDGE_02_MIRROR", "BRAIN_BOAT_EDGE_03_MIRROR", "BRAIN_BOAT_EDGE_CORNER", "BRAIN_BOAT_EDGE_CORNER_MIRROR", "BRAIN_BOAT_EDGE_STAIRS", "BRAIN_BOAT_EDGE_STAIRS_MIRROR",
+      "BRAIN_BOAT_EDGE_FRONT_1_A", "BRAIN_BOAT_EDGE_FRONT_2_A", "BRAIN_BOAT_EDGE_FRONT_2_B", "BRAIN_BOAT_EDGE_FRONT_1_A_MIRROR", "BRAIN_BOAT_EDGE_FRONT_2_A_MIRROR", "BRAIN_BOAT_EDGE_FRONT_2_B_MIRROR", "BRAIN_BOAT_HULL_FLOOR_EDGE", "BRAIN_BOAT_HULL_FLOOR_EDGE_MIRROR", "BRAIN_BOAT_HULL_FLOOR_01",
+      "BRAIN_BOAT_HULL_FLOOR_01_MIRROR", "BRAIN_BOAT_HULL_FLOOR_MID", "BRAIN_BOAT_HULL_FLOOR_EDGE_TOP", "BRAIN_BOAT_HULL_FLOOR_EDGE_TOP_MIRROR", "BRAIN_BOAT_HULL_FLOOR_MID_TOP", "BRAIN_BOAT_EDGE_FLOOR", "BRAIN_BOAT_FRONT_MAST_FRONT", "BRAIN_BOAT_UPPERFLOOR", "BRAIN_BOAT_UPPERFLOOR_MIRROR",
+      "BRAIN_BOAT_UPPERFLOOR_CORNER", "BRAIN_BOAT_UPPERFLOOR_CORNER_MIRROR", "BRAIN_BOAT_UPPERFLOOR_NOWINDOW", "BRAIN_BOAT_UPPERFLOOR_NOWINDOW_MIRROR", "BRAIN_BOAT_UPPERFLOOR_OUTSIDE_CORNER_01", "BRAIN_BOAT_UPPERFLOOR_OUTSIDE_CORNER_02", "BRAIN_BOAT_UPPERFLOOR_OUTSIDE_CORNER_01_MIRROR", "BRAIN_BOAT_UPPERFLOOR_OUTSIDE_CORNER_02_MIRROR", "BRAIN_BOAT_UPPERFLOOR_ONEWINDOW",
+      "BRAIN_BOAT_UPPERFLOOR_ONEWINDOW_MIRROR", "BRAIN_BOAT_UPPERFLOOR_REAR_CORNER", "BRAIN_BOAT_UPPERFLOOR_REAR_CORNER_MIRROR", "BRAIN_BOAT_UPPERFLOOR_BACK_01", "BRAIN_BOAT_UPPERFLOOR_BACK_01_MIRROR", "BRAIN_BOAT_UPPERFLOOR_BACK_02", "BRAIN_BOAT_UPPERFLOOR_STAIRS_SIDE_01", "BRAIN_BOAT_UPPERFLOOR_STAIRS_SIDE_01_MIRROR", "BRAIN_BOAT_UPPERFLOOR_STAIRS_MID_01",
+      "BRAIN_BOAT_UPPERFLOOR_STAIRS_MID_01", "BRAIN_BOAT_STAIRS_FLOOR", "BRAIN_BOAT_HULL_FRONT_1_A", "BRAIN_BOAT_HULL_FRONT_1_B", "BRAIN_BOAT_HULL_FRONT_2_A", "BRAIN_BOAT_HULL_FRONT_2_B", "BRAIN_BOAT_HULL_FRONT_3_A", "BRAIN_BOAT_HULL_FRONT_1_A_MIRROR", "BRAIN_BOAT_HULL_FRONT_1_B_MIRROR",
+      "BRAIN_BOAT_HULL_FRONT_2_A_MIRROR", "BRAIN_BOAT_HULL_FRONT_2_B_MIRROR", "BRAIN_BOAT_HULL_FRONT_3_A_MIRROR", "BRAIN_BOAT_HULL_FRONT_3_B_MIRROR", "BRAIN_BOAT_HULL_FRONT_FRONT", "BRAIN_BOAT_EDGE_FRONT_FRONT", "BRAIN_BOAT_LOC_LADDER_BOTTOM", "BRAIN_BOAT_LOC_LADDER_TOP", "BRAIN_BOAT_LOC_HULL_MAST",
+      "BRAIN_BOAT_ROOM_01", "BRAIN_BOAT_ROOM_02", "BRAIN_BOAT_ROOM_02_MIRROR", "BRAIN_BOAT_ROOM_03", "BRAIN_BOAT_ROOM_03_MIRROR", "BRAIN_BOAT_ROOM_04", "BRAIN_BOAT_ROOM_04_MIRROR", "BRAIN_BOAT_ROOM_05", "BRAIN_BOAT_ROOM_05_MIRROR",
+      "BRAIN_BOAT_ROOM_06", "BRAIN_BOAT_ROOM_06_MIRROR", "BRAIN_BOAT_ROOM_07", "BRAIN_BOAT_ROOM_07_MIRROR", "BRAIN_BOAT_ROOM_08", "BRAIN_BOAT_ROOM_08_MIRROR", "BRAIN_BOAT_ROOM_09", "BRAIN_BOAT_ROOM_TOP", "BRAIN_WALKWAY_01",
+      "BRAIN_WALKWAY_02", "BRAIN_WALKWAY_03", "BRAIN_WALKWAY_04", "BRAIN_BOAT_UPPERFLOOR_STAIRS_SIDE_02_INACTIVE", "BRAIN_BOAT_UPPERFLOOR_STAIRS_SIDE_02_MIRROR_INACTIVE", "BRAIN_BOAT_UPPERFLOOR_STAIRS_MID_02_INACTIVE"
     ],
     "uvType": "BOX"
   },
@@ -11015,8 +11015,8 @@
     "baseMaterial": "GRAY_70",
     "areas": [ "Wilderness - Zombie Pirate Boat" ],
     "objectIds": [
-      22271,
-      22272
+      "BRAIN_BOAT_LOC_CANNON",
+      "BRAIN_BOAT_LOC_CANNON_MIRROR"
     ]
   },
   {
@@ -11024,8 +11024,8 @@
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "areas": [ "Wilderness - Zombie Pirate Boat" ],
     "objectIds": [
-      53222,
-      53223
+      "WILDY_PIRATE_BOAT_LOCKER",
+      "WILDY_PIRATE_BOAT_LOCKER_OPEN"
     ]
   },
   {
@@ -11033,11 +11033,11 @@
     "baseMaterial": "GRUNGE_3",
     "areas": [ "Wilderness - Zombie Pirate Boat" ],
     "objectIds": [
-      22221,
-      22222,
-      22223,
-      22225,
-      22270
+      "BRAIN_BOAT_MAST_01_BOTTOM",
+      "BRAIN_BOAT_MAST_01_TOP",
+      "BRAIN_BOAT_FRONT_MAST_REAR",
+      "BRAIN_BOAT_FRONT_MAST_SAIL",
+      "BRAIN_BOAT_LOC_STEERING_WHEEL"
     ],
     "uvType": "BOX"
   },
@@ -11046,37 +11046,37 @@
     "baseMaterial": "ROCK_3",
     "areas": [ "Wilderness - Zombie Pirate Boat" ],
     "objectIds": [
-      22305,
-      22306,
-      22307,
-      22308,
-      22309,
-      22310,
-      22311,
-      22312,
-      22313,
-      22314,
-      22315,
-      22316,
-      22317,
-      22318,
-      22321,
-      22322,
-      22323,
-      22324,
-      22325,
-      22326,
-      22327,
-      22328,
-      22329,
-      22330,
-      22331,
-      22332,
-      22333,
-      22334,
-      22335,
-      22336,
-      22337
+      "BRAIN_ROCK_KIT_1X1_01",
+      "BRAIN_ROCK_KIT_1X1_02",
+      "BRAIN_ROCK_KIT_1X1_03",
+      "BRAIN_ROCK_KIT_3X3_A_01",
+      "BRAIN_ROCK_KIT_3X3_A_02",
+      "BRAIN_ROCK_KIT_3X3_A_03",
+      "BRAIN_ROCK_KIT_3X3_A_04",
+      "BRAIN_ROCK_KIT_3X3_A_05",
+      "BRAIN_ROCK_KIT_3X3_A_06",
+      "BRAIN_ROCK_KIT_3X3_A_07",
+      "BRAIN_ROCK_KIT_3X3_A_08",
+      "BRAIN_ROCK_KIT_3X3_B_01",
+      "BRAIN_ROCK_KIT_3X3_B_02",
+      "BRAIN_ROCK_KIT_3X3_B_03",
+      "BRAIN_ROCK_KIT_3X3_B_06",
+      "BRAIN_ROCK_KIT_3X3_B_07",
+      "BRAIN_ROCK_KIT_3X3_B_08",
+      "BRAIN_ROCK_KIT_3X3_B_09",
+      "BRAIN_ROCK_KIT_3X3_C_01",
+      "BRAIN_ROCK_KIT_3X3_C_02",
+      "BRAIN_ROCK_KIT_3X3_C_03",
+      "BRAIN_ROCK_KIT_3X3_C_04",
+      "BRAIN_ROCK_KIT_3X3_C_05",
+      "BRAIN_ROCK_KIT_3X3_C_06",
+      "BRAIN_ROCK_KIT_3X3_C_07",
+      "BRAIN_ROCK_KIT_3X3_C_08",
+      "BRAIN_ROCK_KIT_3X3_C_09",
+      "BRAIN_ROCK_KIT_2X2_A_01",
+      "BRAIN_ROCK_KIT_2X2_A_02",
+      "BRAIN_ROCK_KIT_2X2_A_03",
+      "BRAIN_ROCK_KIT_2X2_A_04"
     ],
     "uvType": "BOX"
   },
@@ -11084,10 +11084,10 @@
     "description": "Wilderness - Larran's Chests",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      33343,
-      34828,
-      34829,
-      34830
+      "SLAYER_LARRAN_CHEST_SMALL_CLOSED",
+      "SLAYER_LARRAN_CHEST_SMALL_OPEN",
+      "SLAYER_LARRAN_CHEST_BIG_CLOSED",
+      "SLAYER_LARRAN_CHEST_BIG_OPEN"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -11096,14 +11096,14 @@
     "description": "Wilderness - Agility Course - Pipe",
     "baseMaterial": "STONE",
     "objectIds": [
-      23137
+      "OBSTICAL_PIPE2"
     ]
   },
   {
     "description": "Wilderness - Agility Course - Rope Swing",
     "baseMaterial": "ROPE",
     "objectIds": [
-      23132
+      "OBSTICAL_ROPESWING2"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -11112,32 +11112,32 @@
     "description": "Wilderness - Agility Course - Spikes",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      23551,
-      53225
+      "SPIKEDPITLOW",
+      "SPIKES_MANY_NOBLOCKRANGE"
     ]
   },
   {
     "description": "Wilderness - Agility Course - Climbing Rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      23640,
-      23641,
-      23642,
-      23643
+      "WILDCLIMBINGROCK",
+      "CLIMBINGROCKS_INACTIVEGRAY",
+      "CLIMBINGROCKS_INACTIVE2GRAY",
+      "CLIMBINGROCKS_FALLOFFGRAY"
     ]
   },
   {
     "description": "Wilderness - Agility Course - Agility Dispenser",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      53224
+      "WILDY_AGILITY_PILLAR"
     ]
   },
   {
     "description": "Edgeville Wilderness Dungeon - Cave Wall - Opening",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      1477
+      "CAVEWALLTUNNEL"
     ],
     "uvType": "BOX"
   },
@@ -11145,11 +11145,11 @@
     "description": "Wall Decoration - Rocks",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      1474,
-      1493,
-      6393,
-      6394,
-      6395
+      "CAVE_DETAIL1R_DARK",
+      "CAVE_DETAIL1_GREY",
+      "CAVE_DETAIL1_VDARKBROWN",
+      "CAVE_DETAIL1R_VDARKBROWN",
+      "CAVE_DETAIL2_VDARKBROWN"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -11159,8 +11159,8 @@
     "description": "Wilderness - Objects - Mage Arena Level",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      9706,
-      9707
+      "MAGEARENA_LEVER_IN",
+      "MAGEARENA_LEVER_OUT"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.6
@@ -11169,8 +11169,8 @@
     "description": "Wilderness - Slayer Cave - Entrance Stairs",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      40388,
-      40390
+      "WILD_SLAYER_CAVE_SOUTH_ENTRANCE",
+      "WILD_SLAYER_CAVE_NORTH_ENTRANCE"
     ],
     "uvType": "BOX"
   },
@@ -11178,14 +11178,14 @@
     "description": "Wilderness - Slayer Cave - Walls",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      31559,
-      39713,
-      39714,
-      39715,
-      40389,
-      40391,
-      40392,
-      53259
+      "WILD_CAVE_WALL",
+      "WILDY_HUB_CAVE_LEDGE",
+      "WILDY_HUB_CAVE_STEPS_01",
+      "WILDY_HUB_CAVE_STEPS_02",
+      "WILD_SLAYER_CAVE_SOUTH_EXIT",
+      "WILD_SLAYER_CAVE_NORTH_EXIT",
+      "WILD_SLAYER_CAVE_LEDGE",
+      "WILDERNESS_SLAYER_CAVE_CREVICE"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -11199,8 +11199,8 @@
     "description": "Wilderness - Slayer Cave - Stalagmite",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      31569,
-      31570
+      "WILD_CAVE_STALAGMITE_01",
+      "WILD_CAVE_STALAGMITE_02"
     ],
     "uvType": "BOX",
     "uvScale": 0.32
@@ -11209,7 +11209,7 @@
     "description": "Chaos Altar",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      411
+      "CHAOSALTAR"
     ],
     "uvType": "BOX"
   },
@@ -11217,7 +11217,7 @@
     "description": "Player Killing - Loot Key Chest",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH_LIGHT",
     "objectIds": [
-      43484
+      "WILDY_HUB_LOOT_CHEST_CLOSED"
     ],
     "uvType": "BOX"
   },
@@ -11225,9 +11225,9 @@
     "description": "Objects - Wooden - Rocking Chair",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1096,
-      8694,
-      15681
+      "ROCKING_CHAIR",
+      "FARM_ROCKINGCHAIR",
+      "AIDE_ROCKINGCHAIR"
     ],
     "uvType": "BOX"
   },
@@ -11235,7 +11235,7 @@
     "description": "Objects - Wooden - Rocking Chair - Combined back",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12979
+      "QIP_SHEEP_SHEARER_ROCKING_CHAIR"
     ],
     "uvType": "BOX"
   },
@@ -11243,19 +11243,19 @@
     "description": "Objects - Wooden - Chair - No cushion",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1088,
-      3801,
-      4271,
-      7504,
-      9621,
-      10491,
-      11489,
-      12885,
-      14050,
-      15981,
-      17146,
-      20065,
-      24335
+      "CHAIR",
+      "TROLL_CHAIR",
+      "VIKING_LONGHALL_CHAIR",
+      "FARMING_CHAIR",
+      "RIMMINGTON_CHAIR",
+      "ELID_CHAIR1",
+      "DRAYNOR_CHAIR",
+      "BURGH_CHAIR1",
+      "FISHING_CONTEST_CHAIR",
+      "BREW_CHAIR",
+      "DK_CHAIR",
+      "QIP_WATCHTOWER_CHAIR",
+      "CANAFIS_CHAIR"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -11264,7 +11264,7 @@
   {
     "description": "Objects - Wooden - Chair - No cushion - Smashed",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1089, 3802, 49655 ],
+    "objectIds": [ "SMASHEDCHAIR", "TROLL_SMASHEDCHAIR", "POG_SMASHEDCHAIR" ],
     "uvType": "BOX",
     "uvOrientation": 512,
     "uvScale": 0.6
@@ -11273,12 +11273,12 @@
     "description": "Objects - Wooden - Chair 2",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      5346,
-      7182,
-      12887,
-      12888,
-      15091,
-      15682
+      "AHOY_CHAIR_2",
+      "FAI_VARROCK_CHAIR1",
+      "BURGH_CHAIR_3",
+      "BURGH_CHAIR_4",
+      "ROYAL_LONGHALL_CHAIR",
+      "AIDE_CHAIR"
     ],
     "uvType": "BOX"
   },
@@ -11286,8 +11286,8 @@
     "description": "Objects - Wooden - Chair - Plank Highback",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12973,
-      20352
+      "QIP_SHEEP_SHEARER_CHAIR",
+      "CONTACT_CHAIR4"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -11297,7 +11297,7 @@
     "description": "Objects - Wooden - Chair 3 - Mage Training Arena",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      10724
+      "MAGICTRAINING_ORNATECHAIR"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -11306,7 +11306,7 @@
     "description": "Objects - Stone - Chair 4 - Stone Chairs",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6194
+      "DWARF_KELDAGRIM_CHAIR"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -11315,7 +11315,7 @@
     "description": "Objects - Stone - Chair 5 - Stone Chair with cushion",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6195
+      "DWARF_KELDAGRIM_CHAIR_POSH"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -11327,8 +11327,8 @@
     "uvOrientation": 512,
     "uvScale": 0.6,
     "objectIds": [
-      1898,
-      1899
+      "OLDCHAIR",
+      "OLDCHAIR2"
     ]
   },
   {
@@ -11345,15 +11345,15 @@
       }
     ],
     "objectIds": [
-      1896
+      "OLDTHRONE"
     ]
   },
   {
     "description": "Objects - Wooden - Ugly combined backed wooden chair",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7433,
-      14853
+      "FAI_VARROCK_POSH_CHAIR2",
+      "FAI_VARROCK_POOR_CHAIR3"
     ],
     "uvType": "BOX"
   },
@@ -11361,7 +11361,7 @@
     "description": "Ugly combined backed wooden rocking chair - Broken",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      14850
+      "FAI_VARROCK_POOR_CHAIR2"
     ],
     "uvType": "BOX"
   },
@@ -11369,8 +11369,8 @@
     "description": "Objects - Wooden - Chair - High poly mesh",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      27512,
-      27513
+      "HOS_CHAIR_01",
+      "HOS_CHAIR_02"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -11405,20 +11405,20 @@
       }
     ],
     "objectIds": [
-      1090,
-      7404,
-      24103
+      "POSH_CHAIR",
+      "FAI_VARROCK_CHAIR_BLUE",
+      "FAI_FALADOR_POSH_CHAIR_WHITE"
     ]
   },
   {
     "description": "Objects - Wooden - Tables - Round",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      593,
-      598,
-      2335,
-      25733,
-      27544
+      "BIGROUNDTABLE",
+      "ROUNDTABLE",
+      "FAI_VARROCK_BLUE_INN_OUTDOOR_TABLE2",
+      "KR_SIN_ROUNDTABLE",
+      "HOS_ROUND_TABLE"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -11428,15 +11428,15 @@
     "description": "Objects - Wooden - Tables - Round - With Umbrella",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      2334
+      "FAI_VARROCK_BLUE_INN_OUTDOOR_TABLE1"
     ]
   },
   {
     "description": "Ardougne - Objects - Wooden - Stairs - Plank Textured",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      16667,
-      16668
+      "OUTDOORSTAIRS_WOODEN_TOP",
+      "OUTDOORSTAIRS_WOODEN_BOTTOM"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -11446,10 +11446,10 @@
     "description": "Objects - Metallic - Manhole",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      881,
-      882,
-      2543,
-      2545
+      "MANHOLECLOSED",
+      "MANHOLEOPEN",
+      "PLAGUEMANHOLECLOSED",
+      "PLAGUEMANHOLECOVER"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 100
@@ -11458,8 +11458,8 @@
     "description": "Objects - Stone - Large Gravestone - Large",
     "baseMaterial": "STONE_SEMIGLOSS",
     "objectIds": [
-      406,
-      1992
+      "LARGEGRAVE",
+      "GLARIALS_TOMBSTONE_WATERFALL_QUEST"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -11469,10 +11469,10 @@
     "description": "Ardougne - Walls - Stone - Zoo Fence",
     "baseMaterial": "STONE_SEMIGLOSS",
     "objectIds": [
-      21239,
-      21240,
-      21241,
-      21242
+      "PENG_ARDOUGNE_ZOO",
+      "PENG_ARDOUGNE_ZOO_SHORT",
+      "PENG_ARDOUGNE_ZOO_SHORT_L",
+      "PENG_ARDOUGNE_ZOO_SHORT_R"
     ],
     "uvType": "GEOMETRY",
     "flatNormals": true
@@ -11481,7 +11481,7 @@
     "description": "Ardougne - Walls - Stone - Zoo Ferret Fence",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      19995
+      "EP_FERRET_WALL01"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -11491,9 +11491,9 @@
     "description": "Ardougne - Cart - Broken",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      306,
-      327,
-      35869
+      "BROKENCART",
+      "BROKEN_CART_WHEEL",
+      "SOTE_HUNTING_CART_OP"
     ],
     "uvType": "BOX",
     "uvScale": 0.3
@@ -11502,8 +11502,8 @@
     "description": "Objects - Ardougne Castle Prison - Sewer Grate",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      35793,
-      35794
+      "SOTE_PRISON_GRATE_FIXED",
+      "SOTE_PRISON_GRATE_DAMAGED"
     ],
     "uvType": "MODEL_XY"
   },
@@ -11511,7 +11511,7 @@
     "description": "Objects - Ardougne Castle - Spear Wall",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      848
+      "SPEARWALL"
     ],
     "colorOverrides": [
       {
@@ -11527,9 +11527,9 @@
     "description": "Objects - Ardougne Castle - Timber Defence",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      3000,
-      3046,
-      1864
+      "TIMBERDEFENCE_EDGEL_NEW",
+      "TIMBERDEFENCE_EDGER_NEW",
+      "TIMBERDEFENCE_NEW"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -11545,8 +11545,8 @@
     "description": "Objects - Ardougne Castle - Standard",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      864,
-      866
+      "STANDARD1_KANDARIN",
+      "STANDARD2_KANDARIN"
     ],
     "colorOverrides": [
       {
@@ -11562,7 +11562,7 @@
     "description": "Objects - Ardougne Castle - Chairs with fabric",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      1097
+      "THRONE"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -11582,14 +11582,14 @@
     "description": "Objects - Ardougne Castle - Bathroom Table",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      592
+      "BATHTABLE"
     ]
   },
   {
     "description": "Objects - Ardougne Castle - Mirror",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      689
+      "BATHMIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -11609,12 +11609,12 @@
     "description": "Song of the Elves - Battle for West Ardougne - Barricade and Debris",
     "baseMaterial": "NONE",
     "objectIds": [
-      35804,
-      35805,
-      35806,
-      35813,
-      35814,
-      35871
+      "SOTE_BARRICADE",
+      "SOTE_BARRICADE_LEAVE",
+      "SOTE_BARRICADE_BURNING",
+      "SOTE_DEBRIS_1",
+      "SOTE_DEBRIS_2",
+      "SOTE_LLETYA_BARRICADE"
     ],
     "colorOverrides": [
       {
@@ -11632,42 +11632,42 @@
     "description": "Objects - Tree - Fake Dead Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      1133,
-      1134,
-      1135,
-      1136,
-      1137,
-      1138,
-      1139,
-      1140,
-      1141,
-      1142,
-      1143,
-      1287,
-      1288,
-      1384,
-      2447,
-      2448,
-      14593,
-      14594,
-      14595,
-      14635,
-      14636,
-      14637,
-      14664,
-      14666,
-      14693,
-      14694,
-      14695,
-      14696,
-      14738,
-      23559,
-      23530,
-      23561,
-      25169,
-      25174,
-      28658,
-      51766
+      "TK1",
+      "TK2",
+      "TK3",
+      "TK4",
+      "TK_R",
+      "TK_L",
+      "TK_END",
+      "TK_END2",
+      "TK_TOP",
+      "TK_TOP2",
+      "TK_NS",
+      "DEADTREE2_WEB_R",
+      "DEADTREE2_WEB_L",
+      "DEADTREE_BURNT",
+      "GRANDTREE_CLIMBTREE",
+      "GRANDTREE_DOWNTREE",
+      "WILD3_TREE_A",
+      "WILD3_TREE_B",
+      "WILD3_TREE_C",
+      "WILD4_TREE_A",
+      "WILD4_TREE_B",
+      "WILD4_TREE_C",
+      "WILD5_TREE_A",
+      "WILD5_TREE_C",
+      "WILD6_TREE_A",
+      "WILD6_TREE_B",
+      "WILD6_TREE_B_SNOW",
+      "WILD6_TREE_C",
+      "WILD_BURNT_TREE",
+      "CLIMBING_BRANCH",
+      "SLICE_HIDING_CRATES",
+      "CLIMBING_TREE2",
+      "DRAGON_SLAYER_QIP_BURNT_TREE",
+      "DRAGON_SLAYER_QIP_BURNT_FALLEN_TREE",
+      "MM2_GLOUGH_BRANCH_UP_HIDDEN",
+      "AVIUM_DEADTREE_1"
     ],
     "uvType": "BOX"
   },
@@ -11675,7 +11675,7 @@
     "description": "Gnome Stronghold - Objects - Tree - Fake Dead Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      1706
+      "BRIDGE_FLOORSUPPORT"
     ],
     "uvType": "BOX"
   },
@@ -11683,12 +11683,12 @@
     "description": "Ground Decoration - Sticks - Small",
     "baseMaterial": "BARK",
     "objectIds": [
-      1246,
-      1247,
-      1250,
-      1251,
-      1252,
-      48467
+      "FULL_TWIG",
+      "BROKEN_TWIG",
+      "BROKEN_TWIG_DARK",
+      "FULL_TWIG_LIGHT",
+      "BROKEN_TWIG_LIGHT",
+      "GROUNDCOVER_STRANGLER01_TWIGS04"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -11711,23 +11711,23 @@
       }
     ],
     "objectIds": [
-      1982
+      "GNOMEFENCE"
     ]
   },
   {
     "description": "Gnome - Walls - Rope Rails",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      1708
+      "BRIDGE_WALL"
     ]
   },
   {
     "description": "Gnome - Ground Decoration - Wooden - Log Supports",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1702,
-      1703,
-      1704
+      "BRIDGE_CORNERFLOOR",
+      "BRIDGE_FLOORLIGHT",
+      "BRIDGE_SIDEFLOOR"
     ],
     "uvType": "WORLD_XZ"
   },
@@ -11735,7 +11735,7 @@
     "description": "Gnome - Ground Decoration - Wooden - Log Bridges",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1701
+      "BRIDGE_FLOOR"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512,
@@ -11745,7 +11745,7 @@
     "description": "Gnome - Ground Decoration - Wooden - Log Bridges - Corner",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4045
+      "BRIDGE_CORNER_VIZ"
     ],
     "uvType": "MODEL_XZ_MIRROR_A",
     "uvOrientation": 256,
@@ -11755,7 +11755,7 @@
     "description": "Gnome - Objects - Wooden - Hammock",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      430
+      "HAMMOCK"
     ]
   },
   {
@@ -11771,7 +11771,7 @@
       }
     ],
     "objectIds": [
-      201
+      "GNOME_LAMP2"
     ]
   },
   {
@@ -11797,10 +11797,10 @@
       }
     ],
     "objectIds": [
-      1967,
-      1968,
-      1969,
-      1970
+      "TREEDOORL",
+      "TREEDOORR",
+      "TREEDOORL_OPEN",
+      "TREEDOORR_OPEN"
     ]
   },
   {
@@ -11819,8 +11819,8 @@
       }
     ],
     "objectIds": [
-      571,
-      572
+      "GNOMEBUST1",
+      "GNOMEBUST2"
     ]
   },
   {
@@ -11829,7 +11829,7 @@
     "uvType": "BOX",
     "uvScale": 0.48,
     "objectIds": [
-      1104
+      "GNOMEBENCH"
     ]
   },
   {
@@ -11838,7 +11838,7 @@
     "uvType": "BOX",
     "uvOrientation": 600,
     "objectIds": [
-      1103
+      "GNOMESTOOL"
     ]
   },
   {
@@ -11854,32 +11854,32 @@
       }
     ],
     "objectIds": [
-      600
+      "GNOMETABLE"
     ]
   },
   {
     "description": "Gnome - Objects - Wooden - Staircase Rails - Textured",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      16677
+      "SPIRALSTAIRSTOP_WOODEN"
     ]
   },
   {
     "description": "Ground Decoration - Wooden - Agility Logs",
     "baseMaterial": "BARK",
     "objectIds": [
-      3929,
-      3930,
-      3931,
-      3932,
-      3933,
-      23141,
-      23142,
-      23143,
-      23144,
-      23145,
-      23274,
-      23542
+      "REGICIDE_LOGBALANCE1",
+      "REGICIDE_LOGBALANCE2",
+      "REGICIDE_LOGBALANCE1_START",
+      "REGICIDE_LOGBALANCE2_START",
+      "REGICIDE_LOGBALANCE3_START",
+      "LOG_BALANCE1",
+      "LOG_BALANCE2",
+      "LOG_BALANCE3",
+      "BARBARIAN_LOG_BALANCE1",
+      "GNOME_LOG_BALANCE1",
+      "MINE_LOG_BALANCE1",
+      "WILDERNESS_LOG_BALANCE1"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512
@@ -11888,22 +11888,22 @@
     "description": "Objects - Ice Rocks - Small",
     "baseMaterial": "ICE_1",
     "objectIds": [
-      3550,
-      10593,
-      21135,
-      21136,
-      21137,
-      21138,
-      21148,
-      21149,
-      21150,
-      21151,
-      21152,
-      21153,
-      21154,
-      21155,
-      21156,
-      21178
+      "INVISWALL_SERVERSIDE",
+      "WYVERN_DUGUPSOIL_2",
+      "PENG_AGILITY_WATERCHUNKS01",
+      "PENG_AGILITY_WATERCHUNKS02",
+      "PENG_AGILITY_SLEDGE_TRACKS01",
+      "PENG_AGILITY_SLEDGE_TRACKS02",
+      "PENG_AGILITY_SLIPPERY_GLITTERS01",
+      "PENG_AGILITY_SLIPPERY_GLITTERS02",
+      "PENG_AGILITY_SLIPPERY_GLITTERS03",
+      "PENG_AGILITY_SLIPPERY_GLITTERS04",
+      "PENG_AGILITY_SLIPPERY_GLITTERS05",
+      "PENG_AGILITY_SLIPPERY_GLITTERS06",
+      "PENG_AGILITY_SLIPPERY_GLITTERS07",
+      "PENG_AGILITY_SLIPPERY_GLITTERS08",
+      "PENG_AGILITY_SLIPPERY_GLITTERS09",
+      "PENG_SNOWPILE"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.6
@@ -11912,29 +11912,29 @@
     "description": "Objects - Ice Rocks - Large",
     "baseMaterial": "ICE_1",
     "objectIds": [
-      1444,
-      6475,
-      21095,
-      21096,
-      21097,
-      21098,
-      21099,
-      21101,
-      21110,
-      21111,
-      21120,
-      21121,
-      21122,
-      21123,
-      21124,
-      21221,
-      21222,
-      21227,
-      21228,
-      21229,
-      21230,
-      21231,
-      21233
+      "CAVE_DETAIL1_WHITE",
+      "TROLLRESCUE_ICESLIDE4",
+      "PENG_AGILITY_STEPS01",
+      "PENG_AGILITY_ICICLEPILLAR01",
+      "PENG_AGILITY_ICICLEPILLAR_TOP",
+      "PENG_AGILITY_ICICLE01",
+      "PENG_AGILITY_ICEBLOCKADE01",
+      "PENG_AGILITY_ICEBLOCKADE03",
+      "PENG_AGILITY_ICEPLATEAU01",
+      "PENG_AGILITY_ICEPLATEAU02",
+      "PENG_AGILITY_CRUSHCOURSE_STEPSTONE01",
+      "PENG_AGILITY_CRUSHCOURSE_STEPSTONE02",
+      "PENG_AGILITY_CRUSHCOURSE_STEPSTONE03",
+      "PENG_AGILITY_CRUSHCOURSE_STEPSTONE04",
+      "PENG_AGILITY_CRUSHCOURSE_STEPSTONE05",
+      "PENG_FORMATION3",
+      "PENG_FORMATION4",
+      "PENG_WATER_FORMATION1",
+      "PENG_WATER_FORMATION2",
+      "PENG_WATER_FORMATION3",
+      "PENG_WATER_FORMATION4",
+      "PENG_WATER_FORMATION_STALAGMITE",
+      "PENG_WATER_FORMATION_STALAGMITE2"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.25
@@ -11943,12 +11943,12 @@
     "description": "Ground - Snow Piles - Tiny",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      559,
-      560,
-      561,
-      21074,
-      21103,
-      21105
+      "SNOW1",
+      "SNOW2",
+      "SNOW3",
+      "PENG_BASE_LINE",
+      "PENG_AGILITY_SNOW01",
+      "PENG_AGILITY_SNOW03"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 2.0
@@ -11957,9 +11957,9 @@
     "description": "Ground - Snow Piles - Small",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      5033,
-      5034,
-      21104
+      "TROLLROMANCE_ROCKSLIDE5",
+      "TROLLROMANCE_ROCKSLIDE6",
+      "PENG_AGILITY_SNOW02"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -11968,24 +11968,24 @@
     "description": "Objects - Snow Piles - Large",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      5029,
-      5030,
-      5031,
-      10590,
-      10591,
-      21159,
-      21199,
-      21200,
-      21158,
-      21159,
-      21199,
-      21200,
-      21224,
-      26413,
-      26485,
-      26486,
-      26399,
-      27925
+      "TROLLROMANCE_ROCKSLIDE1",
+      "TROLLROMANCE_ROCKSLIDE2",
+      "TROLLROMANCE_ROCKSLIDE3",
+      "WYVERN_ROCKS_1",
+      "WYVERN_ROCKS_1_LARGE",
+      "PENG_AVAL_R",
+      "PENG_AVAL_ROCK1",
+      "PENG_AVAL_ROCK2",
+      "PENG_AVAL_L",
+      "PENG_AVAL_R",
+      "PENG_AVAL_ROCK1",
+      "PENG_AVAL_ROCK2",
+      "PENG_FORMATION_STALAGMITE2",
+      "GODWARS_ENTRANCE_BOULDER_ROCK03",
+      "GODWARS_DUNGEON_ARCHITECTURE_BIGROCKS01",
+      "GODWARS_DUNGEON_ARCHITECTURE_BIGROCKS02",
+      "GODWARS_ENTRANCE_ROCK01",
+      "ARCHEUUS_SNOW_LARGE_01"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.6
@@ -11994,8 +11994,8 @@
     "description": "Objects - Ice - Giant",
     "baseMaterial": "ICE_3",
     "objectIds": [
-      21219,
-      21220
+      "PENG_FORMATION1",
+      "PENG_FORMATION2"
     ],
     "uvType": "GEOMETRY",
     "uvOrientation": 245,
@@ -12005,21 +12005,21 @@
     "description": "Objects - Ice Stalagmite",
     "baseMaterial": "ICE_1",
     "objectIds": [
-      10602,
-      10603,
-      10604,
-      21100,
-      21139,
-      21140,
-      21141,
-      21223,
-      21225,
-      21226,
-      21235,
-      21236,
-      21237,
-      21238,
-      21334
+      "WYVERN_ICICLE_STANDARD",
+      "WYVERN_ICICLE_FALLOFF",
+      "WYVERN_ICICLE_BIG",
+      "PENG_AGILITY_ICEBLOCKADE02",
+      "PENG_AGILITY_ICEBLOCK01",
+      "PENG_AGILITY_ICEBLOCK02",
+      "PENG_AGILITY_ICEBLOCK03",
+      "PENG_FORMATION_STALAGMITE",
+      "PENG_FORMATION_STALAGMITE_LARGE",
+      "PENG_FORMATION_STALAGMITE_GROUP",
+      "PENG_WATER_FORMATION_STALAGMITE_LARGE",
+      "PENG_WATER_FORMATION_STALAGMITE_LARGE_LOWMEM",
+      "PENG_WATER_FORMATION_STALAGMITE_GROUP",
+      "PENG_WATER_FORMATION_STALAGMITE_GROUP_LOWMEM",
+      "FRIS_PALISADE_WALKWAY_END"
     ],
     "uvType": "WORLD_XY",
     "uvScale": 0.25
@@ -12028,7 +12028,7 @@
     "description": "Firm Snowy Patch",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      21179
+      "PENG_OBSERVER_CABIN_NOTBUILD"
     ],
     "uvType": "WORLD_XZ"
   },
@@ -12036,47 +12036,47 @@
     "description": "Ice Walls",
     "baseMaterial": "ICE_2",
     "objectIds": [
-      21034,
-      21035,
-      21036,
-      21037,
-      21038,
-      21039,
-      21040,
-      21041,
-      21042,
-      21043,
-      21044,
-      21045,
-      21046,
-      21047,
-      21048,
-      21049,
-      21050,
-      21051,
-      21052,
-      21053,
-      21054,
-      21055,
-      21058,
-      21059,
-      21060,
-      21061,
-      21062,
-      21063,
-      21064,
-      21065,
-      21066,
-      21067,
-      21069,
-      21070,
-      21071,
-      21072,
-      21077,
-      21166,
-      21169,
-      21170,
-      21171
+      "PENG_BASE",
+      "PENG_BASE_CHASM",
+      "PENG_BASE01",
+      "PENG_BASE02",
+      "PENG_BASE03",
+      "PENG_BASE_LIGHT",
+      "PENG_BASE_BANNER_L",
+      "PENG_BASE_BANNER_R",
+      "PENG_BASE_PILLAR",
+      "PENG_BASE_PILLAR_MIRROR",
+      "PENG_BASE_PILLAR2",
+      "PENG_BASE_PILLAR2_MIRROR",
+      "PENG_BASE_ROOF",
+      "PENG_BASE_ROOF_L",
+      "PENG_BASE_ROOF_R",
+      "PENG_BASE_ROOF_L_TERM",
+      "PENG_BASE_ROOF_R_TERM",
+      "PENG_BASE_ROOF2",
+      "PENG_BASE_ROOF2_L",
+      "PENG_BASE_ROOF2_R",
+      "PENG_BASE_BOOTH_JOIN",
+      "PENG_BASE_BOOTH_FRONT",
+      "PENG_BASE_DOOR_FRONT_L",
+      "PENG_BASE_DOOR_FRONT_R",
+      "PENG_BASE_DOOR_SURROUND",
+      "PENG_BASE_DOOR_SURROUND_INNER",
+      "PENG_BASE_DOOR_TOP",
+      "PENG_BASE_DOOR_JOIN_INNER_L",
+      "PENG_BASE_DOOR_JOIN_INNER_R",
+      "PENG_BASE_DOOR_ICELORDS",
+      "PENG_BASE_DOUBLE_DOOR_L",
+      "PENG_BASE_DOUBLE_DOOR_R",
+      "PENG_BASE_BLAST_DOOR_JOIN_R",
+      "PENG_BASE_BLAST_DOOR_JOIN_L",
+      "PENG_BASE_BLAST_DOOR_COVER_R",
+      "PENG_BASE_BLAST_DOOR_COVER_L",
+      "PENG_BASE_SPIKES",
+      "PENG_BASE_DOOR_INACTIVE",
+      "PENG_BASE_DOUBLE_DOOR_MID_AGILITY",
+      "PENG_CLIFFWALL_DOOR_MID",
+      "PENG_BASE_DOUBLE_DOOR_MID"
     ],
     "uvType": "MODEL_XY",
     "uvScale": 0.48,
@@ -12086,8 +12086,8 @@
     "description": "Ice Walls - Rotated",
     "baseMaterial": "ICE_2",
     "objectIds": [
-      21056,
-      21057
+      "PENG_BASE_BOOTH_SIDE",
+      "PENG_BASE_BOOTH_END"
     ],
     "uvType": "MODEL_YZ",
     "uvScale": 0.48,
@@ -12097,7 +12097,7 @@
     "description": "Ice Walls Cap",
     "baseMaterial": "ICE_1",
     "objectIds": [
-      21196
+      "PENG_CLIFFWALL_2_TOP"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.33
@@ -12106,9 +12106,9 @@
     "description": "Penguin Metal Doors",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      21160,
-      21161,
-      21068
+      "PENG_BASE_DOOR",
+      "PENG_BASE_DOOR_OPEN",
+      "PENG_BASE_BLAST_DOOR"
     ],
     "uvType": "MODEL_XY"
   },
@@ -12116,16 +12116,16 @@
     "description": "WALLS - ICE FENCE",
     "baseMaterial": "ICE_4",
     "objectIds": [
-      21017,
-      21088,
-      21078,
-      21079,
-      21080,
-      21081,
-      21082,
-      21083,
-      21172,
-      21167
+      "PENG_AGILITY_FENCING_MIRROR",
+      "PENG_AGILITY_FENCING",
+      "PENG_ICELORDS_PEN",
+      "PENG_ICELORDS_PEN02",
+      "PENG_ICELORDS_PEN_ROOF",
+      "PENG_ICELORDS_PEN_ROOF_CORNER",
+      "PENG_ICELORDS_PEN_ROOF02",
+      "PENG_ICELORDS_PEN_ROOF_CORNER02",
+      "PENG_AGILITY_FENCING_DOOR",
+      "PENG_ICELORD_PEN_DOOR"
     ],
     "uvType": "GEOMETRY"
   },
@@ -12133,7 +12133,7 @@
     "description": "Cold War - Larrys Boat",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      21177
+      "PENG_BOAT_ICE"
     ],
     "uvType": "BOX"
   },
@@ -12141,8 +12141,8 @@
     "description": "Iceberg - Bird Hide - Uncovered and Broken",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      21180,
-      21182
+      "PENG_OBSERVER_CABIN_BUILT",
+      "PENG_OBSERVER_CABIN_BLOWNUP"
     ],
     "uvType": "BOX",
     "uvScale": 0.76
@@ -12151,7 +12151,7 @@
     "description": "Iceberg - Bird Hide - Covered",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      21181
+      "PENG_OBSERVER_CABIN_BUILT_SNOWY"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -12161,8 +12161,8 @@
     "description": "Iceberg - Agility Course - Snow Drift",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      21142,
-      21143
+      "PENG_AGILITY_OBSTACLEJUMP01",
+      "PENG_AGILITY_OBSTACLEJUMP02"
     ],
     "uvType": "BOX"
   },
@@ -12171,8 +12171,8 @@
     "baseMaterial": "SNOW_2",
     "uvType": "WORLD_XZ",
     "objectIds": [
-      21183,
-      21184
+      "PENG_FOOTPRINTS_STRAIGHT01",
+      "PENG_FOOTPRINTS_CORNER01"
     ],
     "castShadows": false,
     "receiveShadows": false
@@ -12181,52 +12181,52 @@
     "description": "Big Red Button",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      21086
+      "PENG_BASE_DOOR_BUTTON"
     ]
   },
   {
     "description": "Ice Walls 2",
     "baseMaterial": "ICE_1",
     "objectIds": [
-      21112,
-      21113,
-      21114,
-      21115,
-      21116,
-      21117,
-      21118,
-      21119,
-      21157,
-      21186,
-      21187,
-      21188,
-      21189,
-      21190,
-      21191,
-      21192,
-      21193,
-      21194,
-      21195,
-      21197,
-      21198,
-      21201,
-      21202,
-      21203,
-      21204,
-      21205,
-      21206,
-      21207,
-      21208,
-      21209,
-      21210,
-      21211,
-      21212,
-      21213,
-      21214,
-      21215,
-      21216,
-      21217,
-      21218
+      "PENG_AGILITY_CRUSHCOURSE_PIECE01",
+      "PENG_AGILITY_CRUSHCOURSE_PIECE02",
+      "PENG_AGILITY_CRUSHCOURSE_PIECE03",
+      "PENG_AGILITY_CRUSHCOURSE_PIECE04",
+      "PENG_AGILITY_CRUSHCOURSE_PIECE05",
+      "PENG_AGILITY_CRUSHCOURSE_PIECE06",
+      "PENG_AGILITY_CRUSHCOURSE_PIECE07",
+      "PENG_AGILITY_CRUSHCOURSE_PIECE08",
+      "PENG_CRACK01",
+      "PENG_CLIFFWALL_1",
+      "PENG_CLIFFWALL_CHASM",
+      "PENG_CLIFFWALL_1_CRACK",
+      "PENG_CLIFFWALL_1_LEDGE",
+      "PENG_CLIFFWALL_1_CRACK_BIG",
+      "PENG_CLIFFWALL_2",
+      "PENG_CLIFFWALL_2_CRACK",
+      "PENG_CLIFFWALL_2_BREAK",
+      "PENG_CLIFFWALL_2_LEDGE",
+      "PENG_CLIFFWALL_2_CRACK_BIG",
+      "PENG_AVAL_WALL_L",
+      "PENG_AVAL_WALL_R",
+      "PENG_CLIFFWALL_DOOR_R",
+      "PENG_CLIFFWALL_DOOR_L",
+      "PENG_WATER_CLIFFWALL_1",
+      "PENG_WATER_CLIFFWALL_1_CRACK",
+      "PENG_WATER_CLIFFWALL_1_LEDGE",
+      "PENG_WATER_CLIFFWALL_1_CRACK_BIG",
+      "PENG_COAST_1",
+      "PENG_COAST_2",
+      "PENG_COAST_3",
+      "PENG_COAST_4",
+      "PENG_COAST_5",
+      "PENG_COAST_6",
+      "PENG_COAST_7",
+      "PENG_COAST_8",
+      "PENG_COAST_9",
+      "PENG_COAST_10",
+      "PENG_COAST_11",
+      "PENG_COAST_12"
     ],
     "uvType": "MODEL_XY",
     "uvScale": 0.33
@@ -12234,7 +12234,7 @@
   {
     "description": "Remove exaggerated flickering from magical shield on the top floor of the Watchtower",
     "objectIds": [
-      2842
+      "MAGICALSHIELD"
     ],
     "baseMaterial": "UNLIT"
   },
@@ -12242,19 +12242,19 @@
     "description": "Jatizso banners",
     "baseMaterial": "UNLIT",
     "objectIds": [
-      21637
+      "FRISD_BANNER02"
     ]
   },
   {
     "description": "Footprints on agility rooftops",
     "objectIds": [
-      39522,
-      39626,
-      39627,
-      39628,
-      39629,
-      39631,
-      39632
+      "ROOFTOP_FOOTPRINTS_SEERS",
+      "ROOFTOP_FOOTPRINTS_DIAGONAL_SEERS",
+      "ROOFTOP_FOOTPRINTS_SAND",
+      "ROOFTOP_FOOTPRINTS_DIAGONAL_SAND",
+      "ROOFTOP_FOOTPRINTS_DIAGONAL_FALLOFF_SAND",
+      "ROOFTOP_FOOTPRINTS_BROWN",
+      "ROOFTOP_FOOTPRINTS_DIAGONAL_BROWN"
     ],
     "castShadows": false,
     "receiveShadows": false
@@ -12263,22 +12263,22 @@
     "description": "Zanaris - Walls - Grass",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      12007,
-      12009,
-      12010,
-      12011,
-      12012,
-      12013,
-      12014,
-      12015,
-      12016,
-      12017,
-      12018,
-      12026,
-      12027,
-      12029,
-      17001,
-      17002
+      "FAIRY_WALL",
+      "FAIRY_WALL_MUSH_GREEN",
+      "FAIRY_WALL_MUSH_RED",
+      "FAIRY_WALL_MUSH_GREEN_VAR",
+      "FAIRY_WALL_MUSH_RED_VAR",
+      "FAIRY_WALL_LV2",
+      "FAIRY_WALL_LV2_MUSH_GREEN",
+      "FAIRY_WALL_LV2_MUSH_RED",
+      "FAIRY_WALL_LV2_MUSH_RED_VAR",
+      "FAIRY_WALL_LV2_MUSH_GREEN_VAR",
+      "FAIRY_WALL_LV2_TENTACLE",
+      "FAIRY_WALL_ALCOVE",
+      "FAIRY_WALL_MID_FILL",
+      "FAIRY_WALL_LV2_MID_FILL",
+      "FAIRY_SC_SPEARTRAP",
+      "FAIRY_SC_JUTTINGWALL"
     ],
     "uvType": "BOX"
   },
@@ -12286,9 +12286,9 @@
     "description": "Zanaris - Objects - Mushroom Ceiling Objects",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      12019,
-      12020,
-      12021
+      "FAIRY_WALL_TOP_MUSH_RED",
+      "FAIRY_WALL_TOP_MUSH_GREEN",
+      "FAIRY_WALL_TOP_TENTACLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -12297,52 +12297,52 @@
     "description": "Zanaris - Walls - Dirt",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      6926,
-      12004,
-      12031,
-      12032,
-      12033,
-      12034,
-      12035,
-      12038,
-      12039,
-      12109,
-      16310,
-      16311,
-      16312,
-      16313,
-      16314
+      "INVISABLE_NONBLOCKING_WALL",
+      "FAIRY_WALL_TANGLE_DOOR_OPEN1",
+      "TANGLEFOOT_WALL",
+      "TANGLEFOOT_WALLM",
+      "TANGLEFOOT_WALL_TOP_MUSH_GREEN",
+      "TANGLEFOOT_WALL_TOP_MUSH_RED",
+      "TANGLE_WALL_RED",
+      "TANGLE_WALL_FILL_MUSH_GREEN",
+      "TANGLE_WALL_FILL_MUSH_RED",
+      "FAIRY_WALL_DISGUISED",
+      "FAIRYTALE2_WALLTOP_CORNER_BTOB",
+      "FAIRYTALE2_WALLTOP_STRAIGHT_BTOB",
+      "FAIRYTALE2_WALLTOP_INCORNER_BTOB",
+      "FAIRYTALE2_WALLTOP_INCORNER_INV_BTOB",
+      "FAIRYTALE2_WALLTOP_MID_FILL"
     ]
   },
   {
     "description": "Ice Gate",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      5043,
-      5044
+      "ICEGATE_LEFT",
+      "ICEGATE_RIGHT"
     ]
   },
   {
     "description": "Snow Walls",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      5017,
-      5018,
-      5019,
-      5020,
-      5021,
-      5022,
-      5025,
-      40889,
-      40890,
-      40928
+      "TROLLROMANCE_SNOW_CAVEWALL_FACE1",
+      "TROLLROMANCE_SNOW_CAVEWALL_TOP",
+      "TROLLROMANCE_SNOW_CAVEWALL_TOP5",
+      "TROLLROMANCE_SNOW_CAVEWALL_TOP_HIGHER",
+      "TROLLROMANCE_SNOW_CAVEWALL_FACE1_SHORTER",
+      "TROLLROMANCE_SNOW_CAVEWALL_TOP_SHORTER",
+      "TROLLROMANCE_SNOW_CAVEWALL_CREVIS",
+      "XMAS20_CREVICE",
+      "XMAS20_CREVICE_UPSTAIRS",
+      "XMAS20_CAVEWALL"
     ]
   },
   {
     "description": "Ground Objects - White Rock-like Objects - Tiny - Colored",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      5027
+      "TROLLROMANCE_DUGUPSOIL_2"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.6,
@@ -12352,8 +12352,8 @@
     "description": "Ground Objects - White Rock-like Objects - Small - Colored",
     "baseMaterial": "SNOW_3",
     "objectIds": [
-      5026,
-      5028
+      "TROLLROMANCE_DUGUPSOIL_1",
+      "TROLLROMANCE_DUGUPSOIL_3"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.6,
@@ -12362,15 +12362,15 @@
   {
     "description": "POH carpets",
     "objectIds": [
-      6759,
-      6760,
-      6761,
-      6762,
-      6763,
-      6764,
-      6765,
-      6766,
-      6767
+      "POH_RUGCORNER1",
+      "POH_RUGSIDE1",
+      "POH_RUGMIDDLE1",
+      "POH_RUGCORNER2",
+      "POH_RUGSIDE2",
+      "POH_RUGMIDDLE2",
+      "POH_RUGCORNER3",
+      "POH_RUGSIDE3",
+      "POH_RUGMIDDLE3"
     ],
     "baseMaterial": "CARPET",
     "uvType": "WORLD_XZ",
@@ -12380,11 +12380,11 @@
   {
     "description": "POH superior garden zen theme carpet",
     "objectIds": [
-      29242,
-      29243,
-      29244,
-      29245,
-      29246
+      "POH_THEME_ZEN_PATH",
+      "POH_THEME_ZEN_PATH_CORNER",
+      "POH_THEME_ZEN_EDGE",
+      "POH_THEME_ZEN_INNER_CORNER",
+      "POH_THEME_ZEN_OUTER_CORNER"
     ],
     "flatNormals": true,
     "castShadows": false
@@ -12392,29 +12392,29 @@
   {
     "description": "POH basement filler objects",
     "objectIds": [
-      13026,
-      13027,
-      13028,
-      13068
+      "DUNGEON_RUBBLE_CORRIDORFILLER",
+      "DUNGEON_RUBBLE_CORRIDORFILLERL",
+      "DUNGEON_RUBBLE_CORRIDORFILLERR",
+      "DUNGEON_WALLTOP_RUBBLE"
     ],
     "castShadows": false
   },
   {
     "description": "Circular ground portals near runic altars",
     "objectIds": [
-      34749,
-      34750,
-      34751,
-      34752,
-      34753,
-      34754,
-      34755,
-      34756,
-      34757,
-      34758,
-      34759,
-      43478,
-      26149
+      "MINDTEMPLE_EXIT_PORTAL",
+      "WATERTEMPLE_EXIT_PORTAL",
+      "EARTHTEMPLE_EXIT_PORTAL",
+      "FIRETEMPLE_EXIT_PORTAL",
+      "BODYTEMPLE_EXIT_PORTAL",
+      "COSMICTEMPLE_EXIT_PORTAL",
+      "LAWTEMPLE_EXIT_PORTAL",
+      "NATURETEMPLE_EXIT_PORTAL",
+      "CHAOSTEMPLE_EXIT_PORTAL",
+      "DEATHTEMPLE_EXIT_PORTAL",
+      "WRATHTEMPLE_EXIT_PORTAL",
+      "BLOODTEMPLE_EXIT_PORTAL",
+      "RCU_ABYSSAL_ENERGY_APOCALYPSE"
     ],
     "baseMaterial": "UNLIT",
     "castShadows": false
@@ -12422,315 +12422,315 @@
   {
     "description": "Remove flickering shadows from various portals",
     "objectIds": [
-      2156,
-      2157,
-      2158,
-      2880,
-      4150,
-      4151,
-      4152,
-      4153,
-      4154,
-      4155,
-      4156,
-      4157,
-      4387,
-      4388,
-      4389,
-      4390,
-      4406,
-      4407,
-      4408,
-      4525,
-      6282,
-      6551,
-      7272,
-      7273,
-      7288,
-      7289,
-      7315,
-      7316,
-      7318,
-      7319,
-      7321,
-      7322,
-      7324,
-      7325,
-      7352,
-      7353,
-      7819,
-      7820,
-      9368,
-      9369,
-      10251,
-      10733,
-      11356,
-      11357,
-      12260,
-      12355,
-      12356,
-      13616,
-      13617,
-      13619,
-      13623,
-      13624,
-      13626,
-      13630,
-      13631,
-      13633,
-      13636,
-      13637,
-      13638,
-      15406,
-      15407,
-      15408,
-      15996,
-      16686,
-      19005,
-      20786,
-      20843,
-      23093,
-      23095,
-      23115,
-      23707,
-      23922,
-      25014,
-      26642,
-      26643,
-      26644,
-      26645,
-      26646,
-      26727,
-      26728,
-      26731,
-      26732,
-      26733,
-      26734,
-      26735,
-      26736,
-      26737,
-      26738,
-      26739,
-      26740,
-      27095,
-      27096,
-      27097,
-      28822,
-      28925,
-      29338,
-      29339,
-      29340,
-      29341,
-      29342,
-      29343,
-      29344,
-      29345,
-      29346,
-      29347,
-      29348,
-      29349,
-      29350,
-      29351,
-      29352,
-      29353,
-      29354,
-      29355,
-      29356,
-      29357,
-      29358,
-      29359,
-      29360,
-      29361,
-      29667,
-      30386,
-      31618,
-      31621,
-      31622,
-      31961,
-      33037,
-      33092,
-      33093,
-      33094,
-      33095,
-      33096,
-      33097,
-      33098,
-      33099,
-      33100,
-      33101,
-      33102,
-      33103,
-      33104,
-      33105,
-      33106,
-      33107,
-      33108,
-      33109,
-      33179,
-      33180,
-      33181,
-      33346,
-      33354,
-      33355,
-      33356,
-      33357,
-      33358,
-      33359,
-      33360,
-      33361,
-      33362,
-      33363,
-      33364,
-      33365,
-      33366,
-      33367,
-      33370,
-      33371,
-      33372,
-      33373,
-      33374,
-      33375,
-      33376,
-      33377,
-      33378,
-      33379,
-      33380,
-      33381,
-      33382,
-      33383,
-      33384,
-      33385,
-      33386,
-      33387,
-      33388,
-      33389,
-      33390,
-      33391,
-      33392,
-      33393,
-      33394,
-      33395,
-      33396,
-      33397,
-      33398,
-      33399,
-      33400,
-      33401,
-      33402,
-      33403,
-      33404,
-      33405,
-      33406,
-      33407,
-      33408,
-      33409,
-      33423,
-      33424,
-      33425,
-      33426,
-      33427,
-      33428,
-      33429,
-      33430,
-      33431,
-      33432,
-      33433,
-      33434,
-      33435,
-      33436,
-      33437,
-      33438,
-      33439,
-      33440,
-      33443,
-      33444,
-      34748,
-      34774,
-      34775,
-      34776,
-      34777,
-      34778,
-      34826,
-      34947,
-      35075,
-      36240,
-      37547,
-      37548,
-      37549,
-      37550,
-      37551,
-      37562,
-      37563,
-      37564,
-      37565,
-      37574,
-      37575,
-      37576,
-      37577,
-      37578,
-      37579,
-      37581,
-      37583,
-      37584,
-      37585,
-      37586,
-      37587,
-      37588,
-      37589,
-      37590,
-      37591,
-      37592,
-      37593,
-      37595,
-      37596,
-      37597,
-      37598,
-      37599,
-      37600,
-      37601,
-      37602,
-      37603,
-      37604,
-      37605,
-      37607,
-      37608,
-      37609,
-      37610,
-      37611,
-      37612,
-      37613,
-      37614,
-      37615,
-      37616,
-      37957,
-      38827,
-      38828,
-      38829,
-      39549,
-      40440,
-      40441,
-      40460,
-      40461,
-      41416,
-      41417,
-      41418,
-      41617,
-      41618,
-      41807
+      "WIZTOWERPORTAL",
+      "DARKWIZPORTAL",
+      "THORMACPORTAL",
+      "MAGEARENA_SCAN",
+      "VT_MAZEPORTAL_1",
+      "VT_MAZEPORTAL_2",
+      "VT_MAZEPORTAL_3",
+      "VT_MAZEPORTAL_4",
+      "VT_MAZEPORTAL_5",
+      "VT_MAZEPORTAL_6",
+      "VT_MAZEPORTAL_7",
+      "VT_MAZEPORTAL_WRONG",
+      "CASTLEWARS_SARADOMIN_TELE",
+      "CASTLEWARS_ZAMORAK_TELE",
+      "CASTLEWARS_SARADOMIN_EXIT",
+      "CASTLEWARS_ZAMORAK_EXIT",
+      "CASTLEWARS_SARADOMIN_QUIT",
+      "CASTLEWARS_ZAMORAK_QUIT",
+      "CASTLEWARS_RANDOM_TELE",
+      "POH_EXIT_PORTAL",
+      "GOLEM_DEMON_PORTAL",
+      "DT_PORTAL",
+      "RD_PORTAL_ROOM1_ENTRANCE",
+      "RD_PORTAL_ROOM1_EXIT",
+      "RD_PORTAL_ROOM2_ENTRANCE",
+      "RD_PORTAL_ROOM2_EXIT",
+      "RD_PORTAL_ROOM3_ENTRANCE",
+      "RD_PORTAL_ROOM3_EXIT",
+      "RD_PORTAL_ROOM4_ENTRANCE",
+      "RD_PORTAL_ROOM4_EXIT",
+      "RD_PORTAL_ROOM5_ENTRANCE",
+      "RD_PORTAL_ROOM5_EXIT",
+      "RD_PORTAL_ROOM6_ENTRANCE",
+      "RD_PORTAL_ROOM6_EXIT",
+      "RD_PORTAL_ROOM7_ENTRANCE",
+      "RD_PORTAL_ROOM7_EXIT",
+      "CLANWARS_EXITPORTAL_SMALLWOOD_S",
+      "CLANWARS_EXITPORTAL_SMALLWOOD_N",
+      "CORP_PRIVATEPORTAL_OUTSIDE",
+      "CORP_PRIVATEPORTAL_INSIDE",
+      "AGRITH_PORTAL_CLOSING",
+      "MAGICTRAINING_HIDDEN_PORTAL_ENTRANCE1",
+      "DRAYNOR_KILLERWATT_PORTAL2",
+      "DRAYNOR_KILLERWATT_PORTAL_MACHINE",
+      "_100_PORTAL_CHICKEN",
+      "HUNDRED_PORTAL_ACTIVE",
+      "HUNDRED_EXIT_PORTAL",
+      "POH_PORTAL_TEAK_LUMBRIDGE",
+      "POH_PORTAL_TEAK_FALADOR",
+      "POH_PORTAL_TEAK_ARDOUGNE",
+      "POH_PORTAL_MAG_LUMBRIDGE",
+      "POH_PORTAL_MAG_FALADOR",
+      "POH_PORTAL_MAG_ARDOUGNE",
+      "POH_PORTAL_MARBLE_LUMBRIDGE",
+      "POH_PORTAL_MARBLE_FALADOR",
+      "POH_PORTAL_MARBLE_ARDOUGNE",
+      "POH_PORTAL_TEAK_EMPTY",
+      "POH_PORTAL_MAG_EMPTY",
+      "POH_PORTAL_MARBLE_EMPTY",
+      "POH_TELEROOM_1",
+      "POH_TELEROOM_2",
+      "POH_TELEROOM_3",
+      "BREW_EXIT_PORTAL",
+      "ASTRALTEMPLE_EXIT_PORTAL",
+      "SOS_FAM_PORTAL",
+      "SOS_WAR_PORTAL",
+      "FORESTER_FORCEWALL",
+      "SUROK_EXIT_PORTAL_COMPLETE",
+      "SUROK_ENTRANCE_PORTAL",
+      "MACRO_EVIL_BOB_PORTAL",
+      "SOS_PEST_PORTAL",
+      "SOS_DEATH_PORTAL",
+      "II_ROCKS_FLOOR_HARD_02",
+      "CLANWARS_CHALLENGEPORTAL_W",
+      "CLANWARS_CHALLENGEPORTAL_S",
+      "CLANWARS_CHALLENGEPORTAL_E",
+      "CLANWARS_FFAPORTAL",
+      "CLANWARS_FFAEXIT",
+      "CLANWARS_EXITPORTAL_DARKROCK_S",
+      "CLANWARS_EXITPORTAL_DARKROCK_N",
+      "CLANWARS_EXITPORTAL_GREYROCK_S",
+      "CLANWARS_EXITPORTAL_GREYROCK_N",
+      "CLANWARS_EXITPORTAL_ELFWOOD_S",
+      "CLANWARS_EXITPORTAL_ELFWOOD_N",
+      "CLANWARS_EXITPORTAL_SWAMP_S",
+      "CLANWARS_EXITPORTAL_SWAMP_N",
+      "CLANWARS_EXITPORTAL_SMALL_PURPLE",
+      "CLANWARS_PRISONPORTAL_DARKROCK",
+      "CLANWARS_PRISONPORTAL_ELFWOOD",
+      "CLANWARS_PRISONPORTAL_SWAMP",
+      "CLANCUP_PORTAL_CHALLENGEAREA_EXIT",
+      "CLANCUP_PORTAL_FROM_BATTLEAREA",
+      "LEAGUE_5_POH_SPIRIT_RING",
+      "POH_KOUREND_PORTAL",
+      "CATA_BOSS_EXIT_PORTAL",
+      "POH_PORTAL_TEAK_KHARYRLL",
+      "POH_PORTAL_TEAK_LUNARISLE",
+      "POH_PORTAL_TEAK_SENNTISTEN",
+      "POH_PORTAL_TEAK_ANNAKARL",
+      "POH_PORTAL_TEAK_WATERBIRTH",
+      "POH_PORTAL_TEAK_FISHINGGUILD",
+      "POH_PORTAL_TEAK_MARIM",
+      "POH_PORTAL_TEAK_KOUREND",
+      "POH_PORTAL_MAG_KHARYRLL",
+      "POH_PORTAL_MAG_LUNARISLE",
+      "POH_PORTAL_MAG_SENNTISTEN",
+      "POH_PORTAL_MAG_ANNAKARL",
+      "POH_PORTAL_MAG_WATERBIRTH",
+      "POH_PORTAL_MAG_FISHINGGUILD",
+      "POH_PORTAL_MAG_MARIM",
+      "POH_PORTAL_MAG_KOUREND",
+      "POH_PORTAL_MARBLE_KHARYRLL",
+      "POH_PORTAL_MARBLE_LUNARISLE",
+      "POH_PORTAL_MARBLE_SENNTISTEN",
+      "POH_PORTAL_MARBLE_ANNAKARL",
+      "POH_PORTAL_MARBLE_WATERBIRTH",
+      "POH_PORTAL_MARBLE_FISHINGGUILD",
+      "POH_PORTAL_MARBLE_MARIM",
+      "POH_PORTAL_MARBLE_KOUREND",
+      "TOURNAMENT_CASTLEWARS_TO_CLANWARS",
+      "CASTLEWARS_F2P_PORTAL",
+      "DS2_GUILD_PORTAL_CHAMP",
+      "DS2_GUILD_PORTAL_HERO",
+      "DS2_GUILD_PORTAL_LEGEND",
+      "SHAYZIENQUEST_PRISON_PORTAL",
+      "TOB_SOTETSEG_DARKREALM_EXIT",
+      "POH_PORTAL_TEAK_VARROCK_VARROCK1ST",
+      "POH_PORTAL_TEAK_VARROCK_GE1ST",
+      "POH_PORTAL_TEAK_CAMELOT_CAMELOT1ST",
+      "POH_PORTAL_TEAK_CAMELOT_SEERS1ST",
+      "POH_PORTAL_TEAK_YANILLE_WATCHTOWER1ST",
+      "POH_PORTAL_TEAK_YANILLE_YANILLE1ST",
+      "POH_PORTAL_MAHOGANY_VARROCK_VARROCK1ST",
+      "POH_PORTAL_MAHOGANY_VARROCK_GE1ST",
+      "POH_PORTAL_MAHOGANY_CAMELOT_CAMELOT1ST",
+      "POH_PORTAL_MAHOGANY_CAMELOT_SEERS1ST",
+      "POH_PORTAL_MAHOGANY_YANILLE_WATCHTOWER1ST",
+      "POH_PORTAL_MAHOGANY_YANILLE_YANILLE1ST",
+      "POH_PORTAL_MARBLE_VARROCK_VARROCK1ST",
+      "POH_PORTAL_MARBLE_VARROCK_GE1ST",
+      "POH_PORTAL_MARBLE_CAMELOT_CAMELOT1ST",
+      "POH_PORTAL_MARBLE_CAMELOT_SEERS1ST",
+      "POH_PORTAL_MARBLE_YANILLE_WATCHTOWER1ST",
+      "POH_PORTAL_MARBLE_YANILLE_YANILLE1ST",
+      "POH_PORTAL_TEAK_STRONGHOLD",
+      "POH_PORTAL_MAG_STRONGHOLD",
+      "POH_PORTAL_MARBLE_STRONGHOLD",
+      "POH_TELENEXUS_1",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AIP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AIS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AIR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AIQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_ALP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_ALS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_ALR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_ALQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AKP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AKS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AKR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AKQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AJP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_AJS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DIP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DIS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DIR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DIQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DLP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DLS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DLR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DLQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DKP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DKS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DKR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DKQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DJP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DJS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DJR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_DJQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CIP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CIS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CIR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CIQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CLP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CLS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CLR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CLQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CKP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CKS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CKR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CKQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CJP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CJS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CJR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_CJQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BIP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BIS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BIR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BIQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BLP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BLS",
+      "POH_NEXUS_PORTAL_1",
+      "POH_NEXUS_PORTAL_2",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BLR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BLQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BKP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BKS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BKR",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BKQ",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BJP",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BJS",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BJR",
+      "POH_PORTAL_TEAK_CATHERBY",
+      "POH_PORTAL_TEAK_GHORROCK",
+      "POH_PORTAL_TEAK_CARRALLANGAR",
+      "POH_PORTAL_MAG_CATHERBY",
+      "POH_PORTAL_MAG_GHORROCK",
+      "POH_PORTAL_MAG_CARRALLANGAR",
+      "POH_PORTAL_MARBLE_CATHERBY",
+      "POH_PORTAL_MARBLE_GHORROCK",
+      "POH_PORTAL_MARBLE_CARRALLANGAR",
+      "_1V1ARENA_PORTAL_LOWER",
+      "_1V1ARENA_PORTAL_HIGHER",
+      "AIRTEMPLE_EXIT_PORTAL",
+      "ESSENCEMINE_PORTAL_1",
+      "ESSENCEMINE_PORTAL_2",
+      "ESSENCEMINE_PORTAL_3",
+      "ESSENCEMINE_PORTAL_4",
+      "ESSENCEMINE_PORTAL_5",
+      "TOURNAMENT_CLANWARS_TEMPPORTAL_JADFEST",
+      "POH_PRIFDDINAS_PORTAL",
+      "SOTE_LIBRARY_EXIT",
+      "PRIF_AGILITY_SHORTCUT_PORTAL",
+      "LEAGUE_5_POH_SPIRIT_RING_LAST_BJQ",
+      "BH_SUPPLY_CRATE_STACK",
+      "HUNTING_TRAIL4_7L",
+      "HUNTING_TRAIL4_8L",
+      "DT2_LASSAR_REMNANT_POSTQUEST",
+      "BGSOUND_RT_FIRE_LARGE",
+      "WILD5_DUGUPSOIL_6A",
+      "WILD5_DUGUPSOIL_6B",
+      "LIGHT_GODRAY02_SMALL01_WYVERN_CAVE",
+      "WYVERN_CAVE_WALL_COLDMUD_LAMP",
+      "WYVERN_CAVE_WALL_SUPPORT_LEFT",
+      "WYVERN_CAVE_WALL_SUPPORT_RIGHT",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_XLARGE",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_XLARGE2",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_XLARGE3",
+      "POH_PORTAL_TEAK_WEISS",
+      "POH_PORTAL_TEAK_DRAYNOR_MANOR",
+      "POH_PORTAL_TEAK_BATTLEFRONT",
+      "POH_PORTAL_TEAK_MIND_ALTAR",
+      "POH_PORTAL_TEAK_SALVE_GRAVEYARD",
+      "POH_PORTAL_TEAK_FENKENSTRAIN",
+      "POH_PORTAL_TEAK_WEST_ARDOUGNE",
+      "POH_PORTAL_TEAK_HARMONY_ISLAND",
+      "POH_PORTAL_TEAK_CEMETERY",
+      "POH_PORTAL_TEAK_BARROWS",
+      "POH_PORTAL_TEAK_APE_ATOLL",
+      "POH_PORTAL_MAG_WEISS",
+      "POH_PORTAL_MAG_DRAYNOR_MANOR",
+      "POH_PORTAL_MAG_BATTLEFRONT",
+      "POH_PORTAL_MAG_MIND_ALTAR",
+      "POH_PORTAL_MAG_SALVE_GRAVEYARD",
+      "POH_PORTAL_MAG_FENKENSTRAIN",
+      "POH_PORTAL_MAG_WEST_ARDOUGNE",
+      "POH_PORTAL_MAG_HARMONY_ISLAND",
+      "POH_PORTAL_MAG_CEMETERY",
+      "POH_PORTAL_MAG_BARROWS",
+      "POH_PORTAL_MAG_APE_ATOLL",
+      "POH_PORTAL_MARBLE_WEISS",
+      "POH_PORTAL_MARBLE_DRAYNOR_MANOR",
+      "POH_PORTAL_MARBLE_BATTLEFRONT",
+      "POH_PORTAL_MARBLE_MIND_ALTAR",
+      "POH_PORTAL_MARBLE_SALVE_GRAVEYARD",
+      "POH_PORTAL_MARBLE_FENKENSTRAIN",
+      "POH_PORTAL_MARBLE_WEST_ARDOUGNE",
+      "POH_PORTAL_MARBLE_HARMONY_ISLAND",
+      "POH_PORTAL_MARBLE_CEMETERY",
+      "POH_PORTAL_MARBLE_BARROWS",
+      "POH_PORTAL_MARBLE_APE_ATOLL",
+      "TOURNAMENT_CLANWARS_TEMPPORTAL_HUB",
+      "HALLOWED_TREASURE_MAGIC_INACTIVE",
+      "HALLOWED_TREASURE_MAGIC_READY",
+      "HALLOWED_TREASURE_MAGIC_FINAL",
+      "DEATH_OFFICE_EXITPORTAL",
+      "SOUL_WARS_TUT_BLUE_EXIT_PORTAL",
+      "SOUL_WARS_TUT_RED_EXIT_PORTAL",
+      "SOUL_WARS_BLUE_EXIT_PORTAL",
+      "SOUL_WARS_RED_EXIT_PORTAL",
+      "POH_PORTAL_TEAK_ARCEUUS_LIBRARY",
+      "POH_PORTAL_MAG_ARCEUUS_LIBRARY",
+      "POH_PORTAL_MARBLE_ARCEUUS_LIBRARY",
+      "CLAN_HALL_EXIT_MEDIEVAL",
+      "CLAN_HALL_EXIT_CRYSTALLINE",
+      "AKD_JUDGE_PORTAL"
     ],
     "shadowOpacityThreshold": 0.12
   },
   {
     "description": "Use flat normals for POH Portal Nexus, since it spins around",
-    "objectIds": [ 33410 ],
+    "objectIds": [ "POH_NEXUS_PORTAL_3" ],
     "flatNormals": true,
     "shadowOpacityThreshold": 0.12
   },
   {
     "description": "Edgeville Soul Wars portal",
     "objectIds": [
-      40474,
-      40476
+      "SOUL_WARS_EDGEVILLE_PORTAL",
+      "SOUL_WARS_LEAVE_SOULWARS_PORTAL"
     ],
     "shadowOpacityThreshold": 0.12,
     "baseMaterial": "UNLIT"
@@ -12739,7 +12739,7 @@
     "description": "Al-Kharid Windows",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      1848
+      "DESERTWINDOW"
     ],
     "uvType": "MODEL_XY",
     "uvOrientation": 512
@@ -12748,7 +12748,7 @@
     "description": "Pollnivneach Windows",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      6247
+      "FEUD_DESERTWINDOW"
     ],
     "uvType": "MODEL_XY"
   },
@@ -12756,38 +12756,38 @@
     "description": "Al-Kharid Low Stone Wall",
     "baseMaterial": "STONE_LOWGLOSS",
     "objectIds": [
-      987,
-      988,
-      989,
-      990,
-      33344,
-      33345
+      "POSHWALLFENCING_BROWN",
+      "POSHWALLFENCINGLEFTGATE_BROWN",
+      "POSHWALLFENCINGRIGHTGATE_BROWN",
+      "POSHWALLGATETOP_BROWN",
+      "KHARID_POSHWALL_TOPLESS",
+      "KHARID_POSHWALL_FALLENTOP"
     ]
   },
   {
     "description": "Al-Kharid Statues",
     "baseMaterial": "STONE",
     "objectIds": [
-      579,
-      580,
-      581,
-      584
+      "EGYPT_STATUE1",
+      "EGYPT_STATUE2",
+      "EGYPT_STATUE3",
+      "EGYPT_STATUE6"
     ]
   },
   {
     "description": "Al-Kharid Pillars",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      1859,
-      1860
+      "EGYPT_COLUMN3",
+      "EGYPT_COLUMN4"
     ]
   },
   {
     "description": "Al-Kharid stone stable with pillars",
     "baseMaterial": "STONE",
     "objectIds": [
-      613,
-      614
+      "EGYPT_TABLE",
+      "EGYPT_TABLE_2"
     ]
   },
   {
@@ -12798,76 +12798,76 @@
     "uvScale": 0.6,
     "flatNormals": true,
     "objectIds": [
-      914
+      "EGYPTWALLDECOR_COLUMN"
     ]
   },
   {
     "description": "Kharidian Barrell Cactus",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      1406
+      "CACTUS5"
     ]
   },
   {
     "description": "Kharidian Saguaro Cactus",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      1403
+      "CACTUS2"
     ]
   },
   {
     "description": "Kharidian Fern Cactus",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      1405
+      "CACTUS4"
     ]
   },
   {
     "description": "Kharidian Columnar Cactus",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      1404,
-      6277
+      "CACTUS3",
+      "FEUD_CACTUS_ROW"
     ]
   },
   {
     "description": "Kharidian Komodo Cactus",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      1396,
-      2670,
-      2671
+      "CACTUS",
+      "DESERT_CACTUS_FULL",
+      "DESERT_CACTUS_EMPTY"
     ]
   },
   {
     "description": "Kharidian Sophmena Cactus",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      44069,
-      44070,
-      44071,
-      44072,
-      44073,
-      44074,
-      44075,
-      44076,
-      44077
+      "PLANT_CACTUS_02",
+      "PLANT_CACTUS_03",
+      "PLANT_CACTUS_04",
+      "PLANT_CACTUS_05",
+      "PLANT_CACTUS_06",
+      "PLANT_CACTUS_07",
+      "PLANT_CACTUS_08",
+      "PLANT_CACTUS_09",
+      "PLANT_CACTUS_10"
     ]
   },
   {
     "description": "Kharidian Well",
     "baseMaterial": "STONE_LOWGLOSS",
     "objectIds": [
-      878,
-      6249
+      "DESERTWELL",
+      "FEUD_DESERT_WELL"
     ]
   },
   {
     "description": "Al-Kharid Hanging Door",
     "baseMaterial": "CARPET",
     "objectIds": [
-      1533,
-      1534
+      "DESERTDOORCLOSED",
+      "DESERTDOOROPEN"
     ],
     "uvType": "MODEL_XY",
     "uvScale": 0.80
@@ -12876,10 +12876,10 @@
     "description": "Pollnivneach Double Doors",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      6238,
-      6239,
-      6240,
-      6241
+      "FEUD_CLOSED_DOOR_LEFT",
+      "FEUD_OPEN_DOOR_LEFT",
+      "FEUD_CLOSED_DOOR_RIGHT",
+      "FEUD_OPEN_DOOR_RIGHT"
     ],
     "flatNormals": true
   },
@@ -12887,10 +12887,10 @@
     "description": "Pollnivneach Stone Stairs",
     "baseMaterial": "STONE",
     "objectIds": [
-      6242,
-      6243,
-      6244,
-      6245
+      "FEUD_OUTSIDESTAIRS_BASE",
+      "FEUD_OUTSIDESTAIRS_TOP",
+      "FEUD_INSIDESTAIRS_BASE",
+      "FEUD_INSIDESTAIRS_TOP"
     ],
     "flatNormals": true
   },
@@ -12898,11 +12898,11 @@
     "description": "Kharidian Basket",
     "baseMaterial": "CARPET",
     "objectIds": [
-      382,
-      383,
-      384,
-      385,
-      14935
+      "DESERTBASKET_CLOSED",
+      "DESERTBASKET_OPEN",
+      "DESERTBASKET_OPEN2",
+      "GROUPOFDESERTBASKETS",
+      "ROOFTOPS_POLLNIVNEACH_BASKET"
     ],
     "uvType": "GEOMETRY"
   },
@@ -12910,11 +12910,11 @@
     "description": "Metal Birdcage",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      6146,
-      6264,
-      6265,
-      6266,
-      6267
+      "DWARF_BIRD_CAGE_STAND",
+      "FEUD_BIRD_CAGE_STAND",
+      "FEUD_BIRD_CAGE_TABLE",
+      "FEUD_BIRD_CAGE",
+      "FEUD_GOLDEN_BIRD_CAGE_STAND"
     ],
     "uvType": "GEOMETRY"
   },
@@ -12922,12 +12922,12 @@
     "description": "AL_KHARID_WALLS_CORNER",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      6214,
-      6215,
-      6216,
-      6217,
-      6218,
-      6219
+      "DESERTWALL_ROOFEDGE_L",
+      "DESERTWALL_ROOFEDGE_R",
+      "DESERTWALL_ARCH_L",
+      "DESERTWALL_ARCH_R",
+      "DESERTWALL_SUPPORT_ARCH_L",
+      "DESERTWALL_SUPPORT_ARCH_R"
     ],
     "flatNormals": true,
     "uvType": "GEOMETRY"
@@ -12936,14 +12936,14 @@
     "description": "Kharidian Tent",
     "baseMaterial": "CARPET",
     "objectIds": [
-      1673,
-      1674,
-      1675,
-      1676,
-      1677,
-      1678,
-      6270,
-      6271
+      "TENTWALL2",
+      "TENTWALL3",
+      "TENTDOOR1",
+      "TENTDOOR2",
+      "TENTDOOR3",
+      "TENTDOOR4",
+      "FEUD_TENTDOOR",
+      "FEUD_TENTWALL"
     ],
     "uvType": "BOX"
   },
@@ -12951,11 +12951,11 @@
     "description": "Metal Monkeybars",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      14941,
-      14942,
-      14943,
-      23565,
-      23566
+      "ROOFTOPS_POLLNIVNEACH_MONKEYBARS_START",
+      "ROOFTOPS_POLLNIVNEACH_MONKEYBARS_SEGMENT",
+      "ROOFTOPS_POLLNIVNEACH_MONKEYBARS_LEGS",
+      "MONKEYBARS_MID",
+      "MONKEYBARS_END1"
     ],
     "uvType": "BOX"
   },
@@ -12963,7 +12963,7 @@
     "description": "Agility Arrow",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11402
+      "ROOFTOPS_ARROWSIGN"
     ],
     "uvType": "MODEL_XY",
     "uvOrientation": 512
@@ -12972,15 +12972,15 @@
     "description": "Nardah Sophanem - Walls - Rock",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6590,
-      6591,
-      6592,
-      6593,
-      6594,
-      6595,
-      6596,
-      6600,
-      6601
+      "ICTHALARINS_EXTERIOR_WALL",
+      "ICTHALARINS_EXTERIOR_WALL_LVL2",
+      "ICTHALARINS_INTERIOR_WALL",
+      "ICTHALARINS_INTERIOR_WALL_VARI",
+      "ICTHALARINS_CRUMBLYWALL1",
+      "ICTHALARINS_CRUMBLYWALL1R",
+      "ICTHALARINS_CRUMBLYWALL2",
+      "ICTHALARINS_RAMPART",
+      "ICTHALARINS_WINDOW"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -12989,8 +12989,8 @@
     "description": "Nardah Walls - Flipped",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6588,
-      6589
+      "ICTHALARINS_DOOR_ARCH",
+      "ICTHALARINS_DOOR_ARCH_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -12999,7 +12999,7 @@
     "description": "Nardah Walls Rubble",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      10503
+      "ELID_PILE_BICKS"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -13008,13 +13008,13 @@
     "description": "Objects - Wooden - Counter",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      9616,
-      10485,
-      10486,
-      15040,
-      15092,
-      15114,
-      19699
+      "RIMMINGTON_COUNTER",
+      "ELID_COUNTER",
+      "ELID_COUNTER_DARKSIDE",
+      "PIRATETREASURE_COUNTER",
+      "ROYAL_TABLE",
+      "ROYAL_GENERAL_STORE_COUNTER",
+      "HUNTING_SHOP_COUNTER"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512
@@ -13023,10 +13023,10 @@
     "description": "Objects - Wooden - Stairs",
     "baseMaterial": "DOCK_FENCE",
     "objectIds": [
-      10525,
-      10526,
-      11796,
-      11799
+      "ELID_MAYOR_STAIRS",
+      "ELID_MAYOR_STAIRSTOP",
+      "FAI_VARROCK_STAIRS",
+      "FAI_VARROCK_STAIRS_TOP"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13034,8 +13034,8 @@
     "description": "Nardah Worn Stone Stairs",
     "baseMaterial": "STONE_LOWGLOSS",
     "objectIds": [
-      6496,
-      10507
+      "DESERT_TREASURE_SKEWSTEPS",
+      "ELID_SKEW_STEPS"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13043,7 +13043,7 @@
     "description": "Nardah Stone Pew",
     "baseMaterial": "STONE_LOWGLOSS",
     "objectIds": [
-      10508
+      "ELID_STONE_PEW"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13051,7 +13051,7 @@
     "description": "Nardah Clay Oven",
     "baseMaterial": "STONE_LOWGLOSS",
     "objectIds": [
-      10377
+      "ELID_CLAY_OVEN"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13059,7 +13059,7 @@
     "description": "Nardah Cloth Awning",
     "baseMaterial": "CARPET",
     "objectIds": [
-      6602
+      "ICTHALARINS_AWNING"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -13067,11 +13067,11 @@
     "description": "Tree - Non interactable - Jungle",
     "baseMaterial": "BARK",
     "objectIds": [
-      1301,
-      1302,
-      1303,
-      1304,
-      13703
+      "JUNGLETREE1",
+      "JUNGLETREE2",
+      "JUNGLETREE1_KARAMJA",
+      "JUNGLETREE2_KARAMJA",
+      "JUNGLETREE2BIG_KARAMJA"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -13089,15 +13089,15 @@
     "description": "Jungle Tree Small",
     "baseMaterial": "LEAF_VEINS",
     "objectIds": [
-      2887,
-      4818,
-      51762,
-      51763,
-      51764,
-      51765,
-      51853,
-      53188,
-      53189
+      "KHARAZI_JUNGLE_TREE_LOGS",
+      "MM_BUSH_KHARAZI_JUNGLE_TREE1",
+      "AVIUM_TREE_1",
+      "AVIUM_TREE_1_STUMP",
+      "AVIUM_TREE_2",
+      "AVIUM_TREE_2_STUMP",
+      "AVIUM_TREE_ORANGE",
+      "AVIUM_TREE_DARK",
+      "AVIUM_TREE_DARK_STUMP"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.25,
@@ -13115,7 +13115,7 @@
     "description": "Jungle Tree Small - Leafy",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      6578
+      "ICTHALARINS_BANANATREEEMPTY"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -13125,9 +13125,9 @@
     "description": "Jungle Tree Large",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      15948,
-      15951,
-      15954
+      "BREW_JUNGLE_TREE_1",
+      "BREW_JUNGLE_TREE_2",
+      "BREW_JUNGLE_TREE_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -13147,29 +13147,29 @@
       }
     ],
     "objectIds": [
-      1314
+      "MEDPLANT_KARAMJA"
     ]
   },
   {
     "description": "Tropical Tree Big",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      1326,
-      1327,
-      1328,
-      1360,
-      1371,
-      1372,
-      1373,
-      1375,
-      1376,
-      1377,
-      4845,
-      4846,
-      4847,
-      15957,
-      15958,
-      15959
+      "BAMBOO_TREE_BASE",
+      "BAMBOO_TREE_MID",
+      "BAMBOO_TREE_UPPERMID",
+      "LEANING_BAMBOO_TREE_BASE",
+      "BAMBOO_TREE_2_BASE",
+      "BAMBOO_TREE_2_MID",
+      "BAMBOO_TREE_2_UPPERMID",
+      "BAMBOO_TREE_3_BASE",
+      "BAMBOO_TREE_3_MID",
+      "BAMBOO_TREE_3_TOP",
+      "MM_BAMBOO_TREE_BASE",
+      "MM_BAMBOO_TREE_MID",
+      "MM_BAMBOO_TREE_UPPERMID",
+      "BREW_BAMBOO_TREE_BASE",
+      "BREW_BAMBOO_TREE_MID",
+      "BREW_BAMBOO_TREE_UPPERMID"
     ],
     "uvType": "BOX",
     "uvScale": 0.62,
@@ -13179,7 +13179,7 @@
     "description": "Tropical Tree Big - Leaning",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      1361
+      "LEANING_BAMBOO_TREE_MID"
     ],
     "uvType": "BOX",
     "uvScale": 0.62,
@@ -13189,17 +13189,17 @@
     "description": "Tree - Snowy - Weiss",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      33178
+      "ARCTIC_PINE_SNOWY"
     ]
   },
   {
     "description": "Sophamena Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6562,
-      6563,
-      6564,
-      6565
+      "ICTHALARINS_CITY_WALL",
+      "ICTHALARINS_CITY_WALL_TABLET",
+      "ICTHALARINS_CITY_WALL_LEV2",
+      "ICTHALARINS_CITY_WALL_TABLET_LEV2"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13209,8 +13209,8 @@
     "description": "Sophamena Wall Decoration",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      6535,
-      6536
+      "FOUR_DIAMONDS_TOMB_WALL_SCARAB",
+      "FOUR_DIAMONDS_TOMB_WALL_EYE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13220,9 +13220,9 @@
     "description": "Broken Wood Awning",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      3165,
-      3166,
-      15973
+      "ARENA_KIOSK_WOOD",
+      "ARENA_KIOSK_WOOD_MIRROR",
+      "BREW_PIER_CUTOFF_2"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512
@@ -13231,7 +13231,7 @@
     "description": "Wattle Roof",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      3167
+      "ARENA_BUILDINGS_TOP"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13239,24 +13239,24 @@
     "description": "PvP Arena Walls",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      44870,
-      44871,
-      44872,
-      44873,
-      44874,
-      44875,
-      44876,
-      44877,
-      44878,
-      44879,
-      44880,
-      44881,
-      44882,
-      44883,
-      44884,
-      44885,
-      44886,
-      44887
+      "ARENA_DESERT01_WALL01",
+      "ARENA_DESERT01_WINDOW01",
+      "ARENA_DESERT01_WINDOW02",
+      "ARENA_DESERT01_WINDOW02_M",
+      "ARENA_DESERT01_WINDOW02_3X1",
+      "ARENA_DESERT01_INSIDE01",
+      "ARENA_DESERT01_CRUMBLE01",
+      "ARENA_DESERT01_CRUMBLE02",
+      "ARENA_DESERT01_CRUMBLE01_M",
+      "ARENA_DESERT01_CRUMBLE02_M",
+      "ARENA_DESERT01_UPPER01",
+      "ARENA_DESERT01_WINDOWUPPER01",
+      "ARENA_DESERT01_CRUMBLEUPPER01",
+      "ARENA_DESERT01_CRUMBLEUPPER01_M",
+      "ARENA_DESERT01_LOW01",
+      "ARENA_DESERT01_LOW02",
+      "ARENA_DESERT01_LOW02_M",
+      "ARENA_DESERT01_LOW03"
     ],
     "uvType": "BOX"
   },
@@ -13264,8 +13264,8 @@
     "description": "PvP Arena Walls - Corners",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      44888,
-      44889
+      "ARENA_DESERT01_TRANSITION01",
+      "ARENA_DESERT01_TRANSITION01_M"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13273,8 +13273,8 @@
     "description": "PvP Arena Stairs",
     "baseMaterial": "STONE_LOWGLOSS",
     "objectIds": [
-      44924,
-      44925
+      "PVPA_STAGINGAREA_ENTRY",
+      "PVPA_STAGINGAREA_ENTRY02"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13282,7 +13282,7 @@
     "description": "PvP Arena Statue",
     "baseMaterial": "STONE_LOWGLOSS",
     "objectIds": [
-      44829
+      "ARENA_DESERT01_STATUE01"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13290,10 +13290,10 @@
     "description": "PvP Arena blood",
     "baseMaterial": "METALLIC_NONE_GLOSS",
     "objectIds": [
-      44842,
-      44843,
-      44844,
-      44845
+      "ARENA_BLOODSPLAT01_LARGE01",
+      "ARENA_BLOODSPLAT01_LARGE02",
+      "ARENA_BLOODSPLAT01_SMALL01",
+      "ARENA_BLOODSPLAT01_SMALL02"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -13301,17 +13301,17 @@
     "description": "Wall Decoration - Blood",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      12299
+      "_100_DAVE_WALL_BLOOD"
     ]
   },
   {
     "description": "Exercise Mats",
     "baseMaterial": "CARPET",
     "objectIds": [
-      20810,
-      16508,
-      9313,
-      20801
+      "BARRACK_MAT_1",
+      "BARRACK_MAT_2",
+      "BARRACK_MAT_3",
+      "BARRACK_MAT_4"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512
@@ -13320,11 +13320,11 @@
     "description": "Sophanem Gate",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      44035,
-      44036,
-      44037,
-      44038,
-      44039
+      "CONTACT_METAL_RAIL_GATE_TOP_ACTIVE",
+      "SOPHANEM_GATE_LEFT",
+      "SOPHANEM_GATE_LEFT_INACTIVE",
+      "SOPHANEM_GATE_RIGHT",
+      "SOPHANEM_GATE_RIGHT_INACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -13333,69 +13333,69 @@
     "description": "Necropolis ground objects",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      44158,
-      44159,
-      44160,
-      44161,
-      44170,
-      44171,
-      44172,
-      44173
+      "CLIFF_SAND01_1",
+      "CLIFF_SAND02_1",
+      "CLIFF_SAND01_2",
+      "CLIFF_SAND02_2",
+      "CLIFF_SAND01_X",
+      "CLIFF_SAND01_FLAT01",
+      "CLIFF_SAND01_FLAT02",
+      "CLIFF_SAND01_FLAT03"
     ],
     "uvType": "WORLD_XZ"
   },
   {
     "description": "Ruins of Ullek flat normals on walls and other wall objects",
     "objectIds": [
-      43898,
-      43899,
-      43900,
-      43901,
-      43902,
-      43903,
-      43952,
-      43953,
-      43954,
-      44097,
-      44099,
-      44100,
-      44109,
-      44110,
-      44111,
-      44112,
-      44113,
-      44114,
-      44115,
-      44116,
-      44117
+      "BCS_PILLAR_OP",
+      "BCS_PILLAR_NOOP",
+      "BCS_PILLAR_EMBLEM_OP",
+      "BCS_PILLAR_EMBLEM_NOOP",
+      "BCS_WELL_NOOP",
+      "BCS_WELL_OP",
+      "BCS_TOMB_ENTRANCE_CLOSED_NOOP",
+      "BCS_TOMB_ENTRANCE_CLOSED",
+      "BCS_TOMB_ENTRANCE_OPEN",
+      "CLIFF_DESERT_ROCK01",
+      "CLIFF_DESERT_ROCK02",
+      "CLIFF_DESERT_ROCK03",
+      "OUTCROP_DESERT_ROCK2X2",
+      "OUTCROP_DESERT_ROCK2X202",
+      "STAIRS_DESERT_ROCK01",
+      "STAIRS_DESERT_ROCK02",
+      "STAIRS_DESERT_ROCK03",
+      "CLIFF_DESERT_HOUSE01",
+      "CLIFF_DESERT_HOUSE02",
+      "CLIFF_DESERT_HOUSE03",
+      "CLIFF_DESERT_ROCK_DECORATIVE01"
     ],
     "flatNormals": true
   },
   {
     "description": "Ruins of Ullek crypt",
     "objectIds": [
-      43904,
-      43908,
-      43910,
-      43911,
-      43912,
-      43905,
-      43906,
-      43907,
-      43909,
-      43960,
-      43959,
-      43958,
-      43961,
-      43962,
-      43971,
-      43972,
-      43973,
-      43974,
-      43975,
-      43976,
-      43977,
-      43978
+      "BCS_TOMB_WALL01",
+      "BCS_TOMB_WALL_ALCOVE",
+      "BCS_TOMB_WALL_HOLE_OPEN",
+      "BCS_TOMB_WALL_DOOR_CONNECTOR",
+      "BCS_TOMB_WALL_DOOR_CONNECTOR_MIRROR",
+      "BCS_TOMB_WALL02",
+      "BCS_TOMB_WALL03",
+      "BCS_TOMB_WALL03_MIRROR",
+      "BCS_TOMB_WALL_HOLE_CLOSED",
+      "BCS_TOMB_DOOR_UPPER_OUTER",
+      "BCS_TOMB_STAIRS_TOP_MIRROR",
+      "BCS_TOMB_STAIRS_TOP",
+      "BCS_TOMB_DOOR_LOWER_OUTER",
+      "BCS_TOMB_DOOR_LOWER_INNER",
+      "BCS_RIDDLE_PLAQUE_OP",
+      "BCS_RIDDLE_PLAQUE_NOOP",
+      "BCS_EMBLEM_PLAQUE_OP",
+      "BCS_EMBLEM_PLAQUE_NOOP",
+      "BCS_HET_PLAQUE",
+      "BCS_APMEKEN_PLAQUE",
+      "BCS_CRONDIS_PLAQUE",
+      "BCS_SCABARAS_PLAQUE"
     ],
     "flatNormals": true
   },
@@ -13403,14 +13403,14 @@
     "description": "Tombs of Amascut invocation board",
     "flatNormals": true,
     "objectIds": [
-      46073
+      "TOA_INVOCATION_BOARD"
     ]
   },
   {
     "description": "Tombs of Amascut exit doorway",
     "objectIds": [
-      46087,
-      46088
+      "TOA_LOBBY_EXIT",
+      "TOA_LOBBY_EXIT_NOOP"
     ],
     "flatNormals": true,
     "receiveShadows": false
@@ -13419,15 +13419,15 @@
     "description": "Goblin - Walls - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      23320,
-      23321,
-      23331,
-      23332,
-      23333,
-      23334,
-      23335,
-      23336,
-      23337
+      "SLICE_OUTPOST_WALL",
+      "SLICE_OUTPOST_WALL_WINDOW",
+      "SLICE_OUTPOST_WALL_CRUMBLY_DAMAGED_RIGHT",
+      "SLICE_OUTPOST_FORT_WALL",
+      "SLICE_OUTPOST_BROKEN_WALL",
+      "SLICE_OUTPOST_GATE_LEFT",
+      "SLICE_OUTPOST_GATE_LEFT_CAP",
+      "SLICE_OUTPOST_GATE_RIGHT",
+      "SLICE_OUTPOST_GATE_RIGHT_CAP"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -13437,8 +13437,8 @@
     "description": "Goblin - Walls - Wooden - Post",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      12275,
-      12429
+      "_100_DAVE_CELLER_SUPPORT",
+      "GOBLIN_OUTPOST_PIER_SUPPORT"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13448,12 +13448,12 @@
     "description": "Wooden - Plank - Door",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      12444,
-      12445,
-      12446,
-      12447,
-      12448,
-      12449
+      "GOBLIN_OUTPOST_POORDOOR",
+      "GOBLIN_OUTPOST_OPENPOORDOOR",
+      "GOBLIN_OUTPOST_POORDOOR_DOUBLE_INNER",
+      "GOBLIN_OUTPOST_OPENPOORDOOR_DOUBLE_INNER",
+      "GOBLIN_OUTPOST_POORDOOR_DOUBLER_INNER",
+      "GOBLIN_OUTPOST_OPENPOORDOOR_DOUBLER_INNER"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13463,7 +13463,7 @@
     "description": "Wooden - Plank - Door",
     "baseMaterial": "STONE",
     "objectIds": [
-      16567
+      "GOBLIN_FLOOR2"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -13472,22 +13472,22 @@
     "description": "Goblin Village Ice Bridge",
     "baseMaterial": "ICE_3",
     "objectIds": [
-      5040,
-      5041,
-      5042,
-      6463,
-      6464,
-      6465,
-      6466,
-      6467,
-      6468,
-      6469,
-      6470,
-      6471,
-      40905,
-      40906,
-      40907,
-      40908
+      "ICEFLOOR_LEDGE_FLAT",
+      "ICEFLOOR_LEDGE_ONE",
+      "ICEFLOOR_LEDGE_TWO",
+      "ICEFLOOR_LEDGE_THREE",
+      "ICEFLOOR_LEDGE_FOUR",
+      "ICEFLOOR_LEDGE_FIVE",
+      "ICEFLOOR_LEDGE_SIX",
+      "ICEFLOOR_LEDGE_Q",
+      "ICEFLOOR_LEDGE_W",
+      "ICEFLOOR_LEDGE_E",
+      "ICEFLOOR_LEDGE_R",
+      "ICEFLOOR_LEDGE_T",
+      "XMAS20_TRAP",
+      "XMAS20_TRAP_SIDE",
+      "XMAS20_BOOST",
+      "XMAS20_BOOST_SIDE"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 256
@@ -13496,19 +13496,19 @@
     "description": "Goblin Village Wooden Ladder",
     "baseMaterial": "WOOD_GRAIN",
     "objectIds": [
-      16450,
-      16556
+      "GOBLIN_LADDER_BOTTOM",
+      "GOBLIN_LADDER_TOP"
     ]
   },
   {
     "description": "Goblin Cooks Chamber Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      12381,
-      12382,
-      12383,
-      12384,
-      12385
+      "_100_GOBLIN_KITCHEN_WALL",
+      "_100_GOBLIN_KITCHEN_WALL2",
+      "_100_GOBLIN_KITCHEN_SOOTY_WALL",
+      "_100_GOBLIN_KITCHEN_SOOTY_WALL2",
+      "_100_GOBLIN_KITCHEN_SOOTY_OUTLINE"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -13518,9 +13518,9 @@
     "description": "Goblin Battlements",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12439,
-      12438,
-      12441
+      "GOBLIN_OUTPOST_SCAFOLD_TALL",
+      "GOBLIN_OUTPOST_SCAFOLD",
+      "GOBLIN_OUTPOST_SCAFOLD_EDGE"
     ],
     "uvType": "BOX"
   },
@@ -13528,12 +13528,12 @@
     "description": "Sacks - Yellow",
     "baseMaterial": "BURLAP",
     "objectIds": [
-      23,
-      365,
-      2354,
-      2356,
-      2663,
-      34940
+      "PERCY_SACKS",
+      "SACKS",
+      "DIGSITESACKS",
+      "DIGSAMPLESACKS",
+      "MURDERSACKS",
+      "SACKS_NOOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -13543,7 +13543,7 @@
     "description": "Sacks - Grey",
     "baseMaterial": "BURLAP",
     "objectIds": [
-      10304, 10305
+      "VC_SACKS_DWARF", "VC_SACKS2_DWARF"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -13553,15 +13553,15 @@
     "description": "Sacks Pile",
     "baseMaterial": "BURLAP",
     "objectIds": [
-      3025,
-      10314,
-      12394,
-      14743,
-      16867,
-      16868,
-      16870,
-      35956,
-      39696
+      "FAI_VARROCK_SACK_PILE",
+      "VC_SACKS2",
+      "_100_GOBLIN_SACK_PILE_LARGE",
+      "WILD_SACK",
+      "LUNAR_PIRATE_SACK_PILE_SMALL2",
+      "LUNAR_PIRATE_SACK_PILE_SMALL",
+      "LUNAR_PIRATE_SACK_PILE_LARGE",
+      "MOURNING_SACKS",
+      "WILDY_HUB_SACK"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -13571,10 +13571,10 @@
     "description": "Sacks with Sword",
     "baseMaterial": "BURLAP",
     "objectIds": [
-      12392,
-      16869,
-      16871,
-      52583
+      "_100_GOBLIN_SACK_PILE_KNIFE",
+      "LUNAR_PIRATE_SACK_PILE_SMALL_KNIFE",
+      "LUNAR_PIRATE_SACK_PILE_LARGE_KNIFE",
+      "FORTIS_SACKS_KNIFE"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -13594,9 +13594,9 @@
     "description": "Sack",
     "baseMaterial": "BURLAP",
     "objectIds": [
-      7512,
-      12396,
-      39695
+      "FARMING_SHOP_SACKS",
+      "_100_GOBLIN_SACK_EMPTY",
+      "WILDY_HUB_SACK_KNIFE"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -13611,7 +13611,7 @@
   {
     "description": "Object - Sack with Hey or Grain",
     "baseMaterial": "BURLAP",
-    "objectIds": [ 5574, 10306, 16878, 35872, 35954 ],
+    "objectIds": [ "SACK_FULL", "VC_SACK_FULL_DWARF", "LUNAR_PIRATE_GRAIN_SACK", "SOTE_LLETYA_SACK_FULL", "MOURNING_SACK_FULL" ],
     "uvType": "BOX",
     "uvScale": 0.75,
     "retainVanillaUvs": false
@@ -13620,14 +13620,14 @@
     "description": "Culinaromancers Floor",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      12366
+      "_100_TILE"
     ]
   },
   {
     "description": "Meiyerditch Boat",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      17955
+      "SANG_BOAT_IN_WATER"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13637,41 +13637,41 @@
     "description": "Meiyerditch Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      17676,
-      17677,
-      17678,
-      17679,
-      17680,
-      17681,
-      17720,
-      17721,
-      17722,
-      17723,
-      17724,
-      17725,
-      17726,
-      17727,
-      17728,
-      17729,
-      17730,
-      17731,
-      17732,
-      17733,
-      17734,
-      17735,
-      17738,
-      17739,
-      17740,
-      17741,
-      17742,
-      17743,
-      17744,
-      17941,
-      17942,
-      17943,
-      18054,
-      18055,
-      18056
+      "AREA_SANGUINE_OUTER_CRUMBLE1",
+      "AREA_SANGUINE_OUTER_CRUMBLE2",
+      "AREA_SANGUINE_OUTER_CRUMBLE3",
+      "AREA_SANGUINE_OUTER_CRUMBLE3_JUMP",
+      "AREA_SANGUINE_OUTER_CRUMBLE1_MIR",
+      "AREA_SANGUINE_OUTER_CRUMBLE2_MIR",
+      "AREA_SANGUINE_OUTER_WALL1",
+      "AREA_SANGUINE_OUTER_WALL1_NOMINIMAP",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_MIDDLE3_OPEN_NOMINIMAP",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_LEFT3_OPEN_NOMINIMAP",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_RIGHT3_OPEN_NOMINIMAP",
+      "AREA_SANGUINE_OUTER_WALL2",
+      "AREA_SANGUINE_OUTER_WALL3",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_MIDDLE1",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_MIDDLE2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_MIDDLE3_OPEN",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_LEFT1",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_RIGHT1",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_LEFT2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_RIGHT2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_LEFT3_OPEN",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_RIGHT3_OPEN",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_LEFT1_LEVEL2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_RIGHT1_LEVEL2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_LEFT2_LEVEL2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_RIGHT2_LEVEL2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_MIDDLE_LEVEL2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_MIDDLE2_LEVEL2",
+      "AREA_SANGUINE_OUTER_WALL_ARCH_MIDDLE2_LEVEL2_MIR",
+      "MYQ3_SECRET_WALL_01",
+      "MYQ3_SECRET_WALL_02",
+      "MYQ3_SECRET_WALL_03",
+      "MYQ3_GHETTO_BARICADE_WALL_SECRETPASS",
+      "MYQ3_GHETTO_BARICADE_WALL_SECRETPASS_INACTIVE",
+      "MYQ3_SECRET_ROCK_BARRICADE_UNLOCK"
     ],
     "uvType": "BOX",
     "uvScale": 0.55
@@ -13680,8 +13680,8 @@
     "description": "Meiyerditch Walls Rubble",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      18037,
-      18038
+      "MYQ3_RUBBLE_WEST_WALL",
+      "MYQ3_RUBBLE_EAST_WALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.55
@@ -13690,81 +13690,81 @@
     "description": "Meiyerditch Wall Plank Floors",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      17564,
-      17565,
-      17566,
-      17567,
-      17568,
-      17569,
-      17570,
-      17571,
-      17572,
-      17579,
-      17580,
-      17581,
-      17591,
-      17592,
-      17593,
-      17594,
-      17595,
-      17596,
-      17597,
-      17598,
-      17599,
-      17689,
-      17690,
-      17691,
-      17692,
-      17693,
-      17694,
-      17695,
-      17696,
-      17697,
-      17698,
-      17699,
-      17700,
-      17701,
-      17703,
-      17704,
-      17705,
-      17706,
-      17707,
-      17708,
-      17574,
-      17575,
-      17576,
-      17577,
-      17582,
-      17583,
-      17584,
-      17585,
-      17586,
-      17587,
-      17588,
-      17589,
-      17590,
-      18033,
-      18034,
-      18035,
-      18068,
-      18069,
-      18089,
-      18090,
-      18093,
-      18094,
-      18098,
-      18070,
-      18071,
-      18072,
-      18073,
-      18109,
-      18110,
-      18111,
-      18112,
-      18113,
-      18114,
-      18117,
-      18118
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_A",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_B",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_C",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_D",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_E",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_F",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_G",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_H",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_I",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_P",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_Q",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_R",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_J",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_K",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_L",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_M",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_N",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_O",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_P",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_Q",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_R",
+      "AREA_SANGUINE_GHETTO_FLOOR1",
+      "AREA_SANGUINE_GHETTO_FLOOR2",
+      "AREA_SANGUINE_GHETTO_FLOOR3",
+      "AREA_SANGUINE_GHETTO_FLOOR_FALLOFF1A",
+      "AREA_SANGUINE_GHETTO_FLOOR_FALLOFF1A_MIRROR",
+      "AREA_SANGUINE_GHETTO_FLOOR_FALLOFF2A",
+      "AREA_SANGUINE_GHETTO_FLOOR_FALLOFF2A_MIRROR",
+      "AREA_SANGUINE_GHETTO_FLOOR_FALLOFF3A",
+      "AREA_SANGUINE_GHETTO_FLOOR_FALLOFF3A_MIRROR",
+      "MYQ3_CLIMB_DUMMY",
+      "AREA_SANGUINE_PIER1",
+      "AREA_SANGUINE_PIER2",
+      "AREA_SANGUINE_PIER3",
+      "AREA_SANGUINE_ROOF_FLOOR1_GROUND_01",
+      "AREA_SANGUINE_ROOF_FLOOR1_GROUND_02",
+      "AREA_SANGUINE_ROOF_FLOOR1_GROUND_01_MIRROR",
+      "AREA_SANGUINE_ROOF_FLOOR1_GROUND_02_MIRROR",
+      "AREA_SANGUINE_ROOF_FLOOR1_GROUND2_01",
+      "AREA_SANGUINE_ROOF_FLOOR1_GROUND2_02",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_K",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_L",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_M",
+      "AREA_SANGUINE_GHETTO_FLOOR1_INTERIOR_N",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_A",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_B",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_C",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_D",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_E",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_F",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_G",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_H",
+      "AREA_SANGUINE_GHETTO_FLOOR2_INTERIOR_I",
+      "MIEYERDITCH_WALL_FLOORBOARDS_FIXED",
+      "MIEYERDITCH_WALL_FLOORBOARDS_LADDER_DOWN",
+      "MIEYERDITCH_WALL_FLOORBOARDS2_FIXED",
+      "MYQ3_AGIL_FLOOR_LADDER_EMPTY",
+      "MYQ3_AGIL_FLOOR_LADDER_FULL",
+      "MYQ3_AGIL_12_JUMP_EAST",
+      "MYQ3_AGIL_12_JUMP_WEST",
+      "MYQ3_AGIL_17_JUMP_SOUTH",
+      "MYQ3_AGIL_17_JUMP_NORTH",
+      "MYQ3_AGIL_20_JUMP_NORTH",
+      "MYQ3_AGIL_2_JUMP_SOUTH",
+      "MYQ3_AGIL_2_JUMP_NORTH",
+      "MYQ3_AGIL_3_JUMP_EAST",
+      "MYQ3_AGIL_3_JUMP_WEST",
+      "MYQ3_AGIL_27_JUMP_NORTH",
+      "MYQ3_AGIL_27_JUMP_SOUTH",
+      "MYQ3_AGIL_29_JUMP_NORTH",
+      "MYQ3_AGIL_29_JUMP_SOUTH",
+      "MYQ3_AGIL_30_JUMP_EAST",
+      "MYQ3_AGIL_30_JUMP_WEST",
+      "MYQ3_AGIL_41_JUMP_EAST",
+      "MYQ3_AGIL_41_JUMP_WEST"
     ],
     "uvType": "BOX"
   },
@@ -13772,10 +13772,10 @@
     "description": "Meiyerditch Wall Plank Roofs",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      17702,
-      17709,
-      17711,
-      17712
+      "AREA_SANGUINE_ROOF_FLOOR1",
+      "AREA_SANGUINE_ROOF_FLOOR2",
+      "AREA_SANGUINE_ROOF_FLOOR3",
+      "AREA_SANGUINE_ROOF_FLOOR3_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -13783,7 +13783,7 @@
     "description": "Meiyerditch Wall Plank Floors - Kicked",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      18036
+      "MIEYERDITCH_WALL_FLOORBOARDS_LADDER_UP"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -13793,16 +13793,16 @@
     "description": "Meiyerditch Plank Door",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      17600,
-      17601,
-      17973,
-      18031,
-      18032,
-      18047,
-      18048,
-      18057,
-      18091,
-      18092
+      "AREA_SANGUINE_GHETTO_DOOR1",
+      "AREA_SANGUINE_GHETTO_DOOR2",
+      "AREA_SANGUINE_MYREQUE_DOOR_LOCKED",
+      "AREA_SANGUINE_GHETTO_OPEN_DOOR1",
+      "AREA_SANGUINE_GHETTO_OPEN_DOOR2",
+      "MYQ3_LABORATORY_DOOR_CLOSED",
+      "MYQ3_LABORATORY_DOOR_INACTIVE",
+      "MYQ3_DOOR_SHORTCUT_REWARD",
+      "MYQ3_AGIL_14_LOCKED_DOOR",
+      "MYQ3_AGIL_14_LOCKED_DOOR_INACTIVE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13812,40 +13812,40 @@
     "description": "Meiyerditch House Walls",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      17602,
-      17603,
-      17604,
-      17605,
-      17606,
-      17607,
-      17608,
-      17609,
-      17610,
-      17611,
-      17612,
-      17613,
-      17614,
-      17615,
-      17616,
-      17617,
-      17618,
-      17619,
-      17620,
-      17621,
-      17622,
-      17980,
-      18066,
-      18067,
-      18074,
-      18075,
-      18078,
-      18079,
-      18080,
-      18088,
-      18101,
-      18102,
-      18144,
-      18145
+      "AREA_SANGUINE_GHETTO_WINDOW1",
+      "AREA_SANGUINE_GHETTO_WINDOW2",
+      "AREA_SANGUINE_GHETTO_WINDOW3",
+      "AREA_SANGUINE_GHETTO_UPPER_WINDOW1",
+      "AREA_SANGUINE_GHETTO_UPPER_WINDOW2",
+      "AREA_SANGUINE_GHETTO_UPPER_WINDOW3",
+      "AREA_SANGUINE_GHETTO_WALL1",
+      "AREA_SANGUINE_GHETTO_WALL2",
+      "AREA_SANGUINE_GHETTO_WALL3",
+      "AREA_SANGUINE_GHETTO_WALL4",
+      "AREA_SANGUINE_GHETTO_WALL5",
+      "AREA_SANGUINE_GHETTO_WALL6",
+      "AREA_SANGUINE_GHETTO_WALL7",
+      "AREA_SANGUINE_GHETTO_WALL8_LEFT",
+      "AREA_SANGUINE_GHETTO_WALL8_RIGHT",
+      "AREA_SANGUINE_GHETTO_WALL9_LEFT",
+      "AREA_SANGUINE_GHETTO_WALL9_RIGHT",
+      "AREA_SANGUINE_GHETTO_UPPER_WALL1",
+      "AREA_SANGUINE_GHETTO_UPPER_WALL2",
+      "AREA_SANGUINE_GHETTO_UPPER_WALL3",
+      "AREA_SANGUINE_GHETTO_UPPER_WALL4",
+      "AREA_SANGUINE_MYREQUE_SECRET_WALL_CLOSED",
+      "MYQ3_AGIL_WALL_LADDERTOP_FULL",
+      "MYQ3_AGIL_WALL_LADDERTOP_EMPTY",
+      "MYQ3_AGIL_4_PUSHWALL_NORTH",
+      "MYQ3_AGIL_4_PUSHWALL_NORTH_ANIM",
+      "MYQ3_AGIL_5_CRAWL_WALL",
+      "MYQ3_AGIL_6_PUSHWALL_WEST",
+      "MYQ3_AGIL_6_PUSHWALL_WEST_ANIM",
+      "MYQ3_AGIL_11_CRAWL_WALL",
+      "MYQ3_AGIL_24_PUSHWALL_NORTH",
+      "MYQ3_AGIL_24_PUSHWALL_NORTH_ANIM",
+      "SANG_MYREQUE_HIDEOUT_SYMBOL_ACTIVE_OUT",
+      "SANG_MYREQUE_HIDEOUT_SYMBOL_ACTIVE_IN"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -13855,13 +13855,13 @@
     "description": "Objects - Wooden - Poor Looking tables - Wide",
     "baseMaterial": "WOOD_GRAIN_2_WIDE",
     "objectIds": [
-      17545,
-      17546,
-      18059,
-      18060,
-      18062,
-      18063,
-      18064
+      "AREA_SANGUINE_GHETTO_TABLE",
+      "AREA_SANGUINE_GHETTO_TABLE1",
+      "MYQ3_AGIL_TABLE",
+      "MYQ3_AGIL_TRAPDOOR_TABLE",
+      "MYQ3_AGIL_TABLE_02",
+      "MYQ3_AGIL_TRAPDOOR_TABLE_02",
+      "MYQ3_AGIL_TRAPDOOR_TUNNEL_02"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -13870,7 +13870,7 @@
     "description": "Objects - Wooden - Poor Lab tables",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      17896
+      "MYQ3_LAB_TABLE_04"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13880,7 +13880,7 @@
     "description": "Objects - Wooden - Meiyerdith Trapdoor",
     "baseMaterial": "WOOD_GRAIN_2_WIDE",
     "objectIds": [
-      32577
+      "MYQ4_HIDEOUT_TRAPDOOR"
     ],
     "uvType": "BOX",
     "uvScale": 0.86
@@ -13889,8 +13889,8 @@
     "description": "Objects - Wooden - Chair - Meiyerditch",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      17548,
-      17549
+      "AREA_SANGUINE_GHETTO_CHAIR2",
+      "AREA_SANGUINE_GHETTO_CHAIR3"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13900,15 +13900,15 @@
     "description": "Meiyerditch House Roof",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      17639,
-      17748,
-      17749,
-      17750,
-      17751,
-      17752,
-      17753,
-      17754,
-      18097
+      "MYQ3_GHETTO_ROOF_JUMP_02",
+      "AREA_SANGUINE_POOR_ROOF_MIDDLE1",
+      "AREA_SANGUINE_POOR_ROOF_EDGE1_FILLED",
+      "AREA_SANGUINE_POOR_ROOF_EDGE_LEFT1",
+      "AREA_SANGUINE_POOR_ROOF_EDGE_RIGHT1",
+      "AREA_SANGUINE_POOR_ROOF_EDGE1_NO_SIDES",
+      "AREA_SANGUINE_POOR_ROOF_EDGE2_NO_SIDES",
+      "AREA_SANGUINE_POOR_ROOF_CORNER1_NO_SIDES",
+      "MYQ3_AGIL_20_JUMP_SOUTH"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13916,19 +13916,19 @@
     "description": "Meiyerditch Wooden Shelves",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      17534,
-      17535,
-      17536,
-      17537,
-      17538,
-      18086,
-      18087,
-      18095,
-      18096,
-      18105,
-      18106,
-      18107,
-      18108
+      "AREA_SANGUINE_GHETTO_SHELF1",
+      "AREA_SANGUINE_GHETTO_SHELF2",
+      "AREA_SANGUINE_GHETTO_SHELF3",
+      "AREA_SANGUINE_GHETTO_SHELF4",
+      "AREA_SANGUINE_GHETTO_SHELF5",
+      "MYQ3_AGIL_10_SHELF_CLIMB_UP",
+      "MYQ3_AGIL_10_SHELF_CLIMB_DOWN",
+      "MYQ3_AGIL_18_SHELF_CLIMB_UP",
+      "MYQ3_AGIL_18_SHELF_CLIMB_DOWN",
+      "MYQ3_AGIL_25_SHELF_CLIMB_UP",
+      "MYQ3_AGIL_25_SHELF_CLIMB_DOWN",
+      "MYQ3_AGIL_26_SHELF_CLIMB_DOWN",
+      "MYQ3_AGIL_26_SHELF_CLIMB_UP"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -13938,10 +13938,10 @@
     "description": "Meiyerditch Stone Brick Fireplace",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      17641,
-      17642,
-      17643,
-      18039
+      "MYQ3_GHETTO_FIREPLACE_MIDDLE",
+      "MYQ3_GHETTO_FIREPLACE_TOP",
+      "MYQ3_GHETTO_FIREPLACE_TOP_NOOFFSET",
+      "MYQ3_FIREPLACE_LOOSE_TILE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13949,8 +13949,8 @@
     "description": "Meiyerditch Poor Baricade",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      17644,
-      17645
+      "MYQ3_GHETTO_BARICADE",
+      "MYQ3_GHETTO_BARICADE2"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -13960,16 +13960,16 @@
     "description": "Meiyerditch Stone Brick Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      17492,
-      17493,
-      17494,
-      14795,
-      17496,
-      17497,
-      17498,
-      17499,
-      17500,
-      17501
+      "AREA_SANGUINE_CASTLE_WALL1",
+      "AREA_SANGUINE_CASTLE_WALL1_WITHBACK",
+      "AREA_SANGUINE_CASTLE_WALL2",
+      "WILD_SHIP_PLAIN_FLOOR_WHEEL",
+      "AREA_SANGUINE_CASTLE_WALL4",
+      "AREA_SANGUINE_CASTLE_WALL_JOIN1",
+      "AREA_SANGUINE_CASTLE_WALL_JOIN1_MIRROR",
+      "AREA_SANGUINE_CASTLE_WALL_ARCH_LEFT1",
+      "AREA_SANGUINE_CASTLE_WALL_ARCH_SPIKES",
+      "AREA_SANGUINE_CASTLE_WALL_ARCH_RIGHT1"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -13978,8 +13978,8 @@
     "description": "Ver Sinhaza Walls",
     "baseMaterial": "STONE",
     "objectIds": [
-      17487,
-      17514
+      "AREA_SANGUINE_CASTLE_LOWER_WALL1",
+      "MYQ3_CASTLE_WALL_TOP_HIGH"
     ],
     "uvType": "GEOMETRY"
   },
@@ -13987,10 +13987,10 @@
     "description": "Ver Sinhaza Walls",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      17503,
-      17504,
-      17505,
-      17517
+      "AREA_SANGUINE_CASTLE_FENCE_END_RIGHT1",
+      "AREA_SANGUINE_CASTLE_FENCE_MIDDLE1",
+      "AREA_SANGUINE_CASTLE_FENCE_MIDDLE2",
+      "MYQ3_CASTLE_FENCE_MIDDLE"
     ],
     "uvType": "MODEL_YZ",
     "uvOrientation": 512,
@@ -14000,10 +14000,10 @@
     "description": "Meiyerditch Poor Wooden Stairs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      17976,
-      17978,
-      18049,
-      18050
+      "AREA_SANGUINE_GHETTO_STAIRS_UP",
+      "AREA_SANGUINE_GHETTO_STAIRS_DOWN",
+      "MYQ3_LAB_STAIRS_DOWN",
+      "MYQ3_LAB_STAIRS_UP"
     ],
     "uvType": "BOX"
   },
@@ -14011,10 +14011,10 @@
     "description": "Meiyerditch Myreque Hideout Brick Stone Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      17649,
-      17650,
-      17651,
-      17653
+      "MYQ3_HIDEOUT_WALL",
+      "MYQ3_HIDEOUT_WALL_FALLOFF",
+      "MYQ3_HIDEOUT_WALL_FALLOFF_MIRROR",
+      "MYQ3_HIDEOUT_WALL_EXPOSED_PLASTER"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -14024,8 +14024,8 @@
     "description": "Meiyerditch Myreque Hideout Brick Stone Walls Rubble",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      17673,
-      17914
+      "MYQ3_HIDEOUT_CRUMBLED_WALL",
+      "MYQ3_LAB_CRUMBLED_WALL"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -14033,16 +14033,16 @@
     "description": "Meiyerditch Myreque Hideout Brick Stone Walls",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      17652
+      "MYQ3_HIDEOUT_WALL_MUD"
     ]
   },
   {
     "description": "Temple Trekking Sign",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      13873,
-      23275,
-      23276
+      "TEMPLETREK_DANGERSIGN",
+      "BURGH_TREK_SIGN",
+      "PATER_RAMBLE_SIGN"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -14051,9 +14051,9 @@
     "description": "Temple Trekking - Swamp  - Water - Bubbles",
     "baseMaterial": "GRAY_50",
     "objectIds": [
-      13858,
-      13859,
-      13860
+      "TEMPLETREK_SWAMP_BUBBLES",
+      "TEMPLETREK_SWAMP_BUBBLES_LARGE",
+      "TEMPLETREK_SWAMP_BUBBLES_SMALL"
     ],
     "uvType": "MODEL_XZ",
     "castShadows": false
@@ -14062,14 +14062,14 @@
     "description": "Temple Trekking & Kebos Swamp Trees",
     "baseMaterial": "BARK",
     "objectIds": [
-      13843,
-      13844,
-      13845,
-      13846,
-      13847,
-      13848,
-      13849,
-      13850
+      "TEMPLETREK_SWAMPTREE_BASE",
+      "TEMPLETREK_SWAMPTREE_TOP",
+      "TEMPLETREK_SWAMPTREE_BRANCH",
+      "TEMPLETREK_SWAMPTREE_BRANCH_VINE",
+      "TEMPLETREK_SWAMPTREE_SMALL_VINES",
+      "TEMPLETREK_SWAMPTREE_SMALL_1",
+      "TEMPLETREK_SWAMPTREE_SMALL_2",
+      "TEMPLETREK_SWAMPTREE_SMALL_EMPTY"
     ],
     "uvType": "BOX",
     "uvScale": 0.85
@@ -14078,17 +14078,17 @@
     "description": "Meiyerditch Mine Walls",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      17820,
-      17821,
-      17822,
-      17823,
-      17824,
-      17825,
-      17826,
-      17827,
-      17828,
-      17829,
-      17871
+      "AREA_SANGUINE_MINE_WALL",
+      "AREA_SANGUINE_MINE_WALL_ROCKY",
+      "AREA_SANGUINE_MINE_WALL_END",
+      "AREA_SANGUINE_MINE_WALL_END_02",
+      "AREA_SANGUINE_MINE_WALL_END_NO_MAP",
+      "AREA_SANGUINE_MINE_WALL_SUPPORT_LEFT",
+      "AREA_SANGUINE_MINE_WALL_SUPPORT_RIGHT",
+      "AREA_SANGUINE_MINE_WALL_SUPPORT_MID",
+      "AREA_SANGUINE_MINE_WALL_FOR_MINING",
+      "AREA_SANGUINE_MINE_WALL_LAMP",
+      "AREA_SANGUINE_MINE_WALL_TOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -14097,10 +14097,10 @@
     "description": "Meiyerditch Mine Walls - Daeyalt Rocks",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      17962,
-      17963,
-      17964,
-      17965
+      "AREA_SANGUINE_MINE_MINEROCKS_01",
+      "AREA_SANGUINE_MINE_MINEROCKS_02",
+      "AREA_SANGUINE_MINE_MINEROCKS_03",
+      "AREA_SANGUINE_MINE_MINEROCKS_04"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -14109,27 +14109,27 @@
     "description": "Darkmeyer Stone Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      39171,
-      39172,
-      39178,
-      39179,
-      39181,
-      39185,
-      39175,
-      39176,
-      39327,
-      39328,
-      39329,
-      39330,
-      39331,
-      39332,
-      39356,
-      39357,
-      39358,
-      39359,
-      39361,
-      39365,
-      39478
+      "DARKM_OUTER_WALL_3H",
+      "DARKM_OUTER_WALL_3H_MEYERDITCH_WALL_SHORTCUT_TOP",
+      "DARKM_OUTER_WALL_INSIDE_3H",
+      "DARKM_OUTER_WALL_OUTSIDE_1H",
+      "DARKM_OUTER_WALL_OUTSIDE_3H",
+      "DARKM_OUTER_WALL_3H_FLAG",
+      "DARKM_OUTER_WALL_1H",
+      "DARKM_OUTER_WALL_INSIDE_1H",
+      "DARKM_CASTLE_WALL",
+      "DARKM_CASTLE_WALL_OUTSIDE_CORNER",
+      "DARKM_CASTLE_WALL_WINDOW",
+      "DARKM_CASTLE_WALL_DIAGONAL_WINDOW_LEFT",
+      "DARKM_CASTLE_WALL_DIAGONAL_WINDOW_RIGHT",
+      "DARKM_CASTLE_WALL_DIAGONAL_WINDOW",
+      "DARKM_CASTLE_WALL_LVL0_NO_WINDOW_ROOF",
+      "DARKM_CASTLE_WALL_LVL0_NO_WINDOW_ROOF_FOUNTAIN",
+      "DARKM_CASTLE_WALL_LVL0_NO_WINDOW_ROOF_CORNER",
+      "DARKM_CASTLE_WALL_LVL0_NO_WINDOW_ROOF_INSIDE_CORNER",
+      "DARKM_CASTLE_WALL_LVL0_WINDOW_ROOF",
+      "DARKM_CASTLE_WALL_LVL0_DOOR_ROOF",
+      "DARKM_RICH_WALL02"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -14138,9 +14138,9 @@
     "description": "Darkmeyer Stone Tiles",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      39186,
-      39187,
-      39188
+      "DARKM_OUTER_WALL_TOP_TILE",
+      "DARKM_OUTER_WALL_TOP_TILE2",
+      "DARKM_OUTER_WALL_TOP_TILE2_SICKLE"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -14148,15 +14148,15 @@
     "description": "Vampyre Statue",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      18045,
-      18046
+      "MYQ3_LAB_VAMP_STATUE_EMPTY",
+      "MYQ3_LAB_VAMP_STATUE_KEY"
     ]
   },
   {
     "description": "Rack",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      17298
+      "QIP_DIGSITE_COOKINGSHELFEMPTY"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -14165,7 +14165,7 @@
     "description": "Digsite - Objects - Wooden - Tables - Fine",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      17299
+      "QIP_DIGSITE_TABLE"
     ],
     "uvType": "MODEL_XZ",
     "flatNormals": true,
@@ -14176,9 +14176,9 @@
     "description": "Digsite - Ground Decoration - Stone Plate",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      17343,
-      17346,
-      17347
+      "QIP_DIGSITE_LAVA_EDGE_10",
+      "QIP_DIGSITE_HEARTH1",
+      "QIP_DIGSITE_HEARTH2"
     ],
     "uvType": "MODEL_XZ",
     "flatNormals": true,
@@ -14189,7 +14189,7 @@
     "description": "Digsite - Object - Fireplace",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      17325
+      "QIP_DIGSITE_FIREPLACE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -14197,8 +14197,8 @@
     "description": "Digsite - Object - Giant Vase",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      386,
-      17362
+      "EGYPT_LARGEURN",
+      "QIP_DIGSITE_URN"
     ],
     "uvType": "GEOMETRY"
   },
@@ -14206,11 +14206,11 @@
     "description": "Digsite - Ground Decoration - Wooden Plank Path",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      2384,
-      2385,
-      2386,
-      2387,
-      2390
+      "DIGSITE_DECKING",
+      "DIGSITE_DECKING_2",
+      "DIGSITE_DECKING_BROKEN",
+      "DIGSITE_DECKING_CORNER_A",
+      "DIGSITE_DECKING_CORNER_D"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512,
@@ -14220,8 +14220,8 @@
     "description": "Digsite - Ground Decoration - Wooden Plank Path",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      2388,
-      2389
+      "DIGSITE_DECKING_CORNER_B",
+      "DIGSITE_DECKING_CORNER_C"
     ],
     "uvType": "MODEL_XZ_MIRROR_B",
     "uvOrientation": 512,
@@ -14231,14 +14231,14 @@
     "description": "Digsite - Objects - Rectangle Rock - Large",
     "baseMaterial": "STONE",
     "objectIds": [
-      17350,
-      17351,
-      17352,
-      17353,
-      17354,
-      17356,
-      17357,
-      17358
+      "QIP_DIGSITE_ROCKS_1X1_01",
+      "QIP_DIGSITE_ROCKS_1X1_02",
+      "QIP_DIGSITE_ROCKS_1X1_03",
+      "QIP_DIGSITE_ROCKS_1X3_01",
+      "QIP_DIGSITE_ROCKS_1X3_02",
+      "QIP_DIGSITE_ROCKS_2X1_02",
+      "QIP_DIGSITE_ROCKS_2X2_01",
+      "QIP_DIGSITE_ROCKS_2X2_02"
     ],
     "uvType": "BOX"
   },
@@ -14246,10 +14246,10 @@
     "description": "Bush Wall",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      17313,
-      17314,
-      17315,
-      25668
+      "QIP_DIGSITE_HEDGE",
+      "QIP_DIGSITE_HEDGE_CORNER",
+      "QIP_DIGSITE_HEDGE_END",
+      "MURDER_QIP_GARDEN_HEDGE"
     ]
   },
   {
@@ -14258,10 +14258,10 @@
     "uvType": "MODEL_XZ",
     "uvScale": 0.25,
     "objectIds": [
-      1173,
-      1298,
-      1299,
-      1300
+      "SMALLFERN",
+      "FERN",
+      "FERN1",
+      "FERN2"
     ]
   },
   {
@@ -14276,17 +14276,17 @@
       }
     ],
     "objectIds": [
-      1391,
-      1392,
-      1393,
-      1394,
-      5331,
-      5332,
-      5333,
-      5334,
-      9604,
-      9605,
-      9606
+      "PLANT1",
+      "PLANT2",
+      "PLANT3",
+      "PLANT4",
+      "AHOY_PLANT_1",
+      "AHOY_PLANT_2",
+      "AHOY_PLANT_3",
+      "AHOY_PLANT_4",
+      "SMALL_PLANT1",
+      "SMALL_PLANT2",
+      "SMALL_PLANT3"
     ]
   },
   {
@@ -14295,11 +14295,11 @@
     "uvScale": 0.25,
     "uvType": "BOX",
     "objectIds": [
-      1204,
-      1399,
-      1400,
-      1401,
-      1402
+      "JUNGLEPLANT4",
+      "JUNGLEPLANT1",
+      "JUNGLEPLANT1_KARAMJA",
+      "JUNGLEPLANT2",
+      "JUNGLEPLANT3"
     ]
   },
   {
@@ -14308,8 +14308,8 @@
     "uvScale": 0.25,
     "uvType": "MODEL_XZ",
     "objectIds": [
-      1390,
-      1398
+      "JUNGLE2",
+      "GREENER_JUNGLE2"
     ]
   },
   {
@@ -14318,7 +14318,7 @@
     "uvScale": 0.25,
     "uvType": "MODEL_XZ",
     "objectIds": [
-      1184
+      "JUNGLE1"
     ]
   },
   {
@@ -14327,18 +14327,18 @@
     "uvScale": 0.25,
     "uvType": "MODEL_XZ",
     "objectIds": [
-      1186
+      "GREENER_JUNGLE1"
     ]
   },
   {
     "description": "Digsite Wooden Fence Gate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      3630,
-      11766,
-      11767,
-      11770,
-      11771
+      "FAI_VARROCK_MEMBER_GATE_POST",
+      "FAI_VARROCK_MEMBER_GATEL",
+      "FAI_VARROCK_MEMBER_GATER",
+      "FAI_VARROCK_MEMBER_GATEL_OPEN",
+      "FAI_VARROCK_MEMBER_GATER_OPEN"
     ],
     "uvOrientation": 512,
     "uvType": "BOX"
@@ -14347,8 +14347,8 @@
     "description": "Morytania - Rotting Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      3514,
-      3515
+      "PEARTREE_DRUIDICSPIRIT_TRUNK",
+      "PEARTREE_DRUIDICSPIRIT_CROWN"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -14357,8 +14357,8 @@
     "description": "Morytania - Small Bush",
     "baseMaterial": "BARK",
     "objectIds": [
-      3512,
-      13840
+      "PEARTREE_DRUIDICSPIRIT",
+      "TEMPLETREK_LEAFLESSBUSH"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -14367,8 +14367,8 @@
     "description": "Morytania - Rotting Log & Branch",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      3508,
-      3510
+      "LOG_DRUIDICSPIRIT",
+      "BRANCH_DRUIDICSPIRIT"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -14377,9 +14377,9 @@
     "description": "Morytania - Giant Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      4048,
-      4049,
-      4050
+      "SPOOKY_TREE_BASE",
+      "SPOOKY_TREE_MID",
+      "SPOOKY_TREE_TOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -14388,23 +14388,23 @@
     "description": "Morytania - Tall Grass",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      3501,
-      3502,
-      3503,
-      3504,
-      13851,
-      13852,
-      13853,
-      13854,
-      13855
+      "SWAMP_PLANT1",
+      "SWAMP_PLANT2",
+      "SWAMP_PLANT3",
+      "SWAMP_PLANT4",
+      "TEMPLETREK_SWAMP_PLANT1",
+      "TEMPLETREK_SWAMP_PLANT2",
+      "TEMPLETREK_SWAMP_PLANT3",
+      "TEMPLETREK_SWAMP_PLANT4",
+      "TEMPLETREK_SWAMP_PLANT5"
     ]
   },
   {
     "description": "Generic - Plank - Tables - Picnic Bench",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7430,
-      7811
+      "FAI_VARROCK_POSH_BENCH",
+      "CLANWARS_TOURNAMENT_TABLE_SUPPLIES"
     ],
     "flatNormals": true,
     "uvType": "BOX"
@@ -14413,9 +14413,9 @@
     "description": "Generic - Plank - Tables - Picnic Bench - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      611,
-      39687,
-      15041
+      "PICNICBENCH",
+      "WILDY_HUB_BENCH",
+      "PIRATETREASURE_PICNICBENCH"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -14425,7 +14425,7 @@
     "description": "Generic - Plank - Tables - Picnic Bench - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      9532
+      "SARIM_PICNICBENCH"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -14435,7 +14435,7 @@
     "description": "Falador - Plank - Tables - Picnic Bench",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      24107
+      "FAI_FALADOR_PICNICBENCH"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -14446,10 +14446,10 @@
     "description": "Objects - Wooden - Battlements and Scaffold",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1612,
-      42076,
-      42077,
-      42078
+      "TIMBER_SCAFOLDTALL",
+      "SHAYZIEN_TIMBER_SCAFOLDEDGE",
+      "SHAYZIEN_TIMBER_SCAFOLDTOP",
+      "SHAYZIEN_TIMBER_SCAFOLDTALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.85,
@@ -14460,7 +14460,7 @@
     "description": "Hadleys House - Wattle",
     "baseMaterial": "WATTLE_1",
     "objectIds": [
-      1905
+      "PAINTEDBRICKWALL_2"
     ],
     "flatNormals": true,
     "uvType": "VANILLA"
@@ -14469,21 +14469,21 @@
     "description": "Metallic Pipes",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      872,
-      877,
-      2542,
-      3419,
-      3420,
-      3421,
-      6480,
-      18531
+      "LARGESEWERPIPE",
+      "WALLPIPE",
+      "PLAGUESEWERPIPE_OPEN",
+      "ELEMENTAL_PIPING",
+      "ELEMENTAL_PIPING_CORNER",
+      "ELEMENTAL_FLOORPIPE_FLOAT",
+      "LEGENDS_PIPE_CORNER",
+      "ELEM1_QIP_FLOORPIPE_OUTLET"
     ]
   },
   {
     "description": "Objects - Stone - Dessous Gravestone - Large",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6437
+      "VAMPIRE_BIG_GRAVE_NOBLOOD"
     ],
     "uvType": "GEOMETRY",
     "flatNormals": true
@@ -14492,24 +14492,24 @@
     "description": "Double Row Fence",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      47,
-      48,
-      49,
-      50,
-      3729,
-      14036,
-      14037,
-      14038,
-      14039,
-      15514,
-      15515,
-      15516,
-      15517,
-      23848,
-      25671,
-      25672,
-      25673,
-      25674
+      "FISHINGGATECLOSEDL",
+      "FISHINGGATECLOSEDR",
+      "INACFISHINGGATECLOSEDL",
+      "INACFISHINGGATECLOSEDR",
+      "DEATH_FENCING",
+      "FISHING_CONTEST_FENCE",
+      "FISHING_CONTEST_FENCE_POST",
+      "FISHING_CONTEST_FENCE_ENDR",
+      "FISHING_CONTEST_FENCE_ENDL",
+      "FAI_VARROCK_GATE_L",
+      "FAI_VARROCK_GATE_LC",
+      "FAI_VARROCK_GATE_R",
+      "FAI_VARROCK_GATE_RC",
+      "FAI_VARROCK_POSH_FENCING",
+      "MURDER_QIP_CONTEST_FENCE",
+      "MURDER_QIP_CONTEST_FENCE_POST",
+      "MURDER_QIP_CONTEST_FENCE_ENDR",
+      "MURDER_QIP_CONTEST_FENCE_ENDL"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -14519,9 +14519,9 @@
     "description": "Objects - Snowy Rock - Medium",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      5038,
-      5039,
-      6454
+      "TROLLRESCUE_ICY_ROCK_MEDIUM",
+      "TROLLRESCUE_ICY_ROCK_SMALL",
+      "PROTECT_ROCK"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.5
@@ -14530,17 +14530,17 @@
     "description": "Snow Heap",
     "baseMaterial": "SNOW_4",
     "objectIds": [
-      19692
+      "HUNTING_POLAR_CAVEWALL_FACE1_SHORTER"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Remove the shadow cast by objects that look weird with them",
     "objectIds": [
-      19032,
-      19036,
-      23159,
-      26382
+      "DRAYNOR_DIARY_UNDER_WALL_W",
+      "DRAYNOR_DIARY_UNDER_WALL_E",
+      "OLAF2_DUNGEON_ENTRANCE",
+      "GODWARS_LITTLE_HOLE"
     ],
     "castShadows": false
   },
@@ -14548,13 +14548,13 @@
     "description": "Objects - Desert Treasure Pyramid Obilisk - Large",
     "baseMaterial": "ROCK_3_SMOOTH",
     "objectIds": [
-      6483,
-      6484,
-      6486,
-      6487,
-      6490,
-      6492,
-      6493
+      "DESERT_TREASURE_OBLIX_A",
+      "FD_BLOOD_COLUMN",
+      "DESERT_TREASURE_OBLIX_B",
+      "FD_SMOKE_COLUMN",
+      "FD_ICE_COLUMN",
+      "DESERT_TREASURE_OBLIX_D",
+      "FD_SHADOW_COLUMN"
     ],
     "uvType": "BOX",
     "uvOrientation": 680
@@ -14563,7 +14563,7 @@
     "description": "Objects - Desert Treasure Pyramid Statue - Medium",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      6538
+      "FOUR_DIAMONDS_SPHINX"
     ],
     "uvType": "GEOMETRY"
   },
@@ -14571,29 +14571,29 @@
     "description": "Walls - Desert Treasure Pyramid Stone Doorway - Medium",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      6553,
-      6554,
-      6555,
-      6556
+      "DT_ANCIENT_TEMPLE_DOOR_OPEN",
+      "DT_ANCIENT_TEMPLE_DOOR_CLOSE",
+      "DT_ANCIENT_TEMPLE_DOOR_OPEN_MIRROR",
+      "DT_ANCIENT_TEMPLE_DOOR_CLOSE_MIRROR"
     ]
   },
   {
     "description": "Wall Decoration - Desert Treasure Pyramid - Golden Torch",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      6537
+      "FOUR_DIAMONDS_TOMB_WALL_TORCH"
     ]
   },
   {
     "description": "Object - Desert Treasure Pyramid - Sarcophagus - Medium",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      6512,
-      6513,
-      6514,
-      6515,
-      6516,
-      6517
+      "DESERTTREASURE_SARCOPHIGI_DOOR",
+      "DESERTTREASURE_SARCOPHIGI_DOOR_2",
+      "DESERTTREASURE_SARCOPHIGI_DOOR_3",
+      "DESERTTREASURE_SARCOPHIGI_DOOR_4",
+      "DESERTTREASURE_SARCOPHIGI_DOOR_5",
+      "DESERTTREASURE_SARCOPHIGI_DOOR_6"
     ],
     "uvType": "BOX",
     "uvOrientation": 192,
@@ -14603,7 +14603,7 @@
     "description": "Object - Desert Treasure Pyramid - Altar - Large",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      6552
+      "DT_ZAROS_ALTAR"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.23
@@ -14612,7 +14612,7 @@
     "description": "Object - Desert Treasure Pyramid - Lectern - Medium",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      40357
+      "DT_ANCIENT_LECTERN"
     ],
     "uvType": "GEOMETRY"
   },
@@ -14620,16 +14620,16 @@
     "description": "Rocks - Small",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      23976,
-      23977,
-      23978,
-      23979,
-      23980,
-      23981,
-      24146,
-      24147,
-      24148,
-      53253
+      "FAI_ANDROMEDA_ROCK_01",
+      "FAI_ANDROMEDA_ROCK_02",
+      "FAI_ANDROMEDA_ROCK_03",
+      "FAI_ANDROMEDA_ROCK_04",
+      "FAI_ANDROMEDA_ROCK_05",
+      "FAI_ANDROMEDA_ROCK_06",
+      "FAI_ROCK_VSMALL_01",
+      "FAI_ROCK_VSMALL_02",
+      "FAI_ROCK_VSMALL_03",
+      "DAGANNOTH_WATERBIRTH_ROCK_CLIMB_AGILITY_SHORTCUT_MIDDLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.22
@@ -14638,16 +14638,16 @@
     "description": "Rocks - Medium",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      5309,
-      11174,
-      11175,
-      11436,
-      11437,
-      24143,
-      24144,
-      24145,
-      53252,
-      53254
+      "AHOY_SHIPWRECK_ROCKS_LARGE",
+      "CAVEROCKS1",
+      "CAVEROCKS2",
+      "ROCKSLIDE_LIGHTGREY5",
+      "ROCKSLIDE_LIGHTGREY6",
+      "FAI_ROCK_SMALL_01",
+      "FAI_ROCK_SMALL_02",
+      "FAI_ROCK_SMALL_03",
+      "DAGANNOTH_WATERBIRTH_ROCK_CLIMB_AGILITY_SHORTCUT_BOTTOM",
+      "DAGANNOTH_WATERBIRTH_ROCK_CLIMB_AGILITY_SHORTCUT_TOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.22
@@ -14656,10 +14656,10 @@
     "description": "Rocks - Large",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      24139,
-      24140,
-      24141,
-      24142
+      "FAI_ROCK_BIG_01",
+      "FAI_ROCK_BIG_02",
+      "FAI_ROCK_BIG_03",
+      "FAI_ROCK_BIG_04"
     ],
     "uvType": "BOX",
     "uvScale": 0.22
@@ -14668,15 +14668,15 @@
     "description": "Crashed Star",
     "baseMaterial": "ROCK_5_ORE",
     "objectIds": [
-      41020,
-      41021,
-      41223,
-      41224,
-      41225,
-      41226,
-      41227,
-      41228,
-      41229
+      "STAR_SIZE_NINE_STAR",
+      "STAR_SIZE_EIGHT_STAR",
+      "STAR_SIZE_SEVEN_STAR",
+      "STAR_SIZE_SIX_STAR",
+      "STAR_SIZE_FIVE_STAR",
+      "STAR_SIZE_FOUR_STAR",
+      "STAR_SIZE_THREE_STAR",
+      "STAR_SIZE_TWO_STAR",
+      "STAR_SIZE_ONE_STAR"
     ],
     "uvType": "BOX"
   },
@@ -14684,16 +14684,16 @@
     "description": "Seers Village Courthouse Metal Cage",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      25980,
-      25981
+      "KR_COURTHOUSE_JAIL_BARS",
+      "KR_COURTHOUSE_JAIL_BARS_LOCKED_GATE"
     ]
   },
   {
     "description": "Seers Courthouse Plank Floors",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      25830,
-      25831
+      "KR_COURT_FLOOR_01",
+      "KR_COURT_FLOOR_02"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -14701,29 +14701,29 @@
     "description": "Marble - Camelot Knight Statue",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      26073
+      "KR_CAMELOT_KNIGHT_STATUE"
     ]
   },
   {
     "description": "Marble - Stone Stairs",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      25786,
-      25787
+      "KR_STAIRS",
+      "KR_STAIRSTOP"
     ]
   },
   {
     "description": "Keep Le Faye Instanced - Stone Brick Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      3389,
-      3390,
-      3391,
-      3392,
-      3393,
-      5812,
-      5835,
-      25845
+      "KR_KEEP_WALLS",
+      "KR_KEEP_WALLS_DOOR_SUPPORT",
+      "KR_KEEP_BATTLEMENT",
+      "KR_KEEP_BATTLEMENT_HELPER_01",
+      "KR_KEEP_BATTLEMENT_HELPER_02",
+      "KR_KEEP_WALL_WINDOW",
+      "KR_KEEP_WALL_END_01",
+      "KR_KEEP_WALL_END_02"
     ],
     "uvType": "BOX",
     "uvScale": 0.34,
@@ -14733,23 +14733,23 @@
     "description": "Keep Le Faye Dungeon Walls",
     "baseMaterial": "NONE",
     "objectIds": [
-      25880,
-      25881
+      "KR_UNDERGROUND_JAIL_CELL_WALL_BOTTOM_WITH_VENT",
+      "KR_UNDERGROUND_JAIL_CELL_WALL_BOTTOM"
     ]
   },
   {
     "description": "Keep Le Faye Dungeon Wall Light",
     "baseMaterial": "NONE",
     "objectIds": [
-      25888
+      "KR_UNDERGROUND_JAIL_CAVEWALL_TOP_VENT"
     ]
   },
   {
     "description": "Dirt Wedge Stairs",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      23974,
-      23975
+      "FAI_SKEWSTEPS_01",
+      "FAI_SKEWSTEPS_01_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -14758,26 +14758,26 @@
     "description": "Stone Wedge Stairs",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      47422,
-      47423
+      "BH_PORTAL_STAIRS",
+      "BH_PORTAL_STAIRS_TRIM"
     ]
   },
   {
     "description": "Ferox Enclave - Walls - Stone Brick",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      39661,
-      39662,
-      39663,
-      39664,
-      39665,
-      39666,
-      39667,
-      39668,
-      39669,
-      39671,
-      39672,
-      39673
+      "WILDY_HUB_WALL_01",
+      "WILDY_HUB_WALL_02",
+      "WILDY_HUB_WALL_LOW_01",
+      "WILDY_HUB_WALL_LOW_02",
+      "WILDY_HUB_WALL_CRUMBLE_L",
+      "WILDY_HUB_WALL_CRUMBLE_L_02",
+      "WILDY_HUB_WALL_CRUMBLE_SMALL_L",
+      "WILDY_HUB_WALL_CRUMBLE_R",
+      "WILDY_HUB_WALL_CRUMBLE_R_02",
+      "WILDY_HUB_WALL_WINDOW_01",
+      "WILDY_HUB_WALL_WINDOW_02",
+      "WILDY_HUB_WALL_BARS"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -14787,7 +14787,7 @@
     "baseMaterial": "ROCK_1",
     "areas": [ "Wilderness - Slayer Cave - Entrance Wall Fix" ],
     "objectIds": [
-      39671
+      "WILDY_HUB_WALL_WINDOW_01"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -14796,7 +14796,7 @@
     "description": "Ferox Enclave - Ancient Altar",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      39642
+      "WILDY_HUB_ALTAR"
     ],
     "uvType": "BOX"
   },
@@ -14804,9 +14804,9 @@
     "description": "Ferox Enclave - Floating Debris",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      15817,
-      26293,
-      39689
+      "LOTR_MINE_BARREL_IN_WATER",
+      "CLANWARS_PLANKFLOATER",
+      "WILDY_HUB_CRATE_IN_WATER"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -14820,11 +14820,11 @@
     "description": "Ferox Enclave - Misc Objects",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      2214,
-      2215,
-      2273,
-      14744,
-      39688
+      "FAI_VARROCK_UNFINISHED_WEAPONS_01",
+      "FAI_VARROCK_UNFINISHED_WEAPONS_02",
+      "FAI_VARROCK_UNFINISHED_WEAPONS_03",
+      "WILDERNESS_MANICALS",
+      "WILDY_HUB_BACKPACK"
     ],
     "uvType": "BOX"
   },
@@ -14832,7 +14832,7 @@
     "description": "Ferox Enclave - Statue",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      39674
+      "WILDY_HUB_WARRIOR_STATUE"
     ],
     "uvType": "BOX"
   },
@@ -14840,8 +14840,8 @@
     "description": "Sleeping Bag",
     "baseMaterial": "CARPET",
     "objectIds": [
-      5495,
-      28521
+      "FAVOUR_POORBED",
+      "LOVAKENGJ_SLEEPING_BAG"
     ],
     "uvType": "BOX",
     "uvScale": 0.66
@@ -14850,10 +14850,10 @@
     "description": "Morytania - Walls - Wooden - Plank - Rotten Plank Walls",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      5240,
-      5241,
-      20774,
-      20775
+      "AHOY_FARMHOUSE_WALL",
+      "AHOY_FARMHOUSE_WALL_WINDOW",
+      "BARROWS_FARMHOUSE_WALL_OCCLUDING",
+      "BARROWS_FARMHOUSE_WALL_WINDOW_OCCLUDING"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -14864,10 +14864,10 @@
     "description": "Morytania - Walls - Wooden - Plank - Rotten Plank Roof",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      5363,
-      5364,
-      5365,
-      6831
+      "AHOY_WOODEN_ROOF1",
+      "AHOY_WOODEN_ROOF2",
+      "AHOY_WOODEN_ROOF",
+      "AHOY_WOODEN_ROOF_MID2"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -14878,12 +14878,12 @@
     "description": "Morytania - Walls - Wooden - Plank - Rotten Plank Roof - Corner",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      5366,
-      5367,
-      5368,
-      6832,
-      6833,
-      6834
+      "AHOY_WOODEN_ROOF_EDGE",
+      "AHOY_WOODEN_ROOF_EDGE_MIRROR",
+      "AHOY_WOODEN_ROOF_MID_EDGE",
+      "AHOY_WOODEN_ROOF_EDGE_2",
+      "AHOY_WOODEN_ROOF_EDGE_2_MIRROR",
+      "AHOY_WOODEN_ROOF_MID_EDGE2"
     ],
     "uvType": "BOX",
     "uvOrientationX": 1536,
@@ -14896,12 +14896,12 @@
     "description": "Morytania - Walls - Stone - Barrows Crypt",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      20728,
-      20729,
-      20730,
-      20731,
-      20732,
-      20764
+      "BARROWS_CRYPT",
+      "BARROWS_CRYPT_INNER",
+      "BARROWS_CRYPT_MISSING_BRICK",
+      "BARROWS_CRYPT_PURPLE",
+      "BARROWS_CRYPT_INNER_PURPLE",
+      "BARROWS_CRYPT_MISSING_BRICK_PURPLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -14919,7 +14919,7 @@
     "baseMaterial": "ROCK_2",
     "areas": [ "BARROWS_CRYPTS" ],
     "objectIds": [
-      20737
+      "BARROWS_MOUNTAIN_CAVEWALL_TOP"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -14927,22 +14927,22 @@
     "description": "Morytania - Ground  - Stone - Stone Steps",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      20735,
-      20736,
-      20768,
-      20769
+      "BARROWS_SKEWSTEPS",
+      "BARROWS_SKEWSTEPS_CORNER",
+      "BARROWS_SKEWSTEPS_PURPLE",
+      "BARROWS_SKEWSTEPS_CORNER_PURPLE"
     ]
   },
   {
     "description": "Barrows Sarcophagus",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      20720,
-      20721,
-      20722,
-      20770,
-      20771,
-      20772
+      "BARROW_DHAROK_SARCOPHAGUS",
+      "BARROW_TORAG_SARCOPHAGUS",
+      "BARROW_GUTHAN_SARCOPHAGUS",
+      "BARROW_AHRIM_SARCOPHAGUS",
+      "BARROW_KARIL_SARCOPHAGUS",
+      "BARROW_VERAC_SARCOPHAGUS"
     ],
     "uvType": "BOX"
   },
@@ -14950,12 +14950,12 @@
     "description": "Barrows Stairs",
     "baseMaterial": "STONE_NORMALED_DARK",
     "objectIds": [
-      20667,
-      20668,
-      20669,
-      20670,
-      20671,
-      20672
+      "BARROWS_STAIRS_AHRIM",
+      "BARROWS_STAIRS_DHAROK",
+      "BARROWS_STAIRS_GUTHAN",
+      "BARROWS_STAIRS_KARIL",
+      "BARROWS_STAIRS_TORAG",
+      "BARROWS_STAIRS_VERAC"
     ],
     "uvType": "BOX"
   },
@@ -14963,12 +14963,12 @@
     "description": "Barrows Tunnels Doors lighter",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      20678,
-      20679,
-      20697,
-      20698,
-      20680,
-      20699
+      "BARROWS_DOOR_INACTIVE_R",
+      "BARROWS_DOOR_UNLOCKED_R",
+      "BARROWS_DOOR_INACTIVE_L",
+      "BARROWS_DOOR_UNLOCKED_L",
+      "BARROWS_DOOR_LOCKED_R",
+      "BARROWS_DOOR_LOCKED_L"
     ],
     "uvType": "BOX",
     "uvScale": 1.2
@@ -14977,8 +14977,8 @@
     "description": "Barrows Chest",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      20723,
-      20724
+      "BARROWS_STONE_CHEST_CLOSED",
+      "BARROWS_STONE_CHEST_OPEN"
     ],
     "uvType": "BOX"
   },
@@ -14986,7 +14986,7 @@
     "description": "Barrows Standing Torch",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      20716
+      "BARROWS_TORCH"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -14996,8 +14996,8 @@
     "description": "Ferox Enclave - Wall Rubble",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      39691,
-      39692
+      "WILDY_HUB_STONE_PILE1",
+      "WILDY_HUB_STONE_PILE2"
     ],
     "uvType": "GEOMETRY"
   },
@@ -15005,9 +15005,9 @@
     "description": "Wooden Bank Chest",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2090,
-      21301,
-      26711
+      "FAI_VARROCK_BANK_CHEST",
+      "FRIS_BANK_CHEST_OPEN",
+      "FAIRY_CHEST_BANK"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -15016,8 +15016,8 @@
     "description": "Rough Wooden Plank Stairs ",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      39643,
-      42040
+      "WILDY_HUB_STAIRS",
+      "SHAYZIEN_WOODEN_SKEWSTEPS"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -15027,10 +15027,10 @@
     "description": "Ground Decoration - Flat Rocks - Small",
     "baseMaterial": "ROCK_1_LIGHT",
     "objectIds": [
-      39701,
-      39702,
-      39703,
-      39704
+      "WILDY_HUB_STONES_FLAT_01",
+      "WILDY_HUB_STONES_FLAT_02",
+      "WILDY_HUB_STONES_FLAT_03",
+      "WILDY_HUB_STONES_FLAT_04"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.74
@@ -15040,18 +15040,18 @@
     "baseMaterial": "STONE_NORMALED",
     "uvType": "BOX",
     "objectIds": [
-      1862,
-      2159,
-      5189,
-      47421
+      "SKEWSTEPS1",
+      "SLAYER_SKEWSTEPS",
+      "FENK_SKEWSTEPS",
+      "BH_PORTAL_FLOOR"
     ]
   },
   {
     "description": "Objects - Metallic - Vat",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      1028,
-      1029
+      "TANNINGVAT",
+      "TANNINGVAT2"
     ],
     "uvType": "BOX"
   },
@@ -15059,7 +15059,7 @@
     "description": "Objects - Metallic - Scuttle",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      24321
+      "CANAFIS_INN_COAL_SCUTTLE"
     ],
     "uvType": "BOX"
   },
@@ -15067,9 +15067,9 @@
     "description": "Morytania - Walls - Metallic - Fence",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      3457,
-      3458,
-      3459
+      "ORNATERAILING",
+      "ORNATERAILING_TERMINATOR_L",
+      "ORNATERAILING_TERMINATOR_R"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -15080,8 +15080,8 @@
     "description": "Morytania - Walls - Metallic - Frankenstrains Gate",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      5172,
-      5173
+      "FENK_TOWER_DOOR",
+      "FENK_TOWER_DOOR_OPEN"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -15091,7 +15091,7 @@
     "description": "Morytania - Objects - Metallic - Suit of Armor",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      1900
+      "OLDSUITOFARMOUR"
     ],
     "uvType": "BOX"
   },
@@ -15099,8 +15099,8 @@
     "description": "Wooden Wedge Stairs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1863,
-      24361
+      "SKEWSTEPS1_LBROWN",
+      "CANAFIS_SKEWSTEPS"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -15110,15 +15110,15 @@
     "description": "Morytania - Frankenstrains Castle - Walls - Brick Stone",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      5190,
-      5191,
-      5192,
-      5194,
-      5195,
-      5196,
-      5197,
-      5200,
-      5201
+      "FENK_EXTERIOR_WALL",
+      "FENK_EXTERIOR_WALL_LVL2",
+      "FENK_INTERIOR_WALL",
+      "FENK_CRUMBLYWALL1",
+      "FENK_CRUMBLYWALL1R",
+      "FENK_CRUMBLYWALL2",
+      "FENK_CRUMBLYWALL2_TOP",
+      "FENK_WINDOW_WALL",
+      "FENK_WINDOW_WALL_LVL2"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -15128,8 +15128,8 @@
     "description": "Morytania - Frankenstrains Castle - Walls - Brick Stone Rubble",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      5198,
-      5199
+      "FENK_CRUMBLYWALLLOW",
+      "FENK_CRUMBLYWALLLOW2"
     ],
     "uvType": "BOX",
     "uvOrientation": 1536,
@@ -15139,26 +15139,26 @@
     "description": "Blast Furnace",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      9085,
-      9086,
-      9087,
-      9088,
-      9093,
-      9094,
-      9095,
-      9096,
-      9114,
-      9114,
-      9116,
-      9117,
-      9118,
-      9119,
-      9120,
-      9121,
-      9122,
-      9123,
-      9124,
-      9125
+      "BLAST_FURNACE_STOVE_LOW",
+      "BLAST_FURNACE_STOVE_MEDIUM",
+      "BLAST_FURNACE_STOVE_FULL",
+      "BLAST_FURNACE_COKE",
+      "BLAST_FURNACE_ORE_DISPENSER_EMPTY",
+      "BLAST_FURNACE_ORE_DISPENSER_FORANIM",
+      "BLAST_FURNACE_ORE_DISPENSER_FULL",
+      "BLAST_FURNACE_ORE_DISPENSER_COOLED",
+      "BLAST_FURNACE_PIPES",
+      "BLAST_FURNACE_PIPES",
+      "BLAST_FURNACE_PIPES2",
+      "BLAST_FURNACE_PIPES2_BROKEN",
+      "BLAST_FURNACE_PIPES3",
+      "BLAST_FURNACE_PIPES5",
+      "BLAST_FURNACE_PIPES6",
+      "BLAST_FURNACE_PIPES6_BROKEN",
+      "BLAST_FURNACE_PIPES7",
+      "BLAST_FURNACE_PIPES7_SMOKE",
+      "BLAST_FURNACE_PIPES8",
+      "BLAST_FURNACE_PIPES9"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -15167,10 +15167,10 @@
     "description": "Blast Furnace - Wooden",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      9104,
-      9105,
-      9106,
-      9108
+      "BLAST_FURNACE_CONVEYER_COGS2",
+      "BLAST_FURNACE_CONVEYER_COGS2_BROKEN",
+      "BLAST_FURNACE_CONVEYER_COGS3",
+      "BLAST_FURNACE_CONVEYER_COGS5"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -15187,8 +15187,8 @@
     "description": "Blast Furnace - Drive Belt",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      9102,
-      9107
+      "BLAST_FURNACE_CONVEYER_COGS",
+      "BLAST_FURNACE_CONVEYER_COGS4"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -15203,8 +15203,8 @@
     "description": "Blast Furnace - Ore Belt",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      9100,
-      9101
+      "BLAST_FURNACE_CONVEYER_BELT_CLICKABLE",
+      "BLAST_FURNACE_CONVEYER_BELT"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -15219,7 +15219,7 @@
     "description": "Blast Furnace - Temp Gauge",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      9089
+      "BLAST_FURNACE_GAUGE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -15236,7 +15236,7 @@
     "description": "Blast Furnace - Melting Pot",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      9098
+      "BLAST_FURNACE_CHIMNEY"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -15253,10 +15253,10 @@
     "description": "Blast Furnace - Shelves",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      6154,
-      6155,
-      6156,
-      6157
+      "DWARF_KELDAGRIM_SHELVES1",
+      "DWARF_KELDAGRIM_SHELVES2",
+      "DWARF_KELDAGRIM_SHELVES3",
+      "DWARF_KELDAGRIM_SHELVES4"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -15271,7 +15271,7 @@
     "description": "Motherload Hopper",
     "baseMaterial": "METALLIC_1_HIGHGLOSS",
     "objectIds": [
-      26674
+      "MOTHERLODE_HOPPER"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -15280,7 +15280,7 @@
     "description": "Objects - Stone - Giants Foundry - Moulds",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      44683
+      "GIANTS_FOUNDRY_MOLD_LIBRARY"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -15289,9 +15289,9 @@
     "description": "Objects - Stone - Giants Foundry - Mould Jig",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      44625,
-      44626,
-      44627
+      "GIANTS_FOUNDRY_JIG_EMPTY",
+      "GIANTS_FOUNDRY_JIG_MOULD",
+      "GIANTS_FOUNDRY_JIG_MOULD_FILLED"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -15301,7 +15301,7 @@
     "description": "Objects - Stone - Giants Foundry - Preform storage",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      44633
+      "GIANTS_FOUNDRY_PREFORM_STORAGE_EMPTY"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -15311,16 +15311,16 @@
     "description": "Objects - Stone - Giants Foundry - Lavapool Rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      44653,
-      44654,
-      44655,
-      44656,
-      44657,
-      44658,
-      44659,
-      44660,
-      44661,
-      44662
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM01",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM02",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM03",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM04",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM05",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM06",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM07",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM08",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM09",
+      "GIANTS_FOUNDRY_LAVAPOOL_PLATFORM10"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512,
@@ -15330,7 +15330,7 @@
     "description": "Objects - Wooden - Steps",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      44679
+      "GIANTS_FOUNDRY_WATERFALL_PLATFORM_STEPS"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -15340,7 +15340,7 @@
     "description": "Giants Foundry Single row fences",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      44680
+      "GIANTS_FOUNDRY_WATERFALL_PLATFORM_FENCE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -15349,7 +15349,7 @@
     "description": "Giants Foundry Clamps",
     "baseMaterial": "METALLIC_1_HIGHGLOSS",
     "objectIds": [
-      44729
+      "GIANTS_FOUNDRY_TONGS"
     ],
     "uvType": "BOX",
     "uvScale": 0.28
@@ -15358,9 +15358,9 @@
     "description": "Giants Foundry Crucible",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      44622,
-      44623,
-      44624
+      "GIANTS_FOUNDRY_CRUCIBLE_EMPTY",
+      "GIANTS_FOUNDRY_CRUCIBLE_PARTIAL",
+      "GIANTS_FOUNDRY_CRUCIBLE_FULL"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -15369,23 +15369,23 @@
     "description": "Objects - Stone - Giants Foundry - Lava Rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      37552,
-      37553,
-      37554,
-      37555,
-      37556,
-      37557,
-      37559,
-      37560,
-      37561,
-      44764,
-      44765,
-      44766,
-      44767,
-      44768,
-      44769,
-      44770,
-      44771
+      "DECOKIT_LAVA_9SLICE01",
+      "DECOKIT_LAVA_9SLICE02",
+      "DECOKIT_LAVA_9SLICE03",
+      "DECOKIT_LAVA_9SLICE04",
+      "DECOKIT_LAVA_9SLICE05",
+      "DECOKIT_LAVA_9SLICE06",
+      "DECOKIT_LAVA_9SLICE07",
+      "DECOKIT_LAVA_9SLICE08",
+      "DECOKIT_LAVA_9SLICE09",
+      "DECOKIT_LAVA_MEDIUM01",
+      "DECOKIT_LAVA_LARGE01",
+      "DECOKIT_LAVA_MEDIUM02",
+      "DECOKIT_LAVA_LARGE02",
+      "DECOKIT_LAVA_MEDIUM03",
+      "DECOKIT_LAVA_LARGE03",
+      "DECOKIT_LAVA_MEDIUM04",
+      "DECOKIT_LAVA_LARGE04"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -15393,10 +15393,10 @@
     "description": "Objects - Stone - Giants Foundry - Lava Rocks - Small",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      42494,
-      42495,
-      42496,
-      42497
+      "DECOKIT_LAVA_DEFAULT01",
+      "DECOKIT_LAVA_DEFAULT02",
+      "DECOKIT_LAVA_DEFAULT03",
+      "DECOKIT_LAVA_DEFAULT04"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.8,
@@ -15406,7 +15406,7 @@
     "description": "Giants Foundry - Lava Pool",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      44631
+      "GIANTS_FOUNDRY_LAVA_POOL"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -15414,7 +15414,7 @@
     "description": "Objects - Misc - Giants Foundry - Hammer",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      44727
+      "GIANTS_FOUNDRY_HAMMER"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -15430,7 +15430,7 @@
     "description": "Giants Foundry - Trip Hammer",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      44619
+      "GIANTS_FOUNDRY_TRIP_HAMMER"
     ],
     "colorOverrides": [
       {
@@ -15449,8 +15449,8 @@
     "description": "Giants Foundry - Belt System",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      44762,
-      44763
+      "GIANTS_FOUNDRY_TOOL_POWERUNIT",
+      "GIANTS_FOUNDRY_TOOL_POWERUNIT02"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -15473,7 +15473,7 @@
     "description": "Giants Foundry - Grindstone",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      44620
+      "GIANTS_FOUNDRY_GRINDSTONE"
     ],
     "colorOverrides": [
       {
@@ -15496,7 +15496,7 @@
     "uvType": "BOX",
     "uvScale": 0.3,
     "objectIds": [
-      44621
+      "GIANTS_FOUNDRY_POLISHING_WHEEL"
     ],
     "colorOverrides": [
       {
@@ -15518,7 +15518,7 @@
     "uvType": "BOX",
     "uvScale": 0.3,
     "objectIds": [
-      44761
+      "GIANTS_FOUNDRY_WATERWHEEL_01"
     ],
     "colorOverrides": [
       {
@@ -15541,7 +15541,7 @@
     "uvScale": 0.6,
     "uvOrientation": 256,
     "objectIds": [
-      44632
+      "GIANTS_FOUNDRY_WATERFALL"
     ],
     "colorOverrides": [
       {
@@ -15560,17 +15560,17 @@
     "uvOrientation": 750,
     "uvScale": 1.5,
     "objectIds": [
-      44747,
-      44748,
-      44749,
-      44750
+      "GIANTS_FOUNDRY_WATERFALL_WATER_01",
+      "GIANTS_FOUNDRY_WATERFALL_WATER_02",
+      "GIANTS_FOUNDRY_WATERFALL_WATER_03",
+      "GIANTS_FOUNDRY_WATERFALL_WATER_04"
     ]
   },
   {
     "description": "Giants Anvil",
     "baseMaterial": "METALLIC_1_GLOSS",
     "objectIds": [
-      39724
+      "GH_ANVIL"
     ],
     "uvType": "BOX",
     "uvScale": 0.28
@@ -15579,8 +15579,8 @@
     "description": "Giants Foundry - Volcano",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      29629,
-      29630
+      "RC_ZMI_CRATER_LAVA",
+      "RC_ZMI_CRATER_LAVA_BIG"
     ],
     "uvType": "GEOMETRY",
     "uvScale": 0.28
@@ -15588,14 +15588,14 @@
   {
     "description": "Giants Foundry -  Wooden - Chest",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 44726 ],
+    "objectIds": [ "GIANTS_FOUNDRY_CHEST_INACTIVE" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
   {
     "description": "Giants Foundry -  Wooden - Pile of Buckets",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 33309 ],
+    "objectIds": [ "MY2ARM_THRONE_ROOM_BUCKETS" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientationY": -200,
@@ -15609,28 +15609,28 @@
   {
     "description": "Giants Foundry -  Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 44638 ],
+    "objectIds": [ "GIANTS_FOUNDRY_SUPPLY_BOX_EMPTY" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
   {
     "description": "Giants Foundry -  Wooden - Bank Chest",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 44630 ],
+    "objectIds": [ "GIANTS_FOUNDRY_CHEST" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
   {
     "description": "Giants Foundry -  Wooden - WheelBarrow",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 44728 ],
+    "objectIds": [ "GIANTS_FOUNDRY_WHEEL_BARROW" ],
     "uvType": "BOX",
     "uvOrientationX": 576,
     "uvOrientationZ": 512
   },
   {
     "description": "Replace vanilla scrolling waterfall texture with droplets, until a better solution is found",
-    "objectIds": [ 754, 10459 ],
+    "objectIds": [ "WATERFALL_OVERLAY", "WATERFALL_OVERLAY_1_BRIGHTER" ],
     "textureMaterial": "WATER_DROPLETS",
     "baseMaterial": "WATER_FLAT",
     "areas": [
@@ -15640,47 +15640,47 @@
   },
   {
     "description": "Hide vanilla scrolling water models, until a better solution is found",
-    "objectIds": [ 754, 10459, 18863 ],
+    "objectIds": [ "WATERFALL_OVERLAY", "WATERFALL_OVERLAY_1_BRIGHTER", "MYARM_WATER_MOVING_1" ],
     "hide": true
   },
   {
     "description": "Texture for water in Motherlode Mine troughs",
-    "objectIds": [ 754, 10459 ],
+    "objectIds": [ "WATERFALL_OVERLAY", "WATERFALL_OVERLAY_1_BRIGHTER" ],
     "areas": [ "MOTHERLODE_MINE"],
     "textureMaterial": "MOTHERLODE_MINE_WATER"
   },
   {
     "description": "Poison Waste dungeon flowing tar (TODO)",
     "objectIds": [
-      49789,
-      49790,
-      49791,
-      49792,
-      49793,
-      49794,
-      49795,
-      49797,
-      49798,
-      49799,
-      49800,
-      49801,
-      49802,
-      49803
+      "POG_TAR_1",
+      "POG_TAR_2",
+      "POG_TAR_3",
+      "POG_TAR_4",
+      "POG_TAR_5",
+      "POG_TAR_6",
+      "POG_TAR_7",
+      "POG_TAR_9",
+      "POG_TAR_10",
+      "POG_TAR_11",
+      "POG_TAR_12",
+      "POG_TAR_DRAINOFF_01",
+      "POG_TAR_DRAINOFF_02",
+      "POG_TAR_DRAINOFF_03"
     ]
   },
   {
     "description": "Disable shadows for shoreline sludge in The Scar",
     "objectIds": [
-      49373,
-      49376,
-      49377,
-      49378,
-      49380,
-      49381,
-      49382,
-      49383,
-      49384,
-      49385
+      "DT2_SCAR_NERVE_NOOP01",
+      "DT2_SCAR_FALLOFF1",
+      "DT2_SCAR_FALLOFF2",
+      "DT2_SCAR_FALLOFF3",
+      "DT2_SCAR_FALLOFF5",
+      "DT2_SCAR_FALLOFF6",
+      "DT2_SCAR_FALLOFF7",
+      "DT2_SCAR_FALLOFF8",
+      "DT2_SCAR_FALLOFF9",
+      "DT2_SCAR_FALLOFF_10"
     ],
     "castShadows": false,
     "baseMaterial": "TRANSPARENT",
@@ -15689,7 +15689,7 @@
   {
     "description": "The Scar stepping stones",
     "objectIds": [
-      49209
+      "DT2_SCAR_ENTRY_STEPPING_STONE"
     ],
     "castShadows": false,
     "baseMaterial": "STONE",
@@ -15698,17 +15698,17 @@
   {
     "description": "Lassar Undercity floor tile texture",
     "objectIds": [
-      48088,
-      48089,
-      48090,
-      48091,
-      48092,
-      48093
+      "LASSAR_MARBLE_FLOOR_PATTERN_D",
+      "LASSAR_MARBLE_FLOOR_PATTERN_E",
+      "LASSAR_MARBLE_FLOOR_PATTERN_F",
+      "LASSAR_MARBLE_FLOOR_PATTERN_G",
+      "LASSAR_MARBLE_FLOOR_PATTERN_H",
+      "LASSAR_MARBLE_FLOOR_PATTERN_I"
     ]
   },
   {
     "description": "Lassar Undercity, Cam Torum & Varlamore temple crypt fake brick tiles",
-    "objectIds": [ 46950, 46951 ],
+    "objectIds": [ "TILEKIT_BRICK01_DEFAULT01", "TILEKIT_BRICK01_DEFAULT02" ],
     "baseMaterial": "LASSAR_UNDERCITY_TILES",
     "hideInAreas": [
       "LASSAR_UNDERCITY",
@@ -15720,9 +15720,9 @@
     "description": "Objects - Wooden - Crate - Tall",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      3045,
-      3205,
-      16862
+      "FAI_VARROCK_BOW_CRATES",
+      "FAI_VARROCK_BOW_CRATES_VERT",
+      "LUNAR_PIRATE_CRATE_HIGH"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -15731,8 +15731,8 @@
     "description": "Wall - Decoration - Wooden - Post",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      439,
-      440
+      "FAI_VARROCK_POOR_WALL_SUPPORT",
+      "FAI_VARROCK_POOR_WALL_SUPPORT2"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -15741,9 +15741,9 @@
     "description": "Object - Wooden - Support Post",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      1870,
-      11628,
-      23853
+      "WOODENSUPPORT1",
+      "FAI_BARBARIAN_WOODENSUPPORT",
+      "FAI_VARROCK_WOODENSUPPORT"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -15754,7 +15754,7 @@
     "description": "Object - Plank - Tables - Wooden Bench",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2452
+      "FAI_VARROCK_BLUE_INN_OUTDOOR_STOOL"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -15764,8 +15764,8 @@
     "description": "Object - Tables - Bar Table - Round",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2332,
-      2333
+      "FAI_VARROCK_BLUE_INN_TAVERN_TABLE",
+      "FAI_VARROCK_BLUE_INN_TAVERN_TABLE_LOW"
     ],
     "flatNormals": true,
     "uvType": "MODEL_XZ"
@@ -15774,10 +15774,10 @@
     "description": "Object - Wooden - Plank - Chest",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7192,
-      10661,
-      14773,
-      14774
+      "FAI_VARROCK_CONTAINER",
+      "SNAKEBOSS_BANKCHEST",
+      "WILD_CHEST_CLOSED",
+      "WILD_CHEST_OPEN"
     ],
     "uvType": "BOX",
     "uvOrientationZ": 512,
@@ -15788,13 +15788,13 @@
     "description": "Object - Wooden - Barrel",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      10371,
-      14740,
-      15674,
-      22278,
-      22280,
-      27228,
-      27229
+      "FARMING_SHED_BARREL",
+      "WILD_BARREL",
+      "AIDE_BARREL",
+      "BRAIN_BOAT_LOC_BARREL",
+      "BRAIN_BOAT_LOC_BARREL_STACKED",
+      "SHAYZIEN_BARREL_LARGE_TAP",
+      "SHAYZIEN_BARREL_LARGE"
     ],
     "uvType": "BOX"
   },
@@ -15802,8 +15802,8 @@
     "description": "Object - Wooden - Barrel - with fish",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      9520,
-      27552
+      "SARIM_BARREL_FISH",
+      "PISCARILIUS_FISH_BARREL_FULL"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -15817,7 +15817,7 @@
     "description": "Object - Wooden - Barrel - with coal",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2139
+      "FAI_VARROCK_COAL_BARREL"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -15831,9 +15831,9 @@
     "description": "Object - Dying Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      3648,
-      3649,
-      50074
+      "FAI_VARROCK_DEAD_TREE",
+      "FAI_VARROCK_DEAD_TREE_STUMP",
+      "FAI_VARROCK_DEAD_TREE_NOOP"
     ],
     "uvType": "BOX"
   },
@@ -15841,9 +15841,9 @@
     "description": "Varrock - Wall Decoration - Wooden - Plank",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      5090,
-      5091,
-      5092
+      "FAI_VARROCK_PLANKS1",
+      "FAI_VARROCK_PLANKS2",
+      "FAI_VARROCK_PLANKS3"
     ],
     "uvType": "BOX",
     "uvOrientation": 562,
@@ -15853,7 +15853,7 @@
     "description": "Varrock Washing line - Plank",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      4059
+      "FAI_VARROCK_WASHING_LINE_POST_4"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -15862,20 +15862,20 @@
     "description": "Varrock Washing line - Clothes",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      4487,
-      4058
+      "FAI_VARROCK_WASHING_LINE_3",
+      "FAI_VARROCK_WASHING_LINE_5"
     ]
   },
   {
     "description": "Fortune-teller Aris - Tent",
     "baseMaterial": "BURLAP",
     "objectIds": [
-      2460,
-      2461,
-      2462,
-      2464,
-      2489,
-      2490
+      "FAI_VARROCK_TENTWALL",
+      "FAI_VARROCK_TENT_PEG_CONER",
+      "FAI_VARROCK_TENT_PEG_CONER_MIRROR",
+      "FAI_VARROCK_TENT_SLOPE1",
+      "FAI_VARROCK_TENT_SLOPE2",
+      "FAI_VARROCK_TENT_PEAK"
     ],
     "uvType": "BOX",
     "uvScale": 0.85
@@ -15884,7 +15884,7 @@
     "description": "Fortune-teller Aris - Table with Crystal Ball",
     "baseMaterial": "NONE",
     "objectIds": [
-      2459
+      "FAI_VARROCK_CRYSTALBALLTABLE"
     ],
     "colorOverrides": [
       {
@@ -15901,7 +15901,7 @@
     "description": "Pillory random event crates",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      20885
+      "PILLORY_ROTTEN_TOMATO_CRATE"
     ],
     "uvType": "BOX",
     "uvScale": 0.45
@@ -15910,7 +15910,7 @@
     "description": "Lumbridge - Varrock Crossroads Signpost",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      7141
+      "FAI_VARROCK_SIGNPOST_1"
     ],
     "uvType": "BOX",
     "uvScale": 0.35,
@@ -15920,36 +15920,36 @@
     "description": "What Lies Below - Camp Fire",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23063
+      "SUROK_BANDIT_CAMP_FIRE"
     ]
   },
   {
     "description": "What Lies Below - Rat Burgiss Broken Cart",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      23055
+      "SUROK_RAT_CART"
     ]
   },
   {
     "description": "Objects - Tree - Banana Tree",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      2073
+      "BANANATREEFULL"
     ]
   },
   {
     "description": "Barbarian Village - Wall - Wooden - Log",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      11587,
-      11588,
-      11607,
-      11608,
-      11609,
-      11610,
-      11611,
-      11612,
-      11613
+      "FAI_BARBARIAN_TRUNK_SUPPORT",
+      "FAI_BARBARIAN_TRUNK_SUPPORT_LV2",
+      "FAI_FALADOR_ASTRIX_FENCE_1",
+      "FAI_FALADOR_ASTRIX_FENCE_2",
+      "FAI_FALADOR_ASTRIX_FENCE_3",
+      "FAI_FALADOR_ASTRIX_FENCE_3_MIRROR",
+      "FAI_FALADOR_ASTRIX_FENCE_4",
+      "FAI_FALADOR_ASTRIX_FENCE_5",
+      "FAI_FALADOR_ASTRIX_FENCE_7"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -15959,8 +15959,8 @@
     "description": "Barbarian Village - Objects - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11599,
-      20216
+      "FAI_BARBARIAN_CRATE",
+      "BARBASSAULT_CRATE_STACKED"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -15971,7 +15971,7 @@
     "description": "Barbarian VIllage - Objects - Table - Double - Wooden – Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11619
+      "FAI_BARBARIAN_TABLE"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -15980,7 +15980,7 @@
     "description": "Barbarian VIllage - Objects - Table - Double - Wooden – Plank - With Shelfs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11626
+      "FAI_BARBARIAN_COUNTER"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -15991,10 +15991,10 @@
     "description": "Barbarian VIllage - Wall  Longhall Door – Fake Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11620,
-      11621,
-      11624,
-      11625
+      "FAI_BARBARIAN_LARGE_DOUBLEDOOR_R",
+      "FAI_BARBARIAN_LARGE_DOUBLEDOOR_L",
+      "FAI_BARBARIAN_OPEN_LARGE_DOUBLEDOOR_R",
+      "FAI_BARBARIAN_OPEN_LARGE_DOUBLEDOOR_L"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -16003,10 +16003,10 @@
     "description": "Objects - Rock - Brown Rock - Medium",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      10782,
-      10783,
-      10784,
-      29491
+      "ROCKSLIDE_SMALL",
+      "ROCKSLIDE_SMALL1",
+      "ROCKSLIDE_SMALL2",
+      "HILLGIANT_BOSS_CLIMBINGROCKS"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -16015,22 +16015,22 @@
     "description": "Objects - Wood - Boofshelf - Double",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      381
+      "BOOKCASE2"
     ],
     "uvType": "BOX",
     "flatNormals": true
   },
   {
     "description": "Water wheel in Lumbridge",
-    "objectIds": [ 5589 ],
+    "objectIds": [ "WATERWHEEL_CENTRE" ],
     "flatNormals": true
   },
   {
     "description": "Ore - Empty - Rock",
     "baseMaterial": "ROCK_5_ORE",
     "objectIds": [
-      11390,
-      11391
+      "ROCKS1",
+      "ROCKS2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -16040,9 +16040,9 @@
     "description": "Ore - Tin - Rock",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      10080,
-      11360,
-      11361
+      "NEWBIETINROCK",
+      "TINROCK1",
+      "TINROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -16051,9 +16051,9 @@
     "description": "Ore - Copper - Rock",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      10079,
-      10943,
-      11161
+      "NEWBIECOPPERROCK",
+      "COPPERROCK1",
+      "COPPERROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -16062,9 +16062,9 @@
     "description": "Ore - Iron - Rock",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      11364,
-      11365,
-      42833
+      "IRONROCK1",
+      "IRONROCK2",
+      "GIM_IRONROCK"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -16074,8 +16074,8 @@
     "description": "Ore - Mithril - Rock",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      11372,
-      11373
+      "MITHRILROCK1",
+      "MITHRILROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -16084,8 +16084,8 @@
     "description": "Ore - Adamantite - Rock",
     "baseMaterial": "ROCK_5_ORE",
     "objectIds": [
-      11374,
-      11375
+      "ADAMANTITEROCK1",
+      "ADAMANTITEROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -16095,8 +16095,8 @@
     "description": "Ore - Runeite - Rock",
     "baseMaterial": "ROCK_5_ORE",
     "objectIds": [
-      11376,
-      11377
+      "RUNITEROCK1",
+      "RUNITEROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -16105,8 +16105,8 @@
     "description": "Ore - Coal - Rock",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      11366,
-      11367
+      "COALROCK1",
+      "COALROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -16116,8 +16116,8 @@
     "description": "Ore - Silver - Rock",
     "baseMaterial": "ROCK_4_ORE",
     "objectIds": [
-      11368,
-      11369
+      "SILVERROCK1",
+      "SILVERROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.40,
@@ -16127,8 +16127,8 @@
     "description": "Ore - Gold - Rock",
     "baseMaterial": "ROCK_4_ORE",
     "objectIds": [
-      11370,
-      11371
+      "GOLDROCK1",
+      "GOLDROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -16137,8 +16137,8 @@
     "description": "Ore - Clay - Rock",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      11362,
-      11363
+      "CLAYROCK1",
+      "CLAYROCK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -16148,8 +16148,8 @@
     "description": "Ore - Blurite - Rock",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      11378,
-      11379
+      "BLURITE_ROCK_1",
+      "BLURITE_ROCK_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33,
@@ -16159,21 +16159,21 @@
     "description": "Objects - Concrete - Runecrafting Altars",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      29631,
-      34760,
-      34761,
-      34762,
-      34763,
-      34764,
-      34765,
-      34766,
-      34767,
-      34768,
-      34769,
-      34770,
-      34771,
-      34772,
-      43479
+      "RC_ZMI_DUNGEON_CRACKED_CENTER_ALTAR",
+      "AIR_ALTAR",
+      "MIND_ALTAR",
+      "WATER_ALTAR",
+      "EARTH_ALTAR",
+      "FIRE_ALTAR",
+      "BODY_ALTAR",
+      "COSMIC_ALTAR",
+      "LAW_ALTAR",
+      "NATURE_ALTAR",
+      "CHAOS_ALTAR",
+      "DEATH_ALTAR",
+      "ASTRAL_ALTAR",
+      "WRATH_ALTAR",
+      "BLOOD_ALTAR"
     ],
     "uvType": "BOX",
     "uvScale": 1.4,
@@ -16184,23 +16184,23 @@
     "description": "Objects - Concrete - Runecrafting Altar Pillars",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      34780,
-      34781,
-      34782,
-      34783,
-      34784,
-      34785,
-      43509,
-      43510,
-      43511,
-      43512,
-      43513,
-      43514,
-      43515,
-      43516,
-      43517,
-      43518,
-      43519
+      "RUNETEMPLE_PILLAR_NEW1",
+      "RUNETEMPLE_PILLAR_NEW2",
+      "RUNETEMPLE_PILLAR_NEW_TOP",
+      "LUNAR_RUNETEMPLE_PILLAR_BRIGHT1",
+      "LUNAR_RUNETEMPLE_PILLAR_BRIGHT2",
+      "LUNAR_RUNETEMPLE_PILLAR_BRIGHT_TOP",
+      "RUNETEMPLE_PILLAR01_BLOOD01",
+      "RUNETEMPLE_PILLAR01_BLOOD02",
+      "RUNETEMPLE_ARCH01_BLOOD01",
+      "RUNETEMPLE_PILLAR02_BLOOD01",
+      "RUNETEMPLE_PILLAR02_BLOOD02",
+      "RUNETEMPLE_PILLAR02_BLOOD03",
+      "RUNETEMPLE_PILLAR02_BLOOD04",
+      "RUNETEMPLE_PILLAR02_BLOOD05",
+      "RUNETEMPLE_RUBBLE02_BLOOD01",
+      "RUNETEMPLE_RUBBLE02_BLOOD02",
+      "RUNETEMPLE_RUBBLE02_BLOOD03"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16211,9 +16211,9 @@
     "description": "Objects - Concrete - Runecrafting Altar Lights",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      34786,
-      34787,
-      43520
+      "RUNETEMPLE_STANDINGSTONE_NEW",
+      "LUNAR_RUNETEMPLE_STANDINGSTONE_BRIGHT",
+      "RUNETEMPLE_STANDINGSTONE_BLOOD01"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16224,8 +16224,8 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      590,
-      591
+      "BANKTABLE",
+      "BANKTABLE2"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16241,9 +16241,9 @@
       }
     },
     "objectIds": [
-      10355,
-      10527,
-      10528
+      "BANKBOOTH",
+      "BANKPRIVATEBOOTH",
+      "BANKBOOTHCLOSED"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -16264,7 +16264,7 @@
       }
     },
     "objectIds": [
-      8142
+      "BANKBOOTHCLOSED_END_LEFT"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -16274,8 +16274,8 @@
     "description": "Objects - Concrete - Gravestone",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      404,
-      405
+      "GRAVESTONE1",
+      "GRAVESTONE2"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16286,10 +16286,10 @@
     "baseMaterial": "ROCK_3",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      3456,
-      3482,
-      3483,
-      3484
+      "STONEWALL",
+      "PRIESTPERIL_TOMB_TOP",
+      "PRIESTPERIL_TOMB_CORNERL",
+      "PRIESTPERIL_TOMB_CORNERR"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16299,7 +16299,7 @@
     "description": "Objects - Concrete - Deposit Box",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      10529
+      "BANK_DEPOSIT_BOX"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16309,7 +16309,7 @@
     "description": "Motherlode Mine - Deposit Box",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      25937
+      "KR_BANK_DEPOSIT_BOX"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -16319,9 +16319,9 @@
     "baseMaterial": "LEAF_VEINS",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      10786,
-      10787,
-      10788
+      "SEAWEEDROCK_LARGE",
+      "SEAWEEDROCK_1",
+      "SEAWEEDROCK_2"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16331,8 +16331,8 @@
     "description": "Objects - Textured Rocks - Small",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      10793,
-      12570
+      "BOULDER4",
+      "BOULDER4_GDECOR"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16342,8 +16342,8 @@
     "description": "Objects - Textured Rocks - Medium",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      10790,
-      10791
+      "BOULDER1",
+      "BOULDER2"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16354,8 +16354,8 @@
     "baseMaterial": "GRASS_3",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      11182,
-      11183
+      "MOSS_COVERED_ROCK_1",
+      "MOSS_COVERED_ROCK_2"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -16365,7 +16365,7 @@
     "description": "Objects - Textured Rock - Nightmare Zone Rocks - Small",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      26275
+      "NZONE_STONEMARKER"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -16375,10 +16375,10 @@
     "description": "Nightmare Zone Potion Barrels",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      26277,
-      26278,
-      26279,
-      26280
+      "NZONE_BARREL_1",
+      "NZONE_BARREL_2",
+      "NZONE_BARREL_3",
+      "NZONE_BARREL_4"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -16387,9 +16387,9 @@
     "description": "Objects - Concrete - Nature Altar Pillars",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      407,
-      408,
-      409
+      "HENGE",
+      "HENGE_DIAGONAL",
+      "ALTAR"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false
@@ -16399,14 +16399,14 @@
     "baseMaterial": "ROCK_1",
     "textureMaterial": "HD_CONCRETE",
     "objectIds": [
-      410
+      "GUTHIX_ALTAR"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false
   },
   {
     "description": "",
-    "objectIds": [ 29103 ],
+    "objectIds": [ "DIARY_GUILD_DEPOSIT_BOX" ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -16416,7 +16416,7 @@
     "description": "Objects - Wood - Ladder - In Ground - Untextured",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16680
+      "LADDER_OUTSIDE_TO_UNDERGROUND"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -16425,7 +16425,7 @@
     "description": "Objects - Wood - Ladder - Edgeville Dungeon Ladder",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1581
+      "TRAPDOOR_OPEN"
     ],
     "uvType": "BOX"
   },
@@ -16433,7 +16433,7 @@
     "description": "Objects - Wood - Trap Door",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1579
+      "TRAPDOOR"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -16442,9 +16442,9 @@
     "description": "Objects - Wood - Danger Sign",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1032,
-      2107,
-      10605
+      "DANGERSIGN",
+      "SLAYER_DANGERSIGN",
+      "WYVERN_DANGERSIGN"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -16453,13 +16453,13 @@
     "description": "Walls - Bricks - Light Brick",
     "flatNormals": true,
     "objectIds": [
-      1920,
-      17088,
-      15453,
-      15454,
-      15455,
-      15456,
-      15457
+      "CASTLEWALL_WITH_BATTLEMENTS_A",
+      "XBOWS_TALL_CASTLEWALL",
+      "LUMBRIDGE_POH_ROOF_1_01",
+      "LUMBRIDGE_POH_ROOF_1_02",
+      "LUMBRIDGE_POH_ROOF_1_03",
+      "LUMBRIDGE_POH_ROOF_1_04",
+      "LUMBRIDGE_POH_ROOF_2_01"
     ]
   },
   {
@@ -16469,8 +16469,8 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      1902,
-      13090
+      "BRICKWALL",
+      "BRICKWALL_NOSHARELIGHT"
     ]
   },
   {
@@ -16486,27 +16486,27 @@
       }
     ],
     "objectIds": [
-      13091
+      "BRICKWALL_WINDOW"
     ]
   },
   {
     "description": "Walls - Bricks - Light Brick with White backs",
     "flatNormals": true,
     "objectIds": [
-      1904,
-      1907
+      "PAINTEDBRICKWALL_1",
+      "BLUEPAINTEDBRICKWALL_1"
     ]
   },
   {
     "description": "Objects - Root - Small",
     "baseMaterial": "BARK",
     "objectIds": [
-      1323,
-      1324,
-      1325,
-      1458,
-      51787,
-      51788
+      "ROOTS_1",
+      "ROOTS_2",
+      "ROOTS_3",
+      "CAVE_TWIG1",
+      "AVIUM_ROOTS01",
+      "AVIUM_ROOTS02"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -16516,8 +16516,8 @@
     "description": "Objects - Root - Large",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      1985,
-      1986
+      "LARGEROOT_GNOME",
+      "LARGEROOT2_GNOME"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -16526,7 +16526,7 @@
   {
     "description": "Wooden crates, Wooden table, wooden rack",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 356, 647 ],
+    "objectIds": [ "CRATE_OLD", "RACK" ],
     "flatNormals": true,
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -16534,7 +16534,7 @@
   },
   {
     "description": "Wooden crate",
-    "objectIds": [ 358 ],
+    "objectIds": [ "CRATE3_OLD" ],
     "flatNormals": true,
     "uvType": "BOX",
     "uvOrientationY": 70,
@@ -16544,8 +16544,8 @@
     "description": "Objects - Dirt - Rabbit Hole",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      3940,
-      19337
+      "REGICIDE_RABBIT_HUTCH",
+      "HUNTING_RABBIT_LAUNCHER1"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -16554,12 +16554,12 @@
     "description": "Objects - Dirt - Ferret Burrow",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      19438,
-      19439,
-      19440,
-      19492,
-      19493,
-      19494
+      "HUNTING_TRAIL_SPAWN1",
+      "EAGLEPEAK_HUNTING_TRAIL_VISIBLE_CORNER",
+      "EAGLEPEAK_HUNTING_TRAIL_VISIBLE180_CORNER",
+      "HUNTING_TRAIL_SPAWN4",
+      "HUNTING_TRAIL6_7L",
+      "HUNTING_TRAIL6_8L"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -16568,11 +16568,11 @@
     "description": "Picatoris - Walls - Colony Walls",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      13478,
-      13479,
-      13480,
-      13581,
-      13582
+      "SWAN_RUSTY_WALL_1",
+      "SWAN_RUSTY_WALL_2",
+      "SWAN_RUSTY_WALL_3",
+      "SWAN_RUSTY_WALL_4",
+      "SWAN_RUSTY_WALL_5"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -16581,8 +16581,8 @@
     "description": "Piscatoris - Falconry - Walls - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4198,
-      4246
+      "VIKING_LONGHALL_WALL_OUTSIDE",
+      "VIKING_ABODE_WALL"
     ],
     "uvType": "BOX",
     "uvScale": 1.4,
@@ -16592,7 +16592,7 @@
     "description": "Picatoris - Objects - Dirt - Entrance Hole",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      12656
+      "SWAN_HOLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -16601,10 +16601,10 @@
     "description": "Picatoris - Walls - Wood - Plank Fence",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      12659,
-      12660,
-      12661,
-      12722
+      "SWAN_FENCE1",
+      "SWAN_FENCE2",
+      "SWAN_FENCE3",
+      "SWAN_FENCE4"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -16614,10 +16614,10 @@
     "description": "Piscatoris - Walls - Metallic - Doors",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      12723,
-      12724,
-      12725,
-      13475
+      "SWAN_DOOR_L",
+      "SWAN_OPENDOOR_L",
+      "SWAN_DOOR_R",
+      "SWAN_OPENDOOR_R"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -16626,8 +16626,8 @@
     "description": "Piscatoris - Objects - Wooden - Crate Stack",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      13598,
-      13599
+      "SWAN_CRATES1",
+      "SWAN_CRATES2"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -16638,8 +16638,8 @@
     "description": "Piscatoris - Objects - Wooden - Plank Wall",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      10108,
-      10109
+      "DEAL_WALL_WINDOW",
+      "DEAL_WALL"
     ],
     "uvType": "BOX",
     "uvScale": 1.4,
@@ -16649,9 +16649,9 @@
     "description": "Piscatoris - Roof - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      10111,
-      10112,
-      10113
+      "DEAL_ROOF1",
+      "DEAL_ROOF2",
+      "DEAL_ROOF3"
     ],
     "uvType": "BOX",
     "uvScale": 1.4,
@@ -16662,8 +16662,8 @@
     "description": "Piscatoris - Roof - Wooden - Plank Doors",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      12657,
-      12658
+      "SWAN_BUILDING_DOOR",
+      "SWAN_BUILDING_DOOR_OPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -16673,12 +16673,12 @@
     "description": "Piscatoris & Rellekka - Roof Corners - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4235,
-      4236,
-      4237,
-      4238,
-      4239,
-      4240
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE_NEW_1",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE_NEW_2",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE_NEW_3",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE1_MIRROR_NEW_",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE2_MIRROR_NEW_",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE3_MIRROR_NEW_"
     ],
     "uvType": "BOX",
     "uvScale": 1.4,
@@ -16690,8 +16690,8 @@
     "description": "Piscatoris - Roof Corners - Wooden - Planks - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4229,
-      4232
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE1",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE1_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 1.4,
@@ -16701,8 +16701,8 @@
     "description": "Eagles Peak Climbing Rocks",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      19849,
-      19850
+      "EP_CLIMBING_ROCKS01",
+      "EP_CLIMBING_ROCKS02"
     ],
     "uvType": "BOX",
     "uvScale": 0.3
@@ -16711,31 +16711,31 @@
     "description": "Eagles Peak Cave Door",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      19927
+      "EAGLEPEAK_NEW_CAVE_ENTRANCE_DOOR"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
   },
   {
     "description": "Crafting Guild Blacksmith's tools",
-    "objectIds": [ 2098 ],
+    "objectIds": [ "BLACKSMITHTOOLS" ],
     "flatNormals": true
   },
   {
     "description": "Mage Training Arena - Walls",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      10734,
-      10743,
-      10744,
-      10760,
-      10761,
-      10762,
-      10763,
-      10767,
-      10768,
-      10769,
-      10770
+      "MAGICTRAINING_COIN_COLLECTOR",
+      "MAGICTRAINING_DOORWAY_L",
+      "MAGICTRAINING_DOORWAY_R",
+      "MAGICTRAINING_DUNGEONWALL_LIGHT",
+      "MAGICTRAINING_DUNGEONWALL_LIGHTING",
+      "MAGICTRAINING_DUNGEONWALL",
+      "MAGICTRAINING_DUNGEONWALL_TOP",
+      "MAGICTRAINING_WALL",
+      "MAGICTRAINING_BANK_WALL",
+      "MAGICTRAINING_WALL_SUPPORT",
+      "MAGICTRAINING_WALL_WINDOW"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -16744,17 +16744,17 @@
     "description": "Mage Training Arena - Walls - Doorway of Light",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      10721
+      "MAGICTRAINING_TEMPLE_DOOR"
     ]
   },
   {
     "description": "Mage Training Arena - Walls - Dark",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      10735,
-      10764,
-      10765,
-      10766
+      "MAGICTRAINING_GRAVE_FOODSHUTE",
+      "MAGICTRAINING_DUNGEONWALL_TOP_BONES",
+      "MAGICTRAINING_DUNGEONWALL_BONES",
+      "MAGICTRAINING_DUNGEONWALL_BONES_LIGHT"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -16763,9 +16763,9 @@
     "description": "Mage Training Arena - Roofs",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      10745,
-      10746,
-      10747
+      "MAGICTRAINING_ROOF",
+      "MAGICTRAINING_ROOF_EDGE",
+      "MAGICTRAINING_ROOF_EDGE_MIRROR"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -16774,9 +16774,9 @@
     "description": "Mage Training Arena - Fence",
     "baseMaterial": "MARBLE_1",
     "objectIds": [
-      10748,
-      10749,
-      10750
+      "MAGICTRAINING_OUTER_WALL_ONE",
+      "MAGICTRAINING_OUTER_WALL_END",
+      "MAGICTRAINING_OUTER_WALL_END_MIRROR"
     ],
     "uvType": "BOX",
     "uvOrientation": 128,
@@ -16786,11 +16786,11 @@
     "description": "Mage Training Arena - Metal Fence",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      10740,
-      10741,
-      10742,
-      10773,
-      10776
+      "MAGICTRAINING_MAGE_RAIL",
+      "MAGICTRAINING_MAGE_RAIL_END",
+      "MAGICTRAINING_MAGE_RAIL_END_MIRROR",
+      "MAGICTRAINING_STAIRS_TOP",
+      "MAGICTRAINING_STAIRS_TOP_MIRROR"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -16799,7 +16799,7 @@
     "description": "Mage Training Arena - Telekinetic Fence",
     "baseMaterial": "MARBLE_1",
     "objectIds": [
-      10755
+      "MAGICTRAINING_MINIWALL"
     ],
     "uvType": "BOX",
     "uvOrientation": 128
@@ -16808,10 +16808,10 @@
     "description": "Mage Training Arena - Enchanters Playground Shape Piles",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      23694,
-      23695,
-      23696,
-      23697
+      "MAGICTRAINING_ENCHAN_SHAPEPILE1",
+      "MAGICTRAINING_ENCHAN_SHAPEPILE2",
+      "MAGICTRAINING_ENCHAN_SHAPEPILE3",
+      "MAGICTRAINING_ENCHAN_SHAPEPILE4"
     ],
     "uvType": "BOX"
   },
@@ -16819,8 +16819,8 @@
     "description": "Mage Training Arena - Entrance Statues",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      10736,
-      10737
+      "MAGICTRAINING_STATUE_WIZARD",
+      "MAGICTRAINING_STATUE_WIZARD_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -16828,15 +16828,15 @@
     "description": "Mage Training Arena - Candelabra",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      10720
+      "MAGICTRAINING_CANDLE_STAND"
     ]
   },
   {
     "description": "Mage Training Arena - Stairs with metal rails",
     "baseMaterial": "MARBLE_1",
     "objectIds": [
-      10771,
-      10775
+      "MAGICTRAINING_STAIRS_BASE",
+      "MAGICTRAINING_STAIRS_BASE_MIRROR"
     ],
     "uvType": "BOX"
   },
@@ -16844,9 +16844,9 @@
     "description": "Falador - Mage Training Arena - Marble - Steps",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      10729,
-      10730,
-      10731
+      "MAGICTRAINING_SKEWSTEPS1",
+      "MAGICTRAINING_SKEWSTEPS_R",
+      "MAGICTRAINING_SKEWSTEPS_L"
     ],
     "uvType": "BOX",
     "uvOrientation": 640,
@@ -16856,7 +16856,7 @@
     "description": "Falador - Mage Training Arena - Marble - Steps - Corner",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      10732
+      "MAGICTRAINING_SKEWSTEPS_DIAG"
     ],
     "uvType": "BOX",
     "uvOrientationZ": 640,
@@ -16867,12 +16867,12 @@
     "description": "Objects - Bush - Dead",
     "baseMaterial": "BARK",
     "objectIds": [
-      1122,
-      1123,
-      11113,
-      11911,
-      11913,
-      50097
+      "LEAFLESSBUSH",
+      "LEAFLESSBUSH2",
+      "ENAKH_LEAFLESSBUSH",
+      "FAI_LEAFLESS_BUSH_LARGE_01",
+      "FAI_LEAFLESS_BUSH_LARGE_02",
+      "DOV_HUNTING_PLANT2_NOOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 600
@@ -16881,7 +16881,7 @@
     "description": "Mage Training Arena - Marble - Portal Pillars",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      44856
+      "ARENA_DESERT01_PORTAL01"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -16890,21 +16890,21 @@
     "description": "Mage Training Arena - Marble - Area Portals",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      23673,
-      23674,
-      23675,
-      23676,
-      23677
+      "MAGICTRAINING_TELEDOOR",
+      "MAGICTRAINING_ENCHANTDOOR",
+      "MAGICTRAINING_ALCHEMDOOR",
+      "MAGICTRAINING_GRAVEDOOR",
+      "MAGICTRAINING_RETURNDOOR"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Mage Training Arena - Ground Decoration - Carpets",
     "objectIds": [
-      10756,
-      10757,
-      10758,
-      10759
+      "MAGICTRAINING_MINI_MAT",
+      "MAGICTRAINING_MINI_MAT2",
+      "MAGICTRAINING_MINI_MAT3",
+      "MAGICTRAINING_MINI_MAT4"
     ],
     "baseMaterial": "CARPET",
     "uvType": "WORLD_XZ",
@@ -16915,7 +16915,7 @@
     "description": "Mage Training Arena - Marble - Area Portals",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      10738
+      "MAGICTRAINING_STATUE_WATER"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false
@@ -16924,7 +16924,7 @@
     "description": "Mage Training Arena - Marble - Area Portals",
     "baseMaterial": "MARBLE_2_SEMIGLOSS",
     "objectIds": [
-      10739
+      "MAGICTRAINING_STATUE_AIR"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false
@@ -16933,10 +16933,10 @@
     "description": "Mage Training Arena - Marble - Area Portals",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      10725,
-      10726,
-      10727,
-      10728
+      "MAGICTRAINING_BONES_PILE1",
+      "MAGICTRAINING_BONES_PILE2",
+      "MAGICTRAINING_BONES_PILE3",
+      "MAGICTRAINING_BONES_PILE4"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -16948,30 +16948,30 @@
     "uvType": "BOX",
     "retainVanillaUvs": false,
     "colorOverrides": [
-        {
-          "colors": "h == 10 && s == 0",
-          "baseMaterial": "WATTLE_1",
-          "uvType": "BOX"
-        }
+      {
+        "colors": "h == 10 && s == 0",
+        "baseMaterial": "WATTLE_1",
+        "uvType": "BOX"
+      }
     ],
     "objectIds": [
-      1604,
-      1605,
-      1641,
-      1926,
-      3690,
-      3691,
-      4242,
-      4243,
-      4244,
-      4245
+      "THATCHED_TIMBERROOF",
+      "THATCHED_TIMBERROOF_FILL",
+      "OLDROOF_THATCHED",
+      "ROOF_THATCHED",
+      "DEATH_STONEHUTROOF",
+      "DEATH_STONEHUTROOFB",
+      "VIKING_ABODE_POOR_ROOF",
+      "VIKING_ABODE_POOR_ROOF2",
+      "VIKING_ABODE_POOR_ROOF_CORNER",
+      "VIKING_ABODE_POOR_ROOF_CORNER2"
     ]
   },
   {
     "description": "Objects - Hay - Haystack",
     "textureMaterial": "HD_HAY",
     "objectIds": [
-      300
+      "HAYSTACK3"
     ],
     "uvType": "BOX",
     "uvScale": 0.47,
@@ -16982,8 +16982,8 @@
     "description": "Objects - Hay - Hay Bale",
     "textureMaterial": "HD_HAY",
     "objectIds": [
-      298,
-      299
+      "HAYSTACK",
+      "HAYSTACK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -16995,8 +16995,8 @@
     "description": "Edgeville - Walls - Bank Front Windows - Tutorial Island Walls",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      1853,
-      1854
+      "SHOPWINDOWWALL",
+      "SHOPWINDOWWALL2"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -17011,11 +17011,11 @@
     "description": "Edgeville - Forge - Walls",
     "baseMaterial": "STONE",
     "objectIds": [
-      23748,
-      23750,
-      23751,
-      23752,
-      23753
+      "FAI_VARROCK_BLACKSMITH_WALL",
+      "FAI_VARROCK_BLACKSMITH_ARCH_L",
+      "FAI_VARROCK_BLACKSMITH_ARCH_R",
+      "FAI_VARROCK_BLACKSMITH_ARCH_TOP",
+      "FAI_VARROCK_BLACKSMITHS_SMALL_WALL"
     ],
     "uvType": "BOX"
   },
@@ -17023,7 +17023,7 @@
     "description": "Edgeville - Forge - Furnace",
     "baseMaterial": "STONE",
     "objectIds": [
-      16469
+      "VARROCK_DIARY_FURNACE"
     ],
     "uvType": "BOX",
     "uvOrientation": -256
@@ -17032,11 +17032,11 @@
     "description": "Edgeville - Forge - Misc Objects",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      16470,
-      16471,
-      16472,
-      16476,
-      16512
+      "VARROCK_DIARY_WETSTONE",
+      "VARROCK_DIARY_BELLOWS",
+      "VARROCK_DIARY_WORKBENCH_LATHE",
+      "VARROCK_DIARY_DECORSHIELD1",
+      "VARROCK_DIARY_MATERIALSUPPLY"
     ],
     "uvType": "BOX"
   },
@@ -17044,8 +17044,8 @@
     "description": "Edgeville - Forge - Coal Piles",
     "baseMaterial": "ROCK_5",
     "objectIds": [
-      16474,
-      16475
+      "VARROCK_DIARY_COAL",
+      "VARROCK_DIARY_COAL_SHOVEL"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -17061,10 +17061,10 @@
     "description": "Edgeville - Coffin",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      398,
-      3577,
-      28860,
-      39547
+      "COFFIN",
+      "COFFIN_OPEN",
+      "COFFIN_OPEN_INACTIVE",
+      "DEATH_OFFICE_ACCESS_COFFIN"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -17073,14 +17073,14 @@
     "description": "Edgeville - Streak Board",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      37434
+      "TARGET_NOTICEBOARD"
     ]
   },
   {
     "description": "Edgeville - Well",
     "baseMaterial": "STONE",
     "objectIds": [
-      884
+      "WELL"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -17097,8 +17097,8 @@
     "description": "Edgeville - Bank Door Hinges and Handles",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      1514,
-      1515
+      "BANKDOOR_R_INACTIVE",
+      "BANKDOOR_L_INACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -17107,8 +17107,8 @@
     "description": "Tutorial Island - GIM Armour Crates",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      42827,
-      42828
+      "GIM_ARMOUR_CRATE_STANDARD",
+      "GIM_ARMOUR_CRATE_HARDCORE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -17123,7 +17123,7 @@
     "description": "Tutorial Island - The Node - Bank Chest",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      42834
+      "GIM_BANK_CHEST"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -17137,8 +17137,8 @@
     "description": "Tutorial Island - The Node - Chest with Gold lumps in it",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1768,
-      2079
+      "FAI_VARROCK_BANK_CHEST_OPEN",
+      "PIRATECHEST"
     ],
     "uvOrientation": 512,
     "uvType": "BOX",
@@ -17155,8 +17155,8 @@
     "description": "Tutorial Island - The Node - Statue",
     "baseMaterial": "STONE",
     "objectIds": [
-      17458,
-      42822
+      "LOTR_RUINS_BROKEN_WALL_RUBBLE_LVL1",
+      "GIM_STATUE"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -17171,8 +17171,8 @@
     "description": "Tutorial Island - The Node - Portal",
     "baseMaterial": "STONE",
     "objectIds": [
-      42819,
-      42820
+      "GIM_PORTAL",
+      "GIM_PORTAL_LUMBRIDGE_PORTAL"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -17186,7 +17186,7 @@
     "description": "Tutorial Island - The Node - Furnace",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      42824
+      "GIM_FURNACE"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -17200,8 +17200,8 @@
     "description": "Tutorial Island - Hanging Tools",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      2192,
-      42830
+      "FAI_VARROCK_HANGING_TOOLS_02",
+      "GIM_HANGING_TOOLS_01"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -17219,8 +17219,8 @@
     "description": "Tutorial Island - Workbench",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      2279,
-      24171
+      "FAI_VARROCK_WORKBENCH",
+      "FAI_DWARF_WORKBENCH"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -17237,7 +17237,7 @@
     "description": "Tutorial Island - Drill",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      2281
+      "FAI_VARROCK_SMITHY_DRILL"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -17252,12 +17252,12 @@
     "description": "Tutorial Island - Shelves",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      3026,
-      3027,
-      3028,
-      4511,
-      5082,
-      41740
+      "FAI_VARROCK_SHELVES1",
+      "FAI_VARROCK_SHELVES2",
+      "FAI_VARROCK_SHELVES3",
+      "FAI_VARROCK_SINGLE_SHELF_FLOWERS",
+      "FAI_VARROCK_SHELF_TANKARDS",
+      "FAI_VARROCK_SHELF_BOOKS_INACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -17266,7 +17266,7 @@
     "description": "Tutorial Island - Varrock - Bed",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      7190
+      "FAI_VARROCK_SINGLE_BED"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -17282,21 +17282,21 @@
   {
     "description": "Karamja Volcano Entrance",
     "baseMaterial": "DIRT_2",
-    "objectIds": [ 11441 ],
+    "objectIds": [ "VOLCANO_ENTRANCE" ],
     "uvType": "BOX",
     "uvScale": 0.68,
     "uvOrientationY": 768
   },
   {
     "description": "Judge of Yama boss entrance portal",
-    "objectIds": [ 41808 ],
+    "objectIds": [ "AKD_JUDGE_PORTAL_ENTER_VIS" ],
     "castShadows": false,
     "receiveShadows": false,
     "shadowOpacityThreshold": 0.12
   },
   {
     "description": "Judge of Yama boss flames",
-    "npcIds": [ 10939 ],
+    "npcIds": [ "AKD_JUDGE_WAVE" ],
     "baseMaterial": "UNLIT",
     "castShadows": false
   },
@@ -17304,7 +17304,7 @@
     "description": "Stronghold Of Security Rock Entrance",
     "baseMaterial": "ROCK_5",
     "objectIds": [
-      20790
+      "SOS_DUNG_ENT_OPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.38,
@@ -17314,10 +17314,10 @@
     "description": "Stronghold Of Security - Objects - Wood - Signs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7054,
-      19172,
-      20787,
-      23708
+      "SOS_THANKPLAYERS",
+      "SOS_FAM_DANGERSIGN",
+      "SOS_WAR_DANGERSIGN",
+      "SOS_PEST_DANGERSIGN"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -17327,7 +17327,7 @@
     "description": "Stronghold Of Security - War - Metallic Floor",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      20655
+      "SOS_WAR_FLOOR1"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -17336,8 +17336,8 @@
     "description": "Stronghold Of Security - War - Metallic Floor with fence",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      20657,
-      20658
+      "SOS_WAR_RAIL_1",
+      "SOS_WAR_RAIL_5"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -17346,17 +17346,17 @@
     "description": "Stronghold Of Security - War - Metallic Walls",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      19173,
-      19204,
-      19205,
-      19208,
-      19212,
-      19213,
-      19214,
-      19173,
-      20653,
-      20659,
-      20660
+      "SOS_WAR_WALL",
+      "SOS_WAR_WALL_LIGHT",
+      "SOS_WAR_WALL_LIGHT_UP",
+      "SOS_WAR_WALL_DOORFRAME",
+      "SOS_WAR_WALL_TOP",
+      "SOS_WAR_WALL_TOP2",
+      "SOS_WAR_WALL_TOP3",
+      "SOS_WAR_WALL",
+      "SOS_WAR_WALL_TOP4",
+      "SOS_WAR_SPIKE",
+      "SOS_WAR_SPIKE_UP"
     ],
     "hideVanillaShadows": true,
     "uvType": "BOX"
@@ -17365,7 +17365,7 @@
     "description": "Stronghold Of Security - War - Metallic Overdoor",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      19211
+      "SOS_WAR_DOOR_TOP"
     ],
     "uvType": "BOX"
   },
@@ -17373,8 +17373,8 @@
     "description": "Stronghold Of Security - War - Metallic Ladder",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      20784,
-      20785
+      "SOS_WAR_LADD_UP",
+      "SOS_WAR_LADD_DOWN"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -17384,8 +17384,8 @@
     "description": "Stronghold Of Security War - Metallic - Escape Chain",
     "baseMaterial": "METALLIC_1_HIGHGLOSS",
     "objectIds": [
-      20782,
-      20783
+      "SOS_WAR_CHAINBOTTOM",
+      "SOS_WAR_CHAINTOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -17394,13 +17394,13 @@
     "description": "Stronghold Of Security War - Objects - Bones",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      20661,
-      20662,
-      20663,
-      20664,
-      20665,
-      20780,
-      20781
+      "SOS_WAR_BONES1",
+      "SOS_WAR_BONES2",
+      "SOS_WAR_BONES3",
+      "SOS_WAR_BONES4",
+      "SOS_WAR_SKELETON_1",
+      "SOS_WAR_SKELETON_2",
+      "SOS_WAR_SKELETON_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -17409,7 +17409,7 @@
     "description": "Stronghold Of Security War -  Metallic - Gift of Peace - Chest",
     "baseMaterial": "METALLIC_1_GLOSS",
     "objectIds": [
-      20656
+      "SOS_WAR_CHEST"
     ],
     "flatNormals": true,
     "uvType": "BOX"
@@ -17418,10 +17418,10 @@
     "description": "Stronghold Of Security - Famine - Walls - Dirt",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      17003,
-      17004,
-      17005,
-      17007
+      "SOS_FAM_WALL",
+      "SOS_FAM_WALL_LITE",
+      "SOS_FAM_WALL_SPIKE",
+      "SOS_FAM_WALL_TOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.44
@@ -17430,8 +17430,8 @@
     "description": "Stronghold Of Security - Famine - Bone Structures ",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      17006,
-      18966
+      "SOS_FAM_WALL_THIN",
+      "SOS_FAM_DOOR_TOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -17441,8 +17441,8 @@
     "description": "Stronghold Of Security - Famine - Doors ",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      17009,
-      17100
+      "SOS_FAM_DOOR_FACE",
+      "SOS_FAM_DOOR_FACE_MIRR"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -17453,8 +17453,8 @@
     "description": "Stronghold Of Security - Famine - Ladder ",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      19003,
-      19004
+      "SOS_FAM_LADD_UP",
+      "SOS_FAM_LADD_DOWN"
     ],
     "uvType": "BOX",
     "uvOrientation": 700,
@@ -17464,13 +17464,13 @@
     "description": "Stronghold Of Security - Famine - Objects - Bones",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      18993,
-      18994,
-      18995,
-      18996,
-      18997,
-      18998,
-      18999
+      "SOS_FAM_BONES1",
+      "SOS_FAM_BONES2",
+      "SOS_FAM_BONES3",
+      "SOS_FAM_BONES4",
+      "SOS_FAM_SKELETON_1",
+      "SOS_FAM_SKELETON_2",
+      "SOS_FAM_SKELETON_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -17479,8 +17479,8 @@
     "description": "Stronghold Of Security - Famine - Escape Rope ",
     "baseMaterial": "ROPE",
     "objectIds": [
-      19001,
-      19002
+      "SOS_FAM_ROPE_UP",
+      "SOS_FAM_ROPE_DOWN"
     ],
     "uvType": "BOX",
     "uvOrientation": 50
@@ -17489,15 +17489,15 @@
     "description": "Stronghold Of Security - Walls - Pestilence",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      23648,
-      23649,
-      23650,
-      23652,
-      23657,
-      23658,
-      23659,
-      23660,
-      23661
+      "SOS_PEST_WALL",
+      "SOS_PEST_WALL2",
+      "SOS_PEST_WALL3",
+      "SOS_PEST_WALL_DOORFRAME",
+      "SOS_PEST_WALL_TOP",
+      "SOS_PEST_WALL_TOP2",
+      "SOS_PEST_WALL_TOP3",
+      "SOS_PEST_WALL_TOP4",
+      "SOS_PEST_WALL_TOP_HALF"
     ],
     "uvType": "BOX"
   },
@@ -17505,7 +17505,7 @@
     "description": "Stronghold Of Security - Walls - Pestilence - Tentacle Light",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      23651
+      "SOS_PEST_WALL_LIGHT"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -17519,8 +17519,8 @@
     "description": "Stronghold Of Security - Pestilence - Doors",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      23653,
-      23654
+      "SOS_PEST_DOOR_FACE",
+      "SOS_PEST_DOOR_FACE_MIRR"
     ],
     "uvType": "BOX",
     "uvScale": 1.2
@@ -17529,7 +17529,7 @@
     "description": "Stronghold Of Security - Pestilance - Overdoor Tendrils",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      23662
+      "SOS_PEST_DOOR_TOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -17538,10 +17538,10 @@
     "description": "Stronghold Of Security - Pestilence - Plant Ladder and Goo Covered Vine",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      23703,
-      23704,
-      23705,
-      23706
+      "SOS_PEST_ROPE_UP",
+      "SOS_PEST_ROPE_DOWN",
+      "SOS_PEST_LADD_UP",
+      "SOS_PEST_LADD_DOWN"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -17550,7 +17550,7 @@
     "description": "Stronghold Of Security - Pestilence -  Metallic - Box of Health - Chest",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      23709
+      "SOS_PEST_CHEST"
     ],
     "flatNormals": true,
     "uvType": "BOX",
@@ -17560,7 +17560,7 @@
     "description": "Stronghold Of Security - Pestilence - Textured - Hay - Gift of Plenty - Sack",
     "baseMaterial": "CARPET",
     "objectIds": [
-      19000
+      "SOS_FAM_SACK"
     ],
     "uvType": "BOX",
     "uvScale": 0.85,
@@ -17570,14 +17570,14 @@
     "description": "Stronghold Of Security - Pestilence - Objects - Bones",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23663,
-      23664,
-      23665,
-      23666,
-      23667,
-      23668,
-      23669,
-      23923
+      "SOS_PEST_BONES1",
+      "SOS_PEST_BONES2",
+      "SOS_PEST_BONES3",
+      "SOS_PEST_BONES4",
+      "SOS_PEST_SKELETON_1",
+      "SOS_PEST_SKELETON_2",
+      "SOS_PEST_SKELETON_3",
+      "SOS_DEATH_BONES1"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -17586,9 +17586,9 @@
     "description": "Stronghold Of Security - Pestilence - Ground Objects - Rock Like Objects",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23670,
-      23671,
-      23699
+      "SOS_PEST_DUGUPSOIL1",
+      "SOS_PEST_DUGUPSOIL2",
+      "SOS_PEST_DUGUPSOIL3"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -17597,25 +17597,25 @@
     "description": "Stronghold Of Security Petilance - Dripping Tendrils",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      23700,
-      23701,
-      23702
+      "SOS_PEST_TENDRILS",
+      "SOS_PEST_TENDRILS_FALLOFF",
+      "SOS_PEST_TENDRILS_CORNER"
     ]
   },
   {
     "description": "Stronghold Of Security - Death - Walls",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      23711,
-      23712,
-      23713,
-      23714,
-      23715,
-      23716,
-      23717,
-      23718,
-      23719,
-      23720
+      "SOS_DEATH_WALL",
+      "SOS_DEATH_WALL2",
+      "SOS_DEATH_WALL3",
+      "SOS_DEATH_WALL4",
+      "SOS_DEATH_WALL_LIGHT",
+      "SOS_DEATH_WALL_LIGHT_GLOW",
+      "SOS_DEATH_WALLTOP1",
+      "SOS_DEATH_WALLTOP2",
+      "SOS_DEATH_WALLTOP3",
+      "SOS_DEATH_WALL_TOP_HALF"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -17625,12 +17625,12 @@
     "description": "Stronghold Of Security - Death - Objects - Bones",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23924,
-      23925,
-      23926,
-      23927,
-      23928,
-      23929
+      "SOS_DEATH_BONES2",
+      "SOS_DEATH_BONES3",
+      "SOS_DEATH_BONES4",
+      "SOS_DEATH_SKELETON_1",
+      "SOS_DEATH_SKELETON_2",
+      "SOS_DEATH_SKELETON_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -17639,7 +17639,7 @@
     "description": "Stronghold Of Security - Death - Objects - Boney Ladder",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23921
+      "SOS_DEATH_LADD_UP"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -17648,8 +17648,8 @@
     "description": "Stronghold Of Security - Death - Objects - Escape Bone Chain",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      23732,
-      23920
+      "SOS_DEATH_ROPE_UP",
+      "SOS_DEATH_ROPE_DOWN"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -17658,10 +17658,10 @@
     "description": "Stronghold Of Security - Death - Doors",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      23727,
-      23728,
-      23729,
-      23730
+      "SOS_DEATH_DOOR_FACE",
+      "SOS_DEATH_DOOR_FACE_MIRR",
+      "SOS_DEATH_DOOR_FACE_OPEN",
+      "SOS_DEATH_DOOR_FACE_MIRR_OPEN"
     ],
     "shadowOpacityThreshold": 0.12,
     "uvType": "BOX",
@@ -17672,27 +17672,27 @@
     "description": "Stronghold Of Security Death - Reward - Cradle of Life",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      23731
+      "SOS_DEATH_PRAM"
     ]
   },
   {
     "description": "Mad Eadgars Sign",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 3823 ],
+    "objectIds": [ "EADGAR_CAVE_SIGN" ],
     "uvType": "BOX",
     "flatNormals": true
   },
   {
     "description": "Trollheim Cave Walls",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 3790 ],
+    "objectIds": [ "TROLL_CLIMBINGROCKS_TOP" ],
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Trollheim Eadgars Cave Exit",
     "baseMaterial": "EADGARS_CAVE_FIX",
-    "objectIds": [ 3760, 3761 ],
+    "objectIds": [ "TROLL_MAD_EADGAR_EXIT", "TROLL_STRONGHOLD_EXIT" ],
     "uvType": "BOX",
     "uvScale": 0.7
   },
@@ -17700,11 +17700,11 @@
     "description": "Trollheim Tents",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      3208,
-      3653,
-      3654,
-      3655,
-      3656
+      "DEATH_CAMP_ROOF",
+      "DEATH_CAMP_ROOF_INNER",
+      "DEATH_CAMPROOF_SUPPORT",
+      "DEATH_CAMPROOF_RIPPED",
+      "DEATH_CAMPROOF_RIPPED_LEFT"
     ],
     "uvOrientation": 128,
     "uvType": "BOX",
@@ -17713,35 +17713,35 @@
   {
     "description": "Trollheim Dark Wall in Doorway",
     "baseMaterial": "TROLLHEIM_WALL_FIX_1",
-    "objectIds": [ 3792 ],
+    "objectIds": [ "TROLL_CAVEWALL_FACE_DOORSIDE_LEFT" ],
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Trollheim Dark Wall in Doorway",
     "baseMaterial": "TROLLHEIM_WALL_FIX_2",
-    "objectIds": [ 3793 ],
+    "objectIds": [ "TROLL_CAVEWALL_FACE_DOORSIDE_RIGHT" ],
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Trollheim Staircase Boarder",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 3796 ],
+    "objectIds": [ "TROLL_FLOOR_DEPTH2" ],
     "uvType": "BOX",
     "uvScale": 0.5
   },
   {
     "description": "Trollheim Stone Staircase",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 3788, 3789 ],
+    "objectIds": [ "TROLL_STRONGHOLD_STAIRS", "TROLL_STRONGHOLD_STAIRSTOP" ],
     "uvType": "BOX",
     "uvScale": 0.6
   },
   {
     "description": "Trollheim Stone Kitchen Drawers",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 3800, 3816 ],
+    "objectIds": [ "TROLL_ROCKCOUNTER", "EADGAR_KITCHEN_DRAWERS" ],
     "uvType": "BOX",
     "uvOrientation": 768,
     "uvScale": 0.6
@@ -17749,28 +17749,28 @@
   {
     "description": "Trollheim Goat Poop",
     "baseMaterial": "DIRT_2",
-    "objectIds": [ 3818, 3819 ],
+    "objectIds": [ "EADGAR_KITCHEN_GOAT_POO", "EADGAR_KITCHEN_GOAT_POO_SMALL" ],
     "uvType": "BOX",
     "uvScale": 0.6
   },
   {
     "description": "Trollheim Food Trouph",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 3820 ],
+    "objectIds": [ "EADGAR_KITCHEN_FOODTROUGH" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
   {
     "description": "Trollheim - Wooden - Door",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1744, 3776, 3777, 3780, 3781 ],
+    "objectIds": [ "TROLL_STRONGHOLD_INTERIOR_DOOR_PERM_OPEN", "TROLL_STRONGHOLD_INTERIOR_DOOR", "TROLL_STRONGHOLD_INTERIOR_DOOR_OPEN", "TROLL_STRONGHOLD_PRISON_DOOR_CLOSED", "TROLL_STRONGHOLD_PRISON_DOOR_OPEN" ],
     "uvType": "BOX",
     "flatNormals": true
   },
   {
     "description": "Trollheim - Stocks",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 648 ],
+    "objectIds": [ "STOCKS" ],
     "uvType": "BOX",
     "uvOrientation": 512,
     "flatNormals": true
@@ -17778,7 +17778,7 @@
   {
     "description": "Trollheim Bones",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 3665 ],
+    "objectIds": [ "DEATH_TROLLLEFTOVERS" ],
     "uvType": "BOX",
     "uvOrientation": 256,
     "uvScale": 0.75
@@ -17786,7 +17786,7 @@
   {
     "description": "Trollheim Skeleton Corpe",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 3797, 3798, 3799 ],
+    "objectIds": [ "TROLL_CORPSE", "TROLL_CORPSE2", "TROLL_CORPSE3" ],
     "uvType": "BOX",
     "uvOrientation": 768,
     "uvScale": 0.75
@@ -17794,34 +17794,34 @@
   {
     "description": "Trollheim Cell Walls",
     "baseMaterial": "GRAY_75",
-    "objectIds": [ 3763, 3764, 3765, 3767, 3778, 3810, 3811, 33217, 33218, 33219, 46816, 46817 ],
+    "objectIds": [ "TROLL_CELLDOOR", "TROLL_CELLDOOR_OPEN", "TROLL_CELLDOOR_EADGAR", "TROLL_CELLDOOR_GODRIC", "TROLL_STRONGHOLD_PRISONWALL", "EADGAR_STOREROOMDOOR", "EADGAR_STOREROOMDOOR_OPEN", "MY2ARM_TOWN_FENCE", "MY2ARM_TOWN_FENCE_LOWGATE", "MY2ARM_TOWN_FENCE_BROKEN", "MY2ARM_TOWN_FENCE_ACTIVE", "MY2ARM_TOWN_FENCE_BROKEN_SHORTCUT" ],
     "flatNormals": true
   },
   {
     "description": "Trollheim Troll Ladder",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 18833, 18834 ],
+    "objectIds": [ "MYARM_EXIT", "MYARM_LADDER" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
   {
     "description": "Trollheim 'Farming' Patches",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 18835, 18836, 18837, 18838, 18839, 18840, 18845, 18846, 18847, 18848, 18849, 18850, 18851, 18852, 18853, 18854, 18855 ],
+    "objectIds": [ "MYARM_MESS_CRATE", "MYARM_MESS_BRANCH", "MYARM_MESS_GOAT", "MYARM_MESS_TROLLEY", "MYARM_MESS_FISH", "MYARM_MESS_ROCKS", "MYARM_FAKEPATCH_SOIL1", "MYARM_FAKEPATCH_SOIL2", "MYARM_FAKEPATCH_WEEDS3", "MYARM_FAKEPATCH_WEEDS2", "MYARM_FAKEPATCH_WEEDS1", "MYARM_FAKEPATCH_EMPTY", "MYARM_FAKEPATCH_SEED", "MYARM_FAKEPATCH_DISEASED", "MYARM_FAKEPATCH_DEAD", "MYARM_FAKEPATCH_GROWING", "MYARM_FAKEPATCH_FULLYGROWN" ],
     "uvType": "BOX",
     "uvOrientation": 256
   },
   {
     "description": "Trollweiss Wrecked Boat",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 33195 ],
+    "objectIds": [ "MY2ARM_SHIPWRECK" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Trollweiss Cave Entrance",
     "baseMaterial": "ROCK_3",
-    "objectIds": [ 33193, 33194 ],
+    "objectIds": [ "MY2ARM_CLIFFBOTTOM_CAVEENTRANCE_BLOCKED", "MY2ARM_CLIFFBOTTOM_CAVEENTRANCE_CLEAR" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.6
@@ -17829,7 +17829,7 @@
   {
     "description": "Skeleton",
     "baseMaterial": "BONE",
-    "objectIds": [ 660, 663, 12243, 12244, 12245, 33196, 50003, 50004 ],
+    "objectIds": [ "CORPSE", "CORPSE4", "CHICKENQUEST_SKELETON_1", "CHICKENQUEST_SKELETON_2", "CHICKENQUEST_SKELETON_3", "MY2ARM_SKELETON", "RAT_BOSS_CORPSE02", "RAT_BOSS_CORPSE01" ],
     "uvType": "BOX",
     "uvOrientation": 768,
     "uvScale": 0.75
@@ -17837,7 +17837,7 @@
   {
     "description": "Bones - Medium",
     "baseMaterial": "BONE",
-    "objectIds": [ 33323, 33324, 33325, 33326 ],
+    "objectIds": [ "MY2ARM_BONES1", "MY2ARM_BONES2", "MY2ARM_BONES3", "MY2ARM_BONES4" ],
     "uvType": "BOX",
     "uvOrientation": 768,
     "uvScale": 0.6
@@ -17845,21 +17845,21 @@
   {
     "description": "Ground Objects - Bones",
     "baseMaterial": "BONE",
-    "objectIds": [ 44837, 44838, 44839, 44840 ],
+    "objectIds": [ "ARENA_DESERT01_BONES01", "ARENA_DESERT01_BONES02", "ARENA_DESERT01_BONES03", "ARENA_DESERT01_BONES04" ],
     "uvType": "BOX",
     "uvOrientation": 256
   },
   {
     "description": "Bone Objects",
     "baseMaterial": "BONE",
-    "objectIds": [ 668, 697, 699, 700, 701, 702, 703, 736, 737 ],
+    "objectIds": [ "PILE_OF_SKULLS_GRUBBY", "ANIMALSKULL", "CARCASS", "CURVEDBONE", "CURVEDBONE_BURNT", "LARGEBONE", "LARGEBONE_BURNT", "ANIMALSKULL_BURNT", "CARCASS_BURNT" ],
     "uvType": "BOX",
     "uvScale": 0.4
   },
   {
     "description": "Weiss Snowy Rocks",
     "baseMaterial": "ROCK_3",
-    "objectIds": [ 33215, 33216 ],
+    "objectIds": [ "MY2ARM_TOWN_STONE_BLOCK_WALL_01", "MY2ARM_TOWN_STONE_BLOCK_WALL_02" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.3
@@ -17867,7 +17867,7 @@
   {
     "description": "Weiss Salts",
     "baseMaterial": "DIRT_1",
-    "objectIds": [ 33222, 33223, 33224 ],
+    "objectIds": [ "MY2ARM_TOWN_RED_SALT_DECOR_A", "MY2ARM_TOWN_GREEN_SALT_DECOR_A", "MY2ARM_TOWN_BLUE_SALT_DECOR_A" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.4
@@ -17875,7 +17875,7 @@
   {
     "description": "Weiss Salt Mine Walls",
     "baseMaterial": "DIRT_1",
-    "objectIds": [ 21516, 21540, 33236, 33236, 33237, 33247 ],
+    "objectIds": [ "FRIS_MINE_WALL", "FRIS_MINE_WALL_TOP", "MY2ARM_CAVE_RAMP", "MY2ARM_CAVE_RAMP", "MY2ARM_CAVE_SQUEEZE", "MY2ARM_CAVE_EXIT_BLOCKED" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.4
@@ -17883,14 +17883,14 @@
   {
     "description": "Weiss Underground Ground Rubble",
     "baseMaterial": "GRUNGE_1",
-    "objectIds": [ 21545, 21546, 21547, 21548 ],
+    "objectIds": [ "FRIS_MINE_DUGUPSOIL_02", "FRIS_MINE_DUGUPSOIL_03", "FRIS_MINE_DUGUPSOIL_04", "FRIS_MINE_DUGUPSOIL_05" ],
     "uvType": "BOX",
     "uvOrientation": 128
   },
   {
     "description": "Weiss Underground Stalactites",
     "baseMaterial": "GRUNGE_1",
-    "objectIds": [ 21554, 21555 ],
+    "objectIds": [ "FRIS_MINE_STALAGTITE_01", "FRIS_MINE_STALAGTITE_02" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.6
@@ -17898,7 +17898,7 @@
   {
     "description": "Weiss Staircase",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 33234 ],
+    "objectIds": [ "MY2ARM_THRONEROOM_STAIRSDOWN" ],
     "uvType": "BOX",
     "uvOrientation": 768,
     "uvScale": 0.6
@@ -17906,7 +17906,7 @@
   {
     "description": "Wise Old Mans Coffin",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 33264, 33264, 33265 ],
+    "objectIds": [ "MY2ARM_COFFIN_BUILT", "MY2ARM_COFFIN_BUILT", "MY2ARM_COFFIN_OCCUPIED" ],
     "uvType": "BOX",
     "uvOrientation": 512,
     "uvScale": 0.6
@@ -17914,32 +17914,32 @@
   {
     "description": "Weiss Smelly Hole",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 33262 ],
+    "objectIds": [ "MY2ARM_HOLE" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
   {
     "description": "Weiss Salt Rocks",
     "baseMaterial": "ROCK_5",
-    "objectIds": [ 33255, 33257 ],
+    "objectIds": [ "MY2ARM_SALTROCK_BLUE", "MY2ARM_SALTROCK_SPECIAL" ],
     "uvType": "BOX"
   },
   {
     "description": "Weiss Salt Rocks",
     "baseMaterial": "ROCK_5",
-    "objectIds": [ 33254, 33256 ],
+    "objectIds": [ "MY2ARM_SALTROCK_GREEN", "MY2ARM_SALTROCK_RED" ],
     "uvType": "BOX"
   },
   {
     "description": "Weiss Empty Rock",
     "baseMaterial": "ROCK_5",
-    "objectIds": [ 33253 ],
+    "objectIds": [ "MY2ARM_SALTROCK_EMPTY" ],
     "uvType": "BOX"
   },
   {
     "description": "Weiss Saltmine Walls",
     "baseMaterial": "ROCK_4",
-    "objectIds": [ 46825, 46826, 46827, 46828, 46829, 46830, 43831, 43832, 46832, 46833, 46834, 46835, 46836, 46837, 46840 ],
+    "objectIds": [ "MY2ARM_MINE_WALL", "MY2ARM_MINE_WALL_SNOWTOP", "MY2ARM_MINE_WALL_SNOWTOP_TRANSITION", "MY2ARM_MINE_WALL_SNOWTOP_TRANSITION_MIRROR", "MY2ARM_MINE_WALL_TOP", "MY2ARM_MINE_WALL_TOP_SNOW01", "DECOKIT_TILES_BROKEN02", "DECOKIT_TILES_BROKEN03", "MY2ARM_MINE_WALL_TOP_FALLOFF_STRAIGHT", "MY2ARM_MINE_WALL_TOP_FALLOFF_STRAIGHT_SNOW", "MY2ARM_MINE_WALL_TOP_FALLOFF_INSIDE_CORNER", "MY2ARM_MINE_WALL_TOP_FALLOFF_INSIDE_CORNER_SNOW", "MY2ARM_MINE_WALL_TOP_FALLOFF_OUTSIDE_CORNER", "MY2ARM_MINE_WALL_TOP_FALLOFF_OUTSIDE_CORNER_SNOW", "MY2ARM_MINE_WALL_3WIDE" ],
     "uvType": "BOX",
     "uvScale": 0.45,
     "uvOrientation": 128
@@ -17947,7 +17947,7 @@
   {
     "description": "Weiss Saltmine to Ghorrock Dungeon Cave",
     "baseMaterial": "ROCK_4_DARK",
-    "objectIds": [ 46839 ],
+    "objectIds": [ "MY2ARM_MINE_WALL_CAVE_EXIT_02_VIS" ],
     "uvType": "BOX",
     "uvScale": 0.45,
     "uvOrientation": 612
@@ -17955,7 +17955,7 @@
   {
     "description": "Weiss Saltmine Stairs",
     "baseMaterial": "ROCK_4",
-    "objectIds": [ 33261 ],
+    "objectIds": [ "MY2ARM_MINE_STEPS" ],
     "uvType": "BOX",
     "uvScale": 0.45,
     "uvOrientation": 384
@@ -17963,20 +17963,20 @@
   {
     "description": "Ghorrock Dungeon - Wall",
     "baseMaterial": "GRUNGE_3_LIGHT",
-    "objectIds": [ 46597, 46623, 46624, 46625, 46626, 46627, 46629, 46630, 46631, 46634, 46635, 46636, 46650, 46651, 46652, 46653, 46654, 46655, 46656, 46657, 46658, 46659, 46660, 46661, 46662, 46663, 46666, 46667, 46596, 46701, 46702, 49092 ],
+    "objectIds": [ "GHORROCK_DUNGEON_CAVE_ENTRY", "GHORROCK_STONE01", "GHORROCK_STONE01_SNOW01", "GHORROCK_STONE01_SNOW01_TRANSITION", "GHORROCK_STONE01_SNOW01_TRANSITION_MIRROR", "GHORROCK_STONE01_SNOW01_PILLAR", "GHORROCK_STONE01_PILLAR02", "GHORROCK_STONE01_DECORATIVE01", "GHORROCK_STONE01_ALCOVE01", "GHORROCK_STONE01_ALCOVE02_CAGE", "GHORROCK_STONE01_ALCOVE02_DOOR", "GHORROCK_STONE01_ALCOVE02_PLAQUE", "GHORROCK_WALLTOP_SNOW_STRAIGHT", "GHORROCK_WALLTOP_SNOW_OUTSIDE_CORNER", "GHORROCK_WALLTOP_SNOW_INSIDE_CORNER", "GHORROCK_GATEWAY01_LEFT_LVL0", "GHORROCK_GATEWAY01_RIGHT_LVL0", "GHORROCK_GATEWAY01_LEFT_LVL1", "GHORROCK_GATEWAY01_RIGHT_LVL1", "GHORROCK_GATEWAY01_MIDDLE_LVL1", "GHORROCK_METAL_GATE_CLOSED", "GHORROCK_METAL_GATE_OPEN", "GHORROCK_METAL_GATE_PADLOCK_CLOSED", "GHORROCK_METAL_GATE_PADLOCK_OPEN", "GHORROCK_ICE01", "GHORROCK_ICE02", "GHORROCK_SNOW01_ICE01_TRANS", "GHORROCK_SNOW01_ICE01_TRANS_MIRROR", "GHORROCK_DUNGEON_EXIT", "ANCIENT_ESSENCE_ROCK_ACTIVE", "ANCIENT_ESSENCE_ROCK_EMPTY", "DT2_GHORROCK_ENTRY_NOOP" ],
     "uvType": "BOX"
   },
   {
     "description": "Ghorrock Dungeon - Snow - Trim",
     "baseMaterial": "GRAY_110",
-    "objectIds": [ 46639, 46640, 46641, 46642, 46643 ]
+    "objectIds": [ "GHORROCK_STONE01_SNOW01_FALLOFF_STRAIGHT", "GHORROCK_STONE01_SNOW01_FALLOFF_STRAIGHT_END", "GHORROCK_STONE01_SNOW01_FALLOFF_STRAIGHT_END_MIRROR", "GHORROCK_STONE01_SNOW01_FALLOFF_OUTSIDE_CORNER", "GHORROCK_STONE01_SNOW01_FALLOFF_INSIDE_CORNER" ]
   },
   {
     "description": "Ghorrock Dungeon - Wooden - Chest",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      46620,
-      46680
+      "SOTN_GHORROCK_CHEST_EMPTY",
+      "GHORROCK_SNOW01_CHEST_CLOSED_NOOP"
     ],
     "uvType": "BOX"
   },
@@ -17984,7 +17984,7 @@
     "description": "Ghorrock Dungeon - Wooden - Chair",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      46677
+      "GHORROCK_SNOW01_SMASHEDCHAIR02"
     ],
     "uvType": "BOX"
   },
@@ -17992,7 +17992,7 @@
     "description": "Ghorrock Dungeon - Wooden - Chair - Smashed",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      46676
+      "GHORROCK_SNOW01_SMASHEDCHAIR01"
     ],
     "uvType": "BOX",
     "uvOrientationY": -206
@@ -18001,7 +18001,7 @@
     "description": "Ghorrock Dungeon - Wooden - Crate",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      46688
+      "GHORROCK_CRATE_SINGLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -18010,7 +18010,7 @@
     "description": "Ghorrock Dungeon - Wooden - Crate - Stacked",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      46689
+      "GHORROCK_CRATE_DOUBLE"
     ],
     "uvType": "BOX",
     "uvOrientationY": -256
@@ -18019,8 +18019,8 @@
     "description": "Ghorrock Dungeon - Tables",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      46674,
-      46675
+      "GHORROCK_SNOW01_BROKENTABLE01",
+      "GHORROCK_SNOW01_BROKENTABLE02"
     ],
     "uvType": "BOX"
   },
@@ -18028,7 +18028,7 @@
     "description": "Ghorrock Dungeon - Lever",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      46687
+      "GHORROCK_LEVER_DOWN"
     ],
     "uvType": "BOX",
     "uvScale": 0.25
@@ -18037,7 +18037,7 @@
     "description": "Ghorrock Dungeon - Wall - Candle",
     "baseMaterial": "WOOD_GRAIN",
     "objectIds": [
-      46647
+      "GHORROCK_WALL_CANDLE01"
     ],
     "uvType": "BOX",
     "uvScale": 0.25
@@ -18045,21 +18045,21 @@
   {
     "description": "White Bed with pillow",
     "baseMaterial": "CARPET",
-    "objectIds": [ 46841 ],
+    "objectIds": [ "MY2ARM_BED" ],
     "uvType": "BOX",
     "uvOrientation": 64
   },
   {
     "description": "Black overhead tiles",
     "baseMaterial": "GRAY_25",
-    "objectIds": [ 44643 ],
+    "objectIds": [ "GIANTS_FOUNDRY_WALL_LVL1_WALLTOP01" ],
     "uvType": "BOX",
     "uvOrientation": 64
   },
   {
     "description": "Throne of Weiss",
     "baseMaterial": "ROCK_2",
-    "objectIds": [ 33232 ],
+    "objectIds": [ "MY2ARM_THRONE" ],
     "uvType": "BOX",
     "uvScale": 0.3,
     "uvOrientation": 512
@@ -18067,7 +18067,7 @@
   {
     "description": "Goat Poo",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 33214 ],
+    "objectIds": [ "MY2ARM_GOATDUNG" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 128
@@ -18075,57 +18075,57 @@
   {
     "description": "Snowy Underground Entrance",
     "baseMaterial": "SNOW_4",
-    "objectIds": [ 33227, 33228, 33229, 33230, 33231 ],
+    "objectIds": [ "MY2ARM_TOWN_HOLE_A", "MY2ARM_TOWN_HOLE_B", "MY2ARM_TOWN_HOLE_C", "MY2ARM_TOWN_HOLE_D", "MY2ARM_TOWN_HOLE_E" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 64
   },
   {
     "description": "Poison Waste Dungeon exit shading",
-    "objectIds": [ 49702 ],
+    "objectIds": [ "POG_SEWER_PIPE_SIDE_02" ],
     "flatNormals": true
   },
   {
     "description": "Fix incorrectly oriented tile model in Karuulm",
-    "objectIds": [ 34533 ],
+    "objectIds": [ "KARUULM_FLOOR_FALLOFF_OUSIDE_CORNER" ],
     "areas": [ [ 1288, 10205, 0 ] ],
     "rotate": 270
   },
   {
     "description": "Textured Bushes",
     "objectIds": [
-      1116, 1117, 1118, 1119,
-      1120, 1121, 1124, 1125,
-      2357, 2358, 2798, 2799,
-      2800, 2802, 2803,
-      17988, 17990, 17991,
-      19427, 19428, 19429,
-      31571, 41456, 46584,
-      46585
+      "HEDGE", "HEDGECORNER", "WILDBUSH1", "WILDBUSH2",
+      "WILDBUSH3", "WILDBUSH4", "BUSH1", "BUSH2",
+      "DIGSITEBUSH", "DIGSITEBUSHSAMPLE", "WATCHTOWERBUSH", "WATCHTOWERBUSHNAIL",
+      "WATCHTOWERBUSHDAGGER", "WATCHTOWERBUSHROBE", "WATCHTOWERBUSHARMOUR",
+      "MYREQUE_BUSH_WITHOUT_LEG", "MYREQUE_BUSH1", "MYREQUE_BUSH2",
+      "HUNTING_TRAIL_END_JUNGLE", "HUNTING_TRAIL_END_BUSH29", "HUNTING_TRAIL_END_BUSH35_55",
+      "ZEP_BUSH", "BIM_BUSH", "SOTN_HUNTING_BUSH_OP",
+      "SOTN_HUNTING_BUSH_NOOP"
     ]
   },
   {
     "description": "Evergreen Trees",
     "baseMaterial": "BARK",
-    "objectIds": [ 2091, 2092, 27060 ],
+    "objectIds": [ "EVERGREEN", "EVERGREEN_LARGE", "MAX_EVERGREEN" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Snowcovered Evergreen Trees - Textured",
     "objectIds": [
-      1318, 1319, 40932,
-      40933, 46509, 46510
+      "EVERGREEN_VSNOWY_LARGE", "EVERGREEN_SNOWY_LARGE", "EVERGREEN_VSNOWY",
+      "EVERGREEN_SNOWY", "XMAS22_EVERGREEN_SNOWY_LARGE", "XMAS22_EVERGREEN_VSNOWY"
     ]
   },
   {
     "description": "Oak Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      1356, 4533, 4540, 8462, 8463,
-      8464, 8465, 8466, 8467,
-      9734, 10820, 20806, 37969,
-      37970, 42395, 42831, 51772
+      "OAKTREE_STUMP", "POH_BIG_TREE3_4", "POH_SMALL_TREE3_5", "OAK_TREE_SEEDLING", "OAK_TREE_1",
+      "OAK_TREE_2", "OAK_TREE_3", "OAK_TREE_FULLYGROWN_1", "OAK_TREE_FULLYGROWN_2",
+      "NEWBIEOAKTREE", "OAKTREE", "DRILL_OAKTREE", "TUT2_OAK",
+      "TUT2_OAK_NOOP", "TREE_OAK_DEFAULT01", "GIM_OAKTREE", "AVIUM_OAK_1"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -18142,11 +18142,11 @@
     "description": "Magic Tree",
     "baseMaterial": "BARK_STONEPINE",
     "objectIds": [
-      4537, 5127, 8396,
-      8397, 8398, 8399,
-      8400, 8401, 8402,
-      8403, 8404, 8405,
-      8406, 8407, 8408, 8409, 10834
+      "POH_BIG_TREE7_4", "POH_SMALL_TREE7_5", "MAGIC_TREE_SEEDLING",
+      "MAGIC_TREE_1", "MAGIC_TREE_2", "MAGIC_TREE_3",
+      "MAGIC_TREE_4", "MAGIC_TREE_5", "MAGIC_TREE_6",
+      "MAGIC_TREE_7", "MAGIC_TREE_8", "MAGIC_TREE_9",
+      "MAGIC_TREE_10", "MAGIC_TREE_11", "MAGIC_TREE_FULLYGROWN_1", "MAGIC_TREE_FULLYGROWN_2", "MAGICTREE"
     ],
     "uvType": "BOX",
     "uvOrientation": 150,
@@ -18156,7 +18156,7 @@
     "description": "Magic Tree Stump",
     "baseMaterial": "BARK_STONEPINE",
     "objectIds": [
-      9713
+      "MAGIC_TREE_STUMP_NEW"
     ],
     "uvType": "BOX",
     "uvOrientation": 150,
@@ -18172,21 +18172,21 @@
     "description": "Woodcutting Guild - Redwood Tree Bark",
     "baseMaterial": "BARK_STONEPINE_2",
     "objectIds": [
-      29668,
-      29669,
-      29670,
-      29671,
-      29673,
-      29674,
-      29675,
-      29676,
-      29677,
-      29678,
-      29679,
-      29681,
-      29683,
-      29682,
-      29684
+      "REDWOODTREE_L",
+      "REDWOODTREE_L_CUT",
+      "REDWOODTREE_R",
+      "REDWOODTREE_R_CUT",
+      "REDWOODTREE_BOTTOM_CORN1",
+      "REDWOODTREE_BOTTOM_CORN2",
+      "REDWOODTREE_BOTTOM_CORN3",
+      "REDWOODTREE_BOTTOM_SIDE1",
+      "REDWOODTREE_BOTTOM_SIDE2",
+      "REDWOODTREE_MIDDLE_CORN1",
+      "REDWOODTREE_MIDDLE_CORN2",
+      "REDWOODTREE_MIDDLE_SIDE2",
+      "REDWOODTREE_BOTTOM_CENTER",
+      "REDWOODTREE_MIDDLE_SIDE3",
+      "REDWOODTREE_MIDDLE_CENTER"
     ],
     "uvType": "BOX",
     "uvScale": 1.2,
@@ -18202,25 +18202,25 @@
     "description": "Woodcutting Guild - Redwood Tree Top Leaves",
     "baseMaterial": "GRUNGE_3_DULL",
     "objectIds": [
-      29693,
-      29694,
-      29695,
-      29696,
-      29697,
-      29698,
-      29699,
-      29700,
-      29701,
-      29702,
-      29703,
-      29704
+      "REDWOODTREE_CANOPY_LOW_BLANK",
+      "REDWOODTREE_CANOPY_LOW_SIDE1",
+      "REDWOODTREE_CANOPY_LOW_SIDE2",
+      "REDWOODTREE_CANOPY_LOW_CORNER1",
+      "REDWOODTREE_CANOPY_LOW_CORNER2",
+      "REDWOODTREE_CANOPY_UPPER_BLANK",
+      "REDWOODTREE_CANOPY_UPPER_SIDE1",
+      "REDWOODTREE_CANOPY_UPPER_CORNER1",
+      "REDWOODTREE_CANOPY_UPPER_CORNER2",
+      "REDWOODTREE_CANOPY_HIGHEST_BLANK",
+      "REDWOODTREE_CANOPY_HIGHEST_SIDE1",
+      "REDWOODTREE_CANOPY_HIGHEST_CORNER1"
     ]
   },
   {
     "description": "Guardians Of the Rift - Rocks - Medium",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      43615
+      "GOTR_RUNESTONE_ROCKS_SMALL01"
     ],
     "uvType": "BOX",
     "uvScale": 0.82,
@@ -18230,17 +18230,17 @@
     "description": "Guardians Of the Rift - Rocks - Large",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      43613,
-      43614,
-      43616,
-      43617,
-      43618,
-      43619,
-      43620,
-      43621,
-      43622,
-      43623,
-      43624
+      "GOTR_RUNESTONE_ROCKS_DEFAULT01",
+      "GOTR_RUNESTONE_ROCKS_LARGE01",
+      "GOTR_RUNESTONE_ROCKS02_DEFAULT01",
+      "GOTR_RUNESTONE_ROCKS02_DEFAULT02",
+      "GOTR_RUNESTONE_ROCKS02_LARGE01",
+      "GOTR_RUNESTONE_ROCKS02_SMALL01",
+      "GOTR_RUNESTONE_ROCKS02_SMALL02",
+      "GOTR_RUNESTONE_ROCKS03_DEFAULT01",
+      "GOTR_RUNESTONE_ROCKS03_DEFAULT02",
+      "GOTR_RUNESTONE_ROCKS03_LARGE01",
+      "GOTR_RUNESTONE_ROCKS03_SMALL01"
     ],
     "uvType": "BOX",
     "uvScale": 0.72,
@@ -18250,11 +18250,11 @@
     "description": "Guardians of the Rift - Marble - Steps",
     "baseMaterial": "MARBLE_3_SEMIGLOSS",
     "objectIds": [
-      43545,
-      43546,
-      43557,
-      43568,
-      43569
+      "GOTR_STEPS_RUNESTONE01_EDGE01",
+      "GOTR_STEPS_RUNESTONE01_EDGE02",
+      "GOTR_STEPS_RUNESTONE02_EDGE01",
+      "GOTR_STEPS_RUNESTONE03_EDGE01",
+      "GOTR_STEPS_RUNESTONE03_EDGE02"
     ],
     "uvType": "BOX",
     "uvOrientation": 640,
@@ -18264,18 +18264,18 @@
     "description": "Guardians of the Rift - Ground Decoration Grunge - Shelf Coral ",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      43659,
-      43660,
-      43661,
-      43662,
-      43663,
-      43666,
-      43667,
-      43668,
-      43669,
-      43670,
-      43671,
-      43672
+      "GOTR_PLANT_SHELF01_DEFAULT01",
+      "GOTR_PLANT_SHELF01_DEFAULT02",
+      "GOTR_PLANT_SHELF01_DEFAULT03",
+      "GOTR_PLANT_SHELF01_FALLOFF01",
+      "GOTR_PLANT_SHELF01_FALLOFF02",
+      "GOTR_PLANT_SHELF02_DEFAULT01",
+      "GOTR_PLANT_SHELF02_DEFAULT02",
+      "GOTR_PLANT_SHELF02_DEFAULT03",
+      "GOTR_PLANT_SHELF02_FALLOFF01",
+      "GOTR_PLANT_SHELF02_FALLOFF02",
+      "GOTR_PLANT_SHELF02_CORNER01",
+      "GOTR_PLANT_SHELF02_CORNER02"
     ],
     "uvType": "GEOMETRY",
     "flatNormals": true
@@ -18284,9 +18284,9 @@
     "description": "Guardians of the Rift - Large Guardian Remains",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43719,
-      43800,
-      43801
+      "GOTR_ESSENCE_TIER_2",
+      "TOTE_ESSENCE_TIER_2",
+      "TOTE_ESSENCE_TIER_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.87
@@ -18295,7 +18295,7 @@
     "description": "Guardians of the Rift - Huge Guardian Remains",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43720
+      "GOTR_ESSENCE_TIER_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.87
@@ -18304,10 +18304,10 @@
     "description": "Guardians of the Rift - Guardian Remains",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43717,
-      43718,
-      43798,
-      43799
+      "GOTR_ESSENCE_TIER_1_LARGE",
+      "GOTR_ESSENCE_TIER_1_LARGE_B",
+      "TOTE_ESSENCE_TIER_1_LARGE",
+      "TOTE_ESSENCE_TIER_1_LARGE_B"
     ],
     "uvType": "BOX"
   },
@@ -18315,10 +18315,10 @@
     "description": "Guardians of the Rift - Guardian Parts",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43715,
-      43716,
-      43796,
-      43797
+      "GOTR_ESSENCE_TIER_1",
+      "GOTR_ESSENCE_TIER_1B",
+      "TOTE_ESSENCE_TIER_1",
+      "TOTE_ESSENCE_TIER_1B"
     ],
     "uvType": "BOX"
   },
@@ -18326,10 +18326,10 @@
     "description": "Guardians of the Rift - Catalytic and Elemental Guides",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43752,
-      43753,
-      43782,
-      43783
+      "GOTR_LANE_ELEMENTAL01",
+      "GOTR_LANE_CATALYTIC01",
+      "TOTE_LANE_ELEMENTAL",
+      "TOTE_LANE_CATALYTIC"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 256,
@@ -18339,16 +18339,16 @@
     "description": "Guardians of the Rift - Guardian Steps",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43551,
-      43552,
-      43552,
-      43553,
-      43554,
-      43556,
-      43562,
-      43563,
-      43564,
-      43567
+      "GOTR_STEPS_RUNESTONE01_TRANSITION01",
+      "GOTR_STEPS_RUNESTONE01_TRANSITION02",
+      "GOTR_STEPS_RUNESTONE01_TRANSITION02",
+      "GOTR_STEPS_RUNESTONE01_TRANSCORN01",
+      "GOTR_STEPS_RUNESTONE01_TRANSCORN02",
+      "GOTR_STEPS_RUNESTONE01_TRANSCORN04",
+      "GOTR_STEPS_RUNESTONE02_TRANSITION01",
+      "GOTR_STEPS_RUNESTONE02_TRANSITION02",
+      "GOTR_STEPS_RUNESTONE02_TRANSCORN01",
+      "GOTR_STEPS_RUNESTONE02_TRANSCORN04"
     ],
     "uvType": "BOX",
     "uvScale": 0.87
@@ -18357,8 +18357,8 @@
     "description": "Guardians of the Rift - Entrance Statues",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43698,
-      43699
+      "GOTR_STATUE",
+      "GOTR_STATUE02"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -18367,45 +18367,45 @@
     "description": "Guardians of the Rift - Guardian Rune Portal Statues",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43701,
-      43702,
-      43703,
-      43704,
-      43705,
-      43706,
-      43707,
-      43708,
-      43709,
-      43710,
-      43711,
-      43712,
-      43784,
-      43785,
-      43786,
-      43787,
-      43788,
-      43789,
-      43790,
-      43791,
-      43792,
-      43793,
-      43794,
-      43795,
-      43809,
-      43810,
-      43811,
-      43812,
-      43813,
-      43814,
-      43815,
-      43816,
-      43817,
-      43818,
-      43819,
-      43820,
-      43841,
-      43821,
-      43822
+      "GOTR_PORTAL_AIR",
+      "GOTR_PORTAL_WATER",
+      "GOTR_PORTAL_EARTH",
+      "GOTR_PORTAL_FIRE",
+      "GOTR_PORTAL_MIND",
+      "GOTR_PORTAL_CHAOS",
+      "GOTR_PORTAL_DEATH",
+      "GOTR_PORTAL_BLOOD",
+      "GOTR_PORTAL_BODY",
+      "GOTR_PORTAL_COSMIC",
+      "GOTR_PORTAL_NATURE",
+      "GOTR_PORTAL_LAW",
+      "TOTE_PORTAL_AIR",
+      "TOTE_PORTAL_WATER",
+      "TOTE_PORTAL_EARTH",
+      "TOTE_PORTAL_FIRE",
+      "TOTE_PORTAL_MIND",
+      "TOTE_PORTAL_CHAOS",
+      "TOTE_PORTAL_DEATH",
+      "TOTE_PORTAL_BLOOD",
+      "TOTE_PORTAL_BODY",
+      "TOTE_PORTAL_COSMIC",
+      "TOTE_PORTAL_NATURE",
+      "TOTE_PORTAL_LAW",
+      "TOTE_TUTORIAL_PORTAL_AIR",
+      "TOTE_TUTORIAL_PORTAL_WATER",
+      "TOTE_TUTORIAL_PORTAL_EARTH",
+      "TOTE_TUTORIAL_PORTAL_FIRE",
+      "TOTE_TUTORIAL_PORTAL_MIND",
+      "TOTE_TUTORIAL_PORTAL_CHAOS",
+      "TOTE_TUTORIAL_PORTAL_DEATH",
+      "TOTE_TUTORIAL_PORTAL_BLOOD",
+      "TOTE_TUTORIAL_PORTAL_BODY",
+      "TOTE_TUTORIAL_PORTAL_COSMIC",
+      "TOTE_TUTORIAL_PORTAL_NATURE",
+      "TOTE_TUTORIAL_PORTAL_LAW",
+      "TOTE_PORTAL_TO_GOTR_PARENT",
+      "TOTE_PORTAL_WATER_ACTIVE",
+      "TOTE_PORTAL_MIND_ACTIVE"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -18414,11 +18414,11 @@
     "description": "Guardians of the Rift - Columns",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43523,
-      43524,
-      43525,
-      43526,
-      43527
+      "GOTR_PILLAR_RUNESTONE03",
+      "GOTR_PILLAR_RUNESTONE04",
+      "GOTR_PILLAR_RUNESTONE05",
+      "GOTR_PILLAR_RUNESTONE06",
+      "GOTR_PILLAR_RUNESTONE07"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -18428,7 +18428,7 @@
     "description": "Guardians of the Rift - Destroyed Columns Base",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43528
+      "GOTR_PILLAR_BROKEN01"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -18438,7 +18438,7 @@
     "description": "Guardians of the Rift - Destroyed Columns Ground",
     "baseMaterial": "ROCK_3_ORE",
     "objectIds": [
-      43529
+      "GOTR_PILLAR_BROKEN02"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -18451,9 +18451,9 @@
     "uvScale": 0.67,
     "uvOrientation": 42,
     "objectIds": [
-      43632,
-      43633,
-      43634
+      "GOTR_PLANT_ELK01_DEFAULT01",
+      "GOTR_PLANT_ELK01_DEFAULT01_2X2",
+      "GOTR_PLANT_ELK01_FALLOFF01"
     ]
   },
   {
@@ -18463,9 +18463,9 @@
     "uvScale": 0.67,
     "uvOrientation": 343,
     "objectIds": [
-      43638,
-      43639,
-      43640
+      "GOTR_PLANT_SPONGE01_DEFAULT01",
+      "GOTR_PLANT_SPONGE01_DEFAULT01_2X2",
+      "GOTR_PLANT_SPONGE01_FALLOFF01"
     ]
   },
   {
@@ -18474,16 +18474,16 @@
     "uvType": "BOX",
     "uvScale": 0.67,
     "objectIds": [
-      43635,
-      43636,
-      43637
+      "GOTR_PLANT_LACE01_DEFAULT01",
+      "GOTR_PLANT_LACE01_DEFAULT01_2X2",
+      "GOTR_PLANT_LACE01_FALLOFF01"
     ]
   },
   {
     "description": "Freminnik Slayer Dungeon - Stone Staircase",
     "baseMaterial": "ROCK_5",
     "objectIds": [
-      29992
+      "KURASK_STEPS_MODEL"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -18492,8 +18492,8 @@
     "description": "Freminnik - Walls - Animal Skin Door",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      4250,
-      4251
+      "VIKING_FUR_DOOR",
+      "VIKING_FUR_DOOR_OPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -18502,11 +18502,11 @@
     "description": "Freminnik - Walls - Wooden - Plank Doors",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4148,
-      4165,
-      4166,
-      4247,
-      4248
+      "VIKING_BARD_BACKSTAGE_DOOR",
+      "VIKING_SEERS_DOOR1",
+      "VIKING_SEERS_DOOR2",
+      "VIKING_ABODE_DOOR",
+      "VIKING_ABODE_DOOR_OPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.66
@@ -18515,17 +18515,17 @@
     "description": "Freminnik - Walls - Wooden - Plank ",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4193,
-      4194,
-      4195,
-      4196,
-      4199,
-      4200,
-      4201,
-      4202,
-      4203,
-      21624,
-      21625
+      "VIKING_LONGHALL_WALL",
+      "VIKING_LONGHALL_WALL_SHORTER",
+      "VIKING_LONGHALL_WALL_HILLSKEW",
+      "VIKING_LONGHALL_WALL_MIRROR",
+      "VIKING_LONGHALL_WALL_SUPPORT",
+      "VIKING_LONGHALL_WALL_SUPPORT_MIRROR",
+      "VIKING_LONGHALL_WALL_WINDOW",
+      "VIKING_LONGHALL_WALL_WINDOW_MIRROR",
+      "VIKING_LONGHALL_WALL_TALL",
+      "VIKING_LONGHALL_WALL_SUPPORT_CAP",
+      "VIKING_LONGHALL_WALL_SUPPORT_CAP_MIRROR"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -18534,8 +18534,8 @@
     "description": "Freminnik - Wall Decoration Wooden - Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4204,
-      4205
+      "VIKING_WALL_BRACES_STRAIGHT",
+      "VIKING_WALL_BRACES_WONKEY"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -18546,15 +18546,15 @@
     "description": "Freminnik - Roof - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4206,
-      4207,
-      4208,
-      4209,
-      4210,
-      4214,
-      4226,
-      4227,
-      26597
+      "VIKING_LONGHALL_ROOF1",
+      "VIKING_LONGHALL_ROOF2",
+      "VIKING_LONGHALL_ROOF3",
+      "VIKING_LONGHALL_ROOF4",
+      "VIKING_LONGHALL_ROOF_EDGE1",
+      "VIKING_LONGHALL_ROOF_EDGE1_MIRROR",
+      "VIKING_LONGHALL_ROOF1_HILLSKEW",
+      "VIKING_LONGHALL_ROOF2_HILLSKEW",
+      "VIKING_LONGHALL_ROOF1_RAISED"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -18564,17 +18564,17 @@
     "description": "Freminnik - Roof Corners/edges - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4218,
-      4219,
-      4220,
-      4221,
-      4222,
-      4223,
-      4224,
-      4225,
-      4241,
-      26598,
-      26599
+      "VIKING_LONGHALL_ROOF_EDGE1_NEW",
+      "VIKING_LONGHALL_ROOF_EDGE1_NEW_MIRROR",
+      "VIKING_LONGHALL_ROOF_EDGE2_NEW",
+      "VIKING_LONGHALL_ROOF_EDGE2_NEW_MIRROR",
+      "VIKING_LONGHALL_ROOF_EDGE3_NEW",
+      "VIKING_LONGHALL_ROOF_EDGE3_NEW_MIRROR",
+      "VIKING_LONGHALL_ROOF_EDGE4_NEW",
+      "VIKING_LONGHALL_ROOF_EDGE4_NEW_MIRROR",
+      "VIKING_SEERSHOUSE_EDGE",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE1_RAISED",
+      "VIKING_LONGHALL_ROOF_EDGE_ABODE1_MIRROR_RAISED"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -18585,7 +18585,7 @@
     "description": "Freminnik - Roof Spire - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4228
+      "VIKING_LONGHALL_CHIMNEY"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -18594,8 +18594,8 @@
     "description": "Freminnik - Wooden - Plank Stage",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4254,
-      4255
+      "VIKING_STAGE_EDGE",
+      "VIKING_THEATRE_FLOOR"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -18605,7 +18605,7 @@
     "description": "Freminnik - Walls - Wooden - Post",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4197
+      "VIKING_LONGHALL_WALL_INSIDE"
     ],
     "uvType": "BOX"
   },
@@ -18613,10 +18613,10 @@
     "description": "Freminnik - Game Objects - Wooden - Plank Tables",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4269,
-      4270,
-      4272,
-      4372
+      "VIKING_LONGHALL_TABLE",
+      "VIKING_LONGHALL_TABLE_CANDLE",
+      "VIKING_TABLE",
+      "VIKING_TABLE_SMALL"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -18626,9 +18626,9 @@
     "description": "Freminnik - Game Objects - Wooden Shelf Empty",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4366,
-      4367,
-      4507
+      "VIKING_SHELF_EMPTY",
+      "VIKING_SHELF_EMPTY_LOW",
+      "FAI_VARROCK_SHELF_EMPTY"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512
@@ -18637,8 +18637,8 @@
     "description": "Game Objects - Wooden Shelf With Pots",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4368,
-      4514
+      "VIKING_SHELF_COOKING",
+      "FAI_VARROCK_SHELF_COOKING"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -18654,7 +18654,7 @@
     "description": "Freminnik - Game Objects - Wooden Shelf With Bucket",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4370
+      "VIKING_SHELF_BUCKET"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512
@@ -18663,8 +18663,8 @@
     "description": "Freminnik - Decorations - Metal Gutter",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      4162,
-      4327
+      "VIKING_PIPE_END_LONGHALL",
+      "VIKING_PIPE_END"
     ],
     "uvType": "BOX",
     "uvOrientation": 272
@@ -18673,7 +18673,7 @@
     "description": "Freminnik - Helmet Shop Sign",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4280
+      "VIKING_SWORD_SHOP"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -18683,11 +18683,11 @@
     "description": "Freminnik - Walls - Barricade",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      4289,
-      4290,
-      4291,
-      4292,
-      4293
+      "VIKING_PIKE_DEFENCE",
+      "VIKING_PIKE_DEFENCE_TERMINATOR_RIGHT",
+      "VIKING_PIKE_DEFENCE_TERMINATOR_LEFT",
+      "VIKING_PIKE_DEFENCE_BEND",
+      "VIKING_PIKE_DEFENCE_BEND_MIRROR"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -18696,9 +18696,9 @@
     "description": "Island of Stone - Cave and Pillars",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      25846,
-      37409,
-      37410
+      "KR_KEEP_PILLAR",
+      "ISLAND_OF_STONE_CAVE_CLOSED",
+      "ISLAND_OF_STONE_CAVE_OPEN"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -18706,36 +18706,36 @@
   {
     "description": "Island of Stone Dungeon - The Jormungund",
     "baseMaterial": "STONE_NORMALED",
-    "npcIds": [ 9289, 9290, 9291, 9292 ],
-    "objectIds": [ 37424 ]
+    "npcIds": [ "JORMUNGAND_FROZEN", "JORMUNGAND_TURN", "JORMUNGAND", "JORMUNGAND_DEAD" ],
+    "objectIds": [ "VIKINGEXILE_JORMUNGAND_WALL_HEAD" ]
   },
   {
     "description": "Island of Stone Dungeon - Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      37411,
-      37412,
-      37413,
-      37414,
-      37415,
-      37416,
-      37417,
-      37419,
-      37420,
-      37425,
-      37426,
-      37427,
-      37428,
-      37429,
-      37430
+      "ISLAND_OF_STONE_CAVE_EXIT",
+      "VIKINGEXILE_PRISON_CAVE_WALL",
+      "VIKINGEXILE_PRISON_CAVETOP",
+      "VIKINGEXILE_PRISON_CAVETOP_FALLOFF_STRAIGHT",
+      "VIKINGEXILE_PRISON_CAVETOP_FALLOFF_INSIDE_CORNER",
+      "VIKINGEXILE_PRISON_CAVETOP_FALLOFF_OUTSIDE_CORNER",
+      "VIKINGEXILE_PRISON_STEPS_BOTTOM",
+      "VIKINGEXILE_PRISON_BOSS_DOOR_LEFT",
+      "VIKINGEXILE_PRISON_BOSS_DOOR_RIGHT",
+      "FREX_PRISON_SNAKE_WALL_CORNER_01",
+      "FREX_PRISON_SNAKE_WALL_CORNER_02",
+      "FREX_PRISON_SNAKE_WALL_STRAIGHT_01",
+      "FREX_PRISON_SNAKE_WALL_STRAIGHT_02",
+      "FREX_PRISON_SNAKE_WALL_STRAIGHT_03",
+      "FREX_PRISON_SNAKE_WALL_STRAIGHT_04"
     ]
   },
   {
     "description": "Island of Stone Dungeon - Old Gate",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      37421,
-      37422
+      "VIKINGEXILE_PRISON_BOSS_DOOR",
+      "VIKINGEXILE_PRISON_BOSS_DOOR_NOOP"
     ],
     "uvType": "BOX"
   },
@@ -18743,8 +18743,8 @@
     "description": "Island of Stone Dungeon - Stalagmite",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      23373,
-      23374
+      "SLICE_STALAGTITE_01",
+      "SLICE_STALAGTITE_02"
     ],
     "uvOrientation": 256
   },
@@ -18752,7 +18752,7 @@
     "description": "Island of Stone Dungeon - Boat Ribs",
     "baseMaterial": "WOOD_GRAIN",
     "objectIds": [
-      4363
+      "VIKING_BOAT_HULL_RIGHT"
     ],
     "uvType": "BOX",
     "uvScale": 0.3
@@ -18761,8 +18761,8 @@
     "description": "Spinning Wheel",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4309,
-      8748
+      "VIKING_SPINNINGWHEEL",
+      "ELF_VILLAGE_SPINNING_WHEEL"
     ],
     "uvType": "BOX"
   },
@@ -18770,7 +18770,7 @@
     "description": "Textured Pottery Oven",
     "textureMaterial": "POTTERY_OVEN_STONE",
     "objectIds": [
-      4308
+      "VIKING_POTTERYOVEN"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -18781,10 +18781,10 @@
     "description": "White Wolf Mountain Pass - Objects - Rock Stairs - Large",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      54,
-      55,
-      56,
-      57
+      "TUNNELSTAIRS",
+      "TUNNELSTAIRSTOP",
+      "TUNNELSTAIRS2",
+      "TUNNELSTAIRSTOP2"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -18793,31 +18793,31 @@
   {
     "description": "Giant Mole Lair - Object - Dirt Floor",
     "baseMaterial": "DIRT_1",
-    "objectIds": [ 12185, 12187, 12188, 12189 ]
+    "objectIds": [ "MOLE_WALL_TOP", "MOLE_WALL_TOP_LVL2", "MOLE_WALL_TOP5_LVL2", "MOLE_WALL_TOP_LVL2_BIG" ]
   },
   {
     "description": "Giant Mole Lair - Walls - Dirt Walls",
     "baseMaterial": "DIRT_2",
-    "objectIds": [ 12175, 12176, 12177, 12178, 12179, 12180, 12181, 12182, 12183, 12184, 12190, 12209, 12214, 12215 ],
+    "objectIds": [ "MOLE_WALL_NO_ROOTS", "MOLE_WALL_NO_ROOTS_LVL2", "MOLE_WALL_NO_ROOTS_LVL2_BIG", "MOLE_WALL_ROOTS_START_01", "MOLE_WALL_ROOTS_START_02", "MOLE_WALL_ROOTS_BEGIN", "MOLE_WALL_ROOTS_PART_A", "MOLE_WALL_ROOTS_PART_B", "MOLE_WALL_ROOTS_PART_C", "MOLE_WALL_ROOTS_LVL2", "MOLE_WALL_TOP5_LVL2_BIG", "MOLE_WALL_RAMP_02", "MOLE_WALL_RAMP_01_MIRROR", "MOLE_WALL_RAMP_02_MIRROR" ],
     "uvType": "BOX"
   },
   {
     "description": "Giant Mole Lair - Walls - Ramp 1",
     "baseMaterial": "DIRT_1",
-    "objectIds": [ 12206, 12207 ],
+    "objectIds": [ "MOLE_RAMP_MID_01", "MOLE_RAMP_MID_02" ],
     "uvType": "BOX"
   },
   {
     "description": "Giant Mole Lair - Walls - Ramp 2",
     "baseMaterial": "DIRT_2",
-    "objectIds": [ 12204, 12205, 12208, 12210, 12211 ],
+    "objectIds": [ "MOLE_RAMP_01", "MOLE_RAMP_02", "MOLE_WALL_RAMP_01", "MOLE_RAMP_01_MIRROR", "MOLE_RAMP_02_MIRROR" ],
     "uvType": "BOX"
   },
   {
     "description": "Zanaris - Objects - Wooden - Stacked Crate - Angled",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16250
+      "FAIRY_CRATES_SMALL_BLUE"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -18828,25 +18828,25 @@
     "description": "Zanaris - Objects - Tree Houses",
     "baseMaterial": "BARK",
     "objectIds": [
-      12070,
-      12071,
-      12072,
-      12073,
-      12074,
-      12075,
-      12076,
-      12077,
-      12078,
-      12079,
-      12080,
-      12081,
-      12082,
-      12083,
-      12084,
-      12085,
-      12086,
-      12087,
-      12088
+      "FAIRY_TREE_1_SPIKE",
+      "FAIRY_TREE_2_NO_SPIKE",
+      "FAIRY_TREE_2_NS1",
+      "FAIRY_TREE_2_NS2",
+      "FAIRY_TREE_2_LFT",
+      "FAIRY_TREE_2_RHT",
+      "FAIRY_TREE_BASE",
+      "FAIRY_TREE_BASE_FAIRYHOUSE",
+      "FAIRY_TREE_ENDS_LFT_RHT",
+      "FAIRY_TREE_ENDS_LFT_RHT_M",
+      "FAIRY_TREE_ENDS_NS",
+      "FAIRY_TREE_ENDS_NS_M",
+      "FAIRY_TREE_LFT_RHT_TOP",
+      "FAIRY_TREE_LFT_RHT_TOP_M",
+      "FAIRY_TREE_NS_TOP",
+      "FAIRY_TREE_NS_TOP_M",
+      "FAIRY_TREE_TOP",
+      "FAIRY_TREE1",
+      "FAIRY_TREE2"
     ],
     "uvType": "BOX"
   },
@@ -18854,7 +18854,7 @@
     "description": "Objects - Wooden - Private Bank Booth Destroyed",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      20324
+      "CONTACT_PRIVATE_BANK_BOOTH_BROKEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.9,
@@ -18865,11 +18865,11 @@
     "description": "Scarab Lair - Objects - Stone - Stalagmite - Huge",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      20305,
-      20306,
-      20307,
-      20309,
-      20310
+      "CONTACT_STALAGMITES_TALL",
+      "CONTACT_STALAGMITES_LARGE_TALL",
+      "CONTACT_STALAGMITES_TWIN_TALL",
+      "CONTACT_STALAGMITES_LARGE_BIG",
+      "CONTACT_STALAGMITES_TWIN_BIG"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -18878,9 +18878,9 @@
     "description": "Scarab Lair - Objects - Stone - Stalagmite - Large",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      20301,
-      20302,
-      20303
+      "CONTACT_STALAGMITES",
+      "CONTACT_STALAGMITES_LARGE",
+      "CONTACT_STALAGMITES_TWIN"
     ],
     "uvType": "BOX"
   },
@@ -18888,8 +18888,8 @@
     "description": "Scarab Lair - Objects - Stone - Stalagmite - Small",
     "baseMaterial": "ROCK_5",
     "objectIds": [
-      20304,
-      20308
+      "CONTACT_STALAGMITES_FALLOFF",
+      "CONTACT_STALAGMITES_FALLOFF_TALL"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -18899,9 +18899,9 @@
     "description": "Scarab Lair - Walls",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      20289,
-      20290,
-      20291
+      "CONTACT_CHASM_EXIT",
+      "CONTACT_UNDERGROUND_WALLS",
+      "CONTACT_UNDERGROUND_TOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -18910,7 +18910,7 @@
     "description": "Sophanem Bank - Plank Trap Door",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      20340
+      "CONTACT_LADDER_BARRICADED"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -18919,7 +18919,7 @@
     "description": "Scarab Lair Stairs - Stone Slab",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      20293
+      "CONTACT_SKEW_STEPS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -18928,7 +18928,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Objects - Stone - Stalagmite - Large",
     "baseMaterial": "ROCK_4",
-    "objectIds": [ 25342, 25343 ],
+    "objectIds": [ "BRUT_STAL1", "BRUT_STAL2" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.78
@@ -18936,7 +18936,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Objects - Stone - Stalagmite - Small",
     "baseMaterial": "ROCK_5",
-    "objectIds": [ 25345 ],
+    "objectIds": [ "BRUT_STAL_FALLOFF" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
@@ -18944,9 +18944,9 @@
     "description": "Fossil Island - Wyvern Task Area - Walls - Stone",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      25296, 25297, 25311, 25312,
-      25313, 25314, 25315, 25316,
-      25317, 25318
+      "BRUT_CAVE_WALL", "BRUT_CAVE_LVL2", "BRUT_CAVE_VAR1_LVL1", "BRUT_CAVE_VAR1_LVL2",
+      "BRUT_CAVE_VAR1_LVL2_M", "BRUT_CAVE_VAR2_LVL1", "BRUT_CAVE_VAR1_LVL1_M", "BRUT_CAVE_VAR2_LVL1_M",
+      "BRUT_CAVE_VAR2_LVL2", "BRUT_CAVE_VAR3_LVL1"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -18955,7 +18955,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Walls - Stone",
     "baseMaterial": "STONE_NORMALED_DARK",
-    "objectIds": [ 25352 ],
+    "objectIds": [ "BRUT_CAVE_TOP_CENTRE" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 256
@@ -18963,7 +18963,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Wall Lip",
     "baseMaterial": "ROCK_4",
-    "objectIds": [ 25321, 25323 ],
+    "objectIds": [ "BRUT_CAVE_LEDGE", "BRUT_CAVE_LEDGE_M" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 256
@@ -18971,7 +18971,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Rock stairs",
     "baseMaterial": "ROCK_3",
-    "objectIds": [ 31485 ],
+    "objectIds": [ "FOSSIL_WYVERN_TASK_STAIRS_1B" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 256
@@ -18980,9 +18980,9 @@
     "description": "Fossil Island - Wyvern Task Area - Objects - Mushroom - Medium",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      14538, 14539, 14541, 14589,
-      14591, 14617, 14618, 14619,
-      14659, 14660, 14661
+      "WILD1_MUSHROOMS_A", "WILD1_MUSHROOMS_B", "WILD1_MUSHROOMS_D", "WILD2_MUSHROOMS_B",
+      "WILD2_MUSHROOMS_D", "WILD3_MUSHROOMS_A", "WILD3_MUSHROOMS_B", "WILD3_MUSHROOMS_C",
+      "WILD4_MUSHROOMS_A", "WILD4_MUSHROOMS_B", "WILD4_MUSHROOMS_C"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -18991,7 +18991,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Objects - Stone - Water Rocks - Large",
     "baseMaterial": "ROCK_5",
-    "objectIds": [ 25344 ],
+    "objectIds": [ "BRUT_STAL3" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.78
@@ -18999,7 +18999,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Wyvern Bones - Large",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 14028 ],
+    "objectIds": [ "WILDERNESS_BONES_BIG_01" ],
     "uvType": "BOX",
     "uvOrientation": 768,
     "uvScale": 0.6
@@ -19007,7 +19007,7 @@
   {
     "description": "Fossil Island - Wyvern Task Area - Objects - Stone - Shrine",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 30851 ],
+    "objectIds": [ "FOSSIL_SLAYER_CAVE_DRAGONKIN_SHRINE" ],
     "uvType": "BOX",
     "uvOrientation": 128,
     "uvScale": 0.78
@@ -19015,28 +19015,28 @@
   {
     "description": "Fossil Island - Objects - Giant Yellow Mushtree",
     "baseMaterial": "GRAY_75",
-    "objectIds": [ 30838, 30839 ]
+    "objectIds": [ "FOSSIL_MUSHROOM_TREE_02_TRUNK", "FOSSIL_MUSHROOM_TREE_02_TOP" ]
   },
   {
     "description": "Fossil Island - Objects - Yellow Mushtree",
     "baseMaterial": "GRAY_75",
-    "objectIds": [ 30834 ]
+    "objectIds": [ "FOSSIL_MUSHROOM_TREE_01" ]
   },
   {
     "description": "Fossil Island - Objects - White Mushtree",
     "baseMaterial": "GRAY_75",
-    "objectIds": [ 30835 ]
+    "objectIds": [ "FOSSIL_MUSHROOM_TREE_BLUE" ]
   },
   {
     "description": "Fossil Island - Objects - Lifelilly",
     "baseMaterial": "GRAY_75",
-    "objectIds": [ 30841 ]
+    "objectIds": [ "FOSSIL_MUSHROOM_LIFELILLY" ]
   },
   {
     "description": "Sorceress Garden Shurb Walls - Spring",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      12721, 12726, 12727, 12728, 12729
+      "_100_OSMAN_TRELLIS_SPRING", "_100_OSMAN_TRELLIS_SPRING_SINGLE", "_100_OSMAN_TRELLIS_SPRING_CORNER", "_100_OSMAN_TRELLIS_SPRING_END", "_100_OSMAN_TRELLIS_SPRING_T"
     ],
     "uvType": "BOX"
   },
@@ -19044,8 +19044,8 @@
     "description": "Sorceress Garden Shurb Walls - Summer",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      11989, 11990, 11991, 11992,
-      11993, 11994, 11995
+      "_100_OSMAN_TRELLIS_SUMMER", "_100_OSMAN_TRELLIS_SUMMER_SINGLE", "_100_OSMAN_TRELLIS_SUMMER_CORNER", "LUNAR_MOONCLAN_SHADOW_ON_GROUND",
+      "_100_OSMAN_TRELLIS_SUMMER_END", "_100_OSMAN_TRELLIS_SUMMER_T", "_100_OSMAN_TRELLIS_SUMMER_X"
     ],
     "uvType": "BOX"
   },
@@ -19053,7 +19053,7 @@
     "description": "Sorceress Garden Shurb Walls - Winter",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      12619, 12620, 12621, 12622
+      "_100_OSMAN_TRELLIS_WINTER", "_100_OSMAN_TRELLIS_WINTER_SINGLE", "_100_OSMAN_TRELLIS_WINTER_CORNER", "_100_OSMAN_TRELLIS_WINTER_END"
     ],
     "uvType": "BOX"
   },
@@ -19061,7 +19061,7 @@
     "description": "Crombwick Maynor - Ground Object - Deck",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      32616
+      "SLEPE_DECKING"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -19071,7 +19071,7 @@
     "description": "Barbarian Outpost - Objects - Wooden - Crate Stack - Small",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11600
+      "FAI_BARBARIAN_SMALL_CRATES"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -19083,8 +19083,8 @@
     "description": "Tirannwn - Lletya - Walls - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8755,
-      8759
+      "ELF_VILLAGE_WALL",
+      "ELF_VILLAGE_WALL_WINDOW"
     ],
     "uvType": "BOX",
     "uvScale": 0.92,
@@ -19094,12 +19094,12 @@
     "description": "Tirannwn - Lletya - Walls - Wooden",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8763,
-      8764,
-      35902,
-      35903,
-      35906,
-      35907
+      "ELF_VILLAGE_OUTWALL",
+      "ELF_VILLAGE_OUTWALLL",
+      "SOTE_ELF_VILLAGE_WALL_BURNT",
+      "SOTE_ELF_VILLAGE_RAIL1_BURNT",
+      "SOTE_ELF_VILLAGE_RAIL2_BURNT",
+      "SOTE_ELF_VILLAGE_WALL_WINDOW_BURNT"
     ],
     "uvType": "BOX",
     "uvScale": 0.92,
@@ -19110,7 +19110,7 @@
     "description": "Tirannwn - Lletya - Walls - Wooden - Angled",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8765
+      "ELF_VILLAGE_OUTWALL2"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -19123,9 +19123,9 @@
     "description": "Tirannwn - Lletya - Fence - Wooden",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8756,
-      8758,
-      35951
+      "ELF_VILLAGE_RAIL1",
+      "ELF_VILLAGE_RAIL2",
+      "ELF_VILLAGE_RAIL1_BLOCKWALK_ONLY"
     ],
     "uvType": "BOX",
     "uvScale": 0.92,
@@ -19136,9 +19136,9 @@
     "description": "Tirannwn - Lletya - Objects - Wooden - Tables - Fine",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8751,
-      20127,
-      35873
+      "ELF_VILLAGE_COUNTER",
+      "ELF_VILLAGE_BANKCOUNTER",
+      "SOTE_ELF_VILLAGE_TABLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -19148,7 +19148,7 @@
     "description": "Tirannwn - Lletya - Objects - Wooden - Tables - Fine - Rounded",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8768
+      "ELF_VILLAGE_TABLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -19158,7 +19158,7 @@
     "description": "Tirannwn - Lletya - Objects - Wooden - Chair - Pointed",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8770
+      "ELF_VILLAGE_CHAIR"
     ],
     "uvType": "BOX",
     "uvScale": 1.0,
@@ -19168,9 +19168,9 @@
     "description": "Tirannwn - Lletya - Objects - Wooden - Bookcase - Textured",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8752,
-      8753,
-      8754
+      "ELF_VILLAGE_BOOKCASE_1",
+      "ELF_VILLAGE_BOOKCASE_2",
+      "ELF_VILLAGE_BOOKCASE_3"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -19181,12 +19181,12 @@
     "description": "Tirannwn - Lletya - Well",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8747,
-      8766,
-      35880,
-      35881,
-      35882,
-      35884
+      "ELF_VILLAGE_WELL",
+      "ELF_VILLAGE_WELL_TOP",
+      "SOTE_WELL_TOP_VIS",
+      "SOTE_WELL_NORMAL",
+      "SOTE_WELL_BROKEN",
+      "SOTE_WELL_BUILT"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -19203,7 +19203,7 @@
     "description": "Tirannwn - Lletya - Grave",
     "baseMaterial": "MARBLE_3",
     "objectIds": [
-      35914
+      "SOTE_GRAVE_VIS"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -19212,8 +19212,8 @@
     "description": "Tirannwn - Lletya - Cooking Range",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      8750,
-      35877
+      "ELF_VILLAGE_RANGE",
+      "SOTE_ELF_VILLAGE_RANGE"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -19229,7 +19229,7 @@
     "description": "Tirannwn - Lletya - Rope Barrier",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8780
+      "ELF_VILLAGE_MUSEUMBARRIERS"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -19248,7 +19248,7 @@
     "description": "Tirannwn - Lletya - Shelves with Thread",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      8776
+      "ELF_VILLAGE_CLOTHES_SHELVES"
     ],
     "colorOverrides": [
       {
@@ -19263,8 +19263,8 @@
     "description": "Tirannwn - Lletya - Clothes Model",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      8778,
-      8779
+      "ELF_VILLAGE_CLOTHESMODEL1",
+      "ELF_VILLAGE_CLOTHESMODEL2"
     ],
     "colorOverrides": [
       {
@@ -19279,8 +19279,8 @@
     "description": "Tirannwn - Lletya - Wall Mounted Crossbow and Arrows Main",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8773,
-      8775
+      "ELF_VILLAGE_HANGING_BOW_AND_ARROW",
+      "ELF_VILLAGE_HANGING_ARROWS"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -19301,8 +19301,8 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "areas": [ "Lletya Crossbow Fix" ],
     "objectIds": [
-      8773,
-      8775
+      "ELF_VILLAGE_HANGING_BOW_AND_ARROW",
+      "ELF_VILLAGE_HANGING_ARROWS"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -19317,10 +19317,10 @@
     "description": "Underground Pass - Dwarven Camp - Ground - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      14184,
-      14185,
-      14186,
-      14187
+      "KOUREND_SHAY_FOOTPATH_14",
+      "KOUREND_SHAY_FOOTPATH_15",
+      "KOUREND_SHAY_FOOTPATH_16",
+      "KOUREND_SHAY_FOOTPATH_17"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -19329,8 +19329,8 @@
     "description": "Underground Pass - Dwarven Camp - Ground - Explosives Hole",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      35888,
-      35889
+      "SOTE_UPASS_HOLE_OPEN_OP",
+      "SOTE_UPASS_HOLE_FILLED"
     ],
     "uvType": "BOX",
     "uvScale": 0.57
@@ -19339,8 +19339,8 @@
     "description": "Underground Pass - Spear Wall",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      849,
-      34938
+      "SPEARWALL_ROW2",
+      "SPEARWALL_SKEW"
     ],
     "colorOverrides": [
       {
@@ -19355,7 +19355,7 @@
     "description": "Underground Pass - Spear Wall",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "npcIds": [
-      8951
+      "SOTE_UPASS_BARRIER"
     ],
     "colorOverrides": [
       {
@@ -19371,7 +19371,7 @@
     "description": "Underground Pass - Catapult",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      671
+      "CATAPULT"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -19380,12 +19380,12 @@
     "description": "Mourners Tunnels - Walls - Dirt",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      8822,
-      8823,
-      9746,
-      9747,
-      24977,
-      24978
+      "MOURNING_CAVEWALL_FACE1",
+      "MOURNING_SHORTER_CAVEWALL_FACE1",
+      "MOURNING_CAVEWALL_CANDLE_FACE1",
+      "MOURNING_SHORTER_CAVEWALL_CANDLE_FACE1",
+      "DARKBOW_WALL_BACK",
+      "DARKBOW_WALL_BACK_CORNER"
     ],
     "uvType": "BOX",
     "uvScale": 0.68,
@@ -19395,10 +19395,10 @@
     "description": "Mourners Tunnels - Wall Caps - Dirt",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      24980,
-      24981,
-      24982,
-      24983
+      "DARKBOW_WALL_BACK_CORNER_BLEND_MIRROR",
+      "DARKBOW_CAVEWALL_TOP",
+      "DARKBOW_CAVEWALL_TOP5",
+      "DARKBOW_CAVEWALL_TOP_SHORT"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.68
@@ -19407,10 +19407,10 @@
     "description": "Metallic - Minecart",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      637,
-      4918,
-      4974,
-      8831
+      "MINECART",
+      "HAUNTEDMINE_OBSTACLE_CART",
+      "HAUNTEDMINE_PUZZLE_CART",
+      "MOURNING_MINECART"
     ],
     "uvType": "BOX",
     "uvScale": 0.68
@@ -19419,8 +19419,8 @@
     "description": "Object - Apple Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      8842,
-      8843
+      "MOURNING_ORCHARD_APPLETREE_NO_APPLES",
+      "MOURNING_ORCHARD_APPLETREE_WITH_APPLES"
     ],
     "uvType": "BOX"
   },
@@ -19428,8 +19428,8 @@
     "description": "West Ardougne - Walls - Wooden - Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11407,
-      11408
+      "REHNISON_HOUSE_WALL",
+      "REHNISON_HOUSE_WINDOW"
     ],
     "uvType": "BOX",
     "uvScale": 1.2,
@@ -19439,7 +19439,7 @@
   {
     "description": "Mos Le Harmless - Objects - Cave Entrance",
     "baseMaterial": "ROCK_1",
-    "objectIds": [ 3650, 3651, 3652, 3752, 3753, 3754 ],
+    "objectIds": [ "HARMLESS_CAVE_ENTRANCE_LEFT", "HARMLESS_CAVE_ENTRANCE_RIGHT", "HARMLESS_CAVE_FILLER_LEFT", "HARMLESS_CAVE_FILLER_RIGHT", "HARMLESS_CAVE_ROCKS_LEFT", "HARMLESS_CAVE_ROCKS_RIGHT" ],
     "uvType": "BOX",
     "uvOrientation": 256,
     "uvScale": 0.9
@@ -19447,14 +19447,14 @@
   {
     "description": "Fossil Island - Outhouse Walls and Lumbridge Swamp Shack",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 10372, 10373, 11763, 15054, 33610, 33611 ],
+    "objectIds": [ "FARMING_SHED_WALL", "FARMING_SHED_WALL_WINDOW", "HOS_GRAPE_ODDDOOR", "FARMING_SHED_ROOF_MID2", "FARMING_SHED_WALL_DAMAGED_SIDE", "FARMING_SHED_WALL_DAMAGED_MID" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Lumbridge Shack Roof - Corners",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 10367, 10368, 10369, 10370, 15055 ],
+    "objectIds": [ "FARMING_SHED_ROOF_EDGE", "FARMING_SHED_ROOF_EDGE_2", "FARMING_SHED_ROOF_EDGE_2_MIRROR", "FARMING_SHED_ROOF_EDGE_MIRROR", "FARMING_SHED_ROOF_MID_EDGE2" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationZ": 512
@@ -19462,7 +19462,7 @@
   {
     "description": "Fossil Island - Outhouse Top and Evil Daves Moms house, Lumbridge Shack",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 10364, 10365, 10366, 12283, 12284, 12285, 12286, 12287, 12290],
+    "objectIds": [ "FARMING_SHED_ROOF1", "FARMING_SHED_ROOF2", "FARMING_SHED_ROOF", "_100_DAVE_ROOFTOP1", "_100_DAVE_ROOFTOP2", "_100_DAVE_ROOFTOP1_MIRROR", "_100_DAVE_ROOFTOP2_MIRROR", "_100_DAVE_ROOF_RIM", "_100_DAVE_ROOFTOPEDGE_FLAT"],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512
@@ -19470,7 +19470,7 @@
   {
     "description": "Daves Moms House Roof - Corner",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 12288, 12289 ],
+    "objectIds": [ "_100_DAVE_ROOFTOPEDGE", "_100_DAVE_ROOFTOPEDGE_MIRROR" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -19479,7 +19479,7 @@
   {
     "description": "Daves Moms House Walls",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 12278 ],
+    "objectIds": [ "_100_DAVE_WALLS" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -19488,29 +19488,29 @@
   {
     "description": "Fossil Island - Stone - Manor Walls",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 30672, 30675, 30676, 30677 ],
+    "objectIds": [ "FOSSIL_DKL_WALL_1", "FOSSIL_DKL_WALLROOF1", "FOSSIL_DKL_WALLROOF2", "FOSSIL_DKL_WINDOW_1" ],
     "uvType": "BOX",
     "uvScale": 0.5,
     "uvOrientation": 768
   },
   {
     "description": "Pest Control boat flags",
-    "objectIds": [ 25621, 25622, 25625 ],
+    "objectIds": [ "PEST_INTERMEDIATE_BANNER_PIER", "PEST_VETERAN_BANNER_PIER", "PEST_VETERAN_BANNER_LANDER_TOP" ],
     "flatNormals": true
   },
   {
     "description": "Objects - Metallic - Metallic Ladder",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
-    "objectIds": [ 11806 ],
+    "objectIds": [ "FAI_VARROCK_MANHOLE_LADDER" ],
     "uvType": "BOX"
   },
   {
     "description": "Varrock Sewers - Objects - Metallic - Scurrius Entrance Bars",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      14203, 14207, 14208, 14839,
-      27120, 27123, 27124, 27125,
-      27126, 27127, 27128
+      "RAT_BOSS_ENTRANCE", "DUNGEONKIT_BARS01_SLOPE01", "DUNGEONKIT_BARS02_EDGE01", "DUNGEONKIT_BARS03_SLOPE02",
+      "DUNGEONKIT_BARS01_LEFT01", "DUNGEONKIT_BARS01_RIGHT01", "DUNGEONKIT_BARS02_LEFT01", "DUNGEONKIT_BARS02_RIGHT01",
+      "DUNGEONKIT_BARS03_LEFT01", "DUNGEONKIT_BARS03_RIGHT01", "DUNGEONKIT_BARS03_BROKEN01"
     ],
     "uvType": "BOX",
     "uvOrientation": 128
@@ -19518,7 +19518,7 @@
   {
     "description": "Ground Objects - Wooden - Planks",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 42416, 42417, 42418, 42419 ],
+    "objectIds": [ "DECOKIT_PLANKS_EDGE01", "DECOKIT_PLANKS_EDGE02", "DECOKIT_PLANKS_EDGE03", "DECOKIT_PLANKS_EDGE04" ],
     "uvType": "BOX",
     "uvOrientation": 512,
     "uvScale": 1.1
@@ -19526,7 +19526,7 @@
   {
     "description": "Ground Objects - Wooden - Planks - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 42420 ],
+    "objectIds": [ "DECOKIT_PLANKS_CORNER01" ],
     "uvType": "BOX",
     "uvOrientation": 320,
     "uvScale": 1.1
@@ -19534,7 +19534,7 @@
   {
     "description": "Ground Objects - Wooden - Planks - Rotated",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 42421 ],
+    "objectIds": [ "DECOKIT_PLANKS_CORNER02" ],
     "uvType": "BOX",
     "uvOrientation": 700,
     "uvScale": 1.1
@@ -19542,7 +19542,7 @@
   {
     "description": "Ground Objects - Wooden - Planks - Diag",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [  42422, 42423 ],
+    "objectIds": [  "DECOKIT_PLANKS_CORNER03", "DECOKIT_PLANKS_CORNER04" ],
     "uvType": "BOX",
     "uvOrientation": 256,
     "uvScale": 1.1
@@ -19550,7 +19550,7 @@
   {
     "description": "Objects - Scurrius Ceiling Roots",
     "baseMaterial": "LIGHT_BARK",
-    "objectIds": [ 50001, 50002 ],
+    "objectIds": [ "RAT_BOSS_ROOTS01", "RAT_BOSS_ROOTS02" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 342
@@ -19558,7 +19558,7 @@
   {
     "description": "Objects - Scurrius Roots",
     "baseMaterial": "LIGHT_BARK",
-    "objectIds": [ 50005, 50006, 50007, 50008, 50009, 50010 ],
+    "objectIds": [ "RAT_BOSS_THORNSKIT01", "RAT_BOSS_THORNSKIT02", "RAT_BOSS_ROOTS01_GROUND01", "RAT_BOSS_ROOTS02_GROUND01", "RAT_BOSS_ROOTS03_GROUND01", "RAT_BOSS_ROOTS04_GROUND01" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 342
@@ -19569,7 +19569,7 @@
     "retainVanillaShadowsInPvm": true,
     "hideHdShadowsInPvm": true,
     "projectileIds": [
-      1357
+      "OLM_CRYSTALROCK_FALLING"
     ]
   },
   {
@@ -19577,21 +19577,21 @@
     "hideVanillaShadows": true,
     "retainVanillaShadowsInPvm": true,
     "npcIds": [
-      8371,
-      8372,
-      8373,
-      8374,
-      8375,
-      10832,
-      10833,
-      10834,
-      10835,
-      10836,
-      10849,
-      10850,
-      10851,
-      10852,
-      10853
+      "VERZIK_PHASE1_TO2_TRANSITION",
+      "VERZIK_PHASE2",
+      "VERZIK_PHASE2_TO3_TRANSITION",
+      "VERZIK_PHASE3",
+      "VERZIK_DEATH_BAT",
+      "VERZIK_PHASE1_TO2_TRANSITION_STORY",
+      "VERZIK_PHASE2_STORY",
+      "VERZIK_PHASE2_TO3_TRANSITION_STORY",
+      "VERZIK_PHASE3_STORY",
+      "VERZIK_DEATH_BAT_STORY",
+      "VERZIK_PHASE1_TO2_TRANSITION_HARD",
+      "VERZIK_PHASE2_HARD",
+      "VERZIK_PHASE2_TO3_TRANSITION_HARD",
+      "VERZIK_PHASE3_HARD",
+      "VERZIK_DEATH_BAT_HARD"
     ]
   },
   {
@@ -19599,19 +19599,19 @@
     "hideVanillaShadows": true,
     "retainVanillaShadowsInPvm": true,
     "npcIds": [
-      8338,
-      8339,
-      8340,
-      8341,
-      10766,
-      10767,
-      10768,
-      10769,
-      10770,
-      10771,
-      10772,
-      10773,
-      11187
+      "TOB_XARPUS_STATIC",
+      "TOB_XARPUS_FEEDING",
+      "TOB_XARPUS_COMBAT",
+      "XARPUS_DEATH",
+      "TOB_XARPUS_STATIC_STORY",
+      "TOB_XARPUS_FEEDING_STORY",
+      "TOB_XARPUS_COMBAT_STORY",
+      "XARPUS_DEATH_STORY",
+      "TOB_XARPUS_STATIC_HARD",
+      "TOB_XARPUS_FEEDING_HARD",
+      "TOB_XARPUS_COMBAT_HARD",
+      "XARPUS_DEATH_HARD",
+      "TOBQUEST_XARPUS"
     ]
   },
   {
@@ -19619,24 +19619,24 @@
     "hideVanillaShadows": true,
     "retainVanillaShadowsInPvm": true,
     "npcIds": [
-      7674,
-      7675,
-      7691,
-      7692,
-      7693,
-      7694,
-      7695,
-      7696,
-      7697,
-      7698,
-      7699,
-      7700,
-      7702,
-      7703,
-      7704,
-      10620,
-      10623,
-      10625
+      "POH_INFERNO_PET",
+      "INFERNO_PET",
+      "INFERNO_NIBBLER",
+      "INFERNO_CREATURE_HARPIE",
+      "INFERNO_CREATURE_SPLITTER",
+      "INFERNO_CREATURE_SPLITTER_MAGE",
+      "INFERNO_CREATURE_SPLITTER_RANGE",
+      "INFERNO_CREATURE_SPLITTER_MELEE",
+      "INFERNO_CREATURE_MELEE",
+      "INFERNO_CREATURE_RANGER",
+      "INFERNO_CREATURE_MAGER",
+      "INFERNO_JAD",
+      "INFERNO_RANGER_FINALWAVE",
+      "INFERNO_MAGER_FINALWAVE",
+      "INFERNO_JAD_FINALWAVE",
+      "POH_JADPET_INFERNO",
+      "JAD_CHALLENGE_JAD",
+      "JADPET_INFERNO"
     ]
   },
   {
@@ -19644,12 +19644,12 @@
     "hideVanillaShadows": true,
     "retainVanillaShadowsInPvm": true,
     "npcIds": [
-      11790,
-      11791,
-      11792,
-      11793,
-      11794,
-      11795
+      "AKKHA_MELEE",
+      "AKKHA_RANGE",
+      "AKKHA_MAGE",
+      "AKKHA_ENRAGE_SPAWN",
+      "AKKHA_ENRAGE_INITIAL",
+      "AKKHA_ENRAGE"
     ]
   },
   {
@@ -19658,12 +19658,12 @@
     "retainVanillaShadowsInPvm": true,
     "hideHdShadowsInPvm": true,
     "graphicsObjectIds": [
-      1449,
-      1889,
-      1890,
-      1938
+      "GARGBOSS_DEBRIS_SHADOW_180",
+      "GARGBOSS_DEBRIS_SHADOW_210",
+      "GARGBOSS_DEBRIS_SHADOW_240",
+      "GARGBOSS_DEBRIS_SHADOW_270"
     ],
-    "projectileIds": [ 1435 ]
+    "projectileIds": [ "GG_FALLING_PROJECTILE" ]
   },
   {
     "description": "Falling rocks at Scurrius",
@@ -19671,13 +19671,13 @@
     "retainVanillaShadowsInPvm": true,
     "hideHdShadowsInPvm": true,
     "graphicsObjectIds": [
-      2644
+      "VFX_RAT_BOSS_FALLING_DEBRIS_01"
     ]
   },
   {
     "description": "Fishing Trawler Boat - Walls - Minigame Hull",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 37351, 37352 ],
+    "objectIds": [ "TRAWLER_HULL_LEAK", "TRAWLER_HULL_PATCHED" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientation": 512
@@ -19686,11 +19686,11 @@
     "description": "Plank Boat - Walls - Wooden - Hull",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      230, 234, 235, 236,
-      237, 238, 240, 242,
-      253, 281, 283, 284,
-      14512, 37350, 37353,
-      37354, 37356, 37365
+      "SHIPHIGHERWALL_LOW", "SHIPHULL", "SHIPHULL_FILLEDL", "SHIPHULL_FILLEDR",
+      "SHIP_FULLWALL", "SHIPHULL_DIAG", "SHIPHULL_FILLER", "SHIPHULL_CANNONOPEN",
+      "STERN", "SHIPHULL_BROKEN", "SHIPHULL_DAMAGED_L", "SHIPHULL_DAMAGED_R",
+      "SHIPHULL_DAMAGED_MIDDLE_FLOOR", "TRAWLER_HULL_DEFAULT", "TRAWLER_HULL_00",
+      "TRAWLER_HULL_01", "TRAWLER_HULL_03", "TRAWLER_HULL_12"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -19700,7 +19700,7 @@
   {
     "description": "Plank Boat - Walls - Wooden - Hull Aft",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 231, 232, 233 ],
+    "objectIds": [ "SHIPHIGHERWALL_BACK", "SHIPHIGHERWALL_BACKEDGEL", "SHIPHIGHERWALL_BACKEDGER" ],
     "uvType": "BOX",
     "uvScale": 0.85,
     "uvOrientationZ": 512,
@@ -19709,7 +19709,7 @@
   {
     "description": "Plank Boat - Walls - Wooden - Hull with Porthole",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 243 ],
+    "objectIds": [ "SHIPHULL_PORTHOLE" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientationZ": 512,
@@ -19718,7 +19718,7 @@
   {
     "description": "Plank Boat - Walls - Wooden - Hull with Bow Supports",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 257, 258 ],
+    "objectIds": [ "FRONTMAST_SUPPORTL", "FRONTMAST_SUPPORTR" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientationZ": 512,
@@ -19727,7 +19727,7 @@
   {
     "description": "Plank Boat - Walls - Wooden - Hull Bow with Woman",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 260 ],
+    "objectIds": [ "FRONTMAST_SUPPORT_BUST" ],
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientationZ": 512,
@@ -19736,7 +19736,7 @@
   {
     "description": "Plank Boat - Wooden - Deck",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 9454, 9457, 9458, 9460, 9461, 9462 ],
+    "objectIds": [ "SARIM_SHIPFLOOR_MIRROR", "SARIM_SHIPFLOOR_HALF", "SARIM_SHIPFLOOR_HALF_MIRROR", "SARIM_SHIPFLOOR_DAMAGED_L", "SARIM_SHIPFLOOR_DAMAGED_R", "SARIM_SHIPFLOOR_DAMAGED2_L" ],
     "uvType": "BOX",
     "uvScale": 1.0,
     "uvOrientation": 512
@@ -19744,7 +19744,7 @@
   {
     "description": "Plank Boat - Wooden - Rails",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 249, 2197, 2213, 9512, 41401, 11258 ],
+    "objectIds": [ "SHIPRAIL", "TRAWLERNET_RAISED_L_BASE3_NOHULL", "TRAWLERNET_RAISED_R_BASE3_NOHULL", "SHIPRAIL_FOR_CANNONS", "TRAWLER_SHIPRAIL_INACTIVE", "FEVER_SHIPRAIL" ],
     "uvType": "BOX",
     "uvScale": 1.1,
     "uvOrientation": 512
@@ -19752,7 +19752,7 @@
   {
     "description": "Plank Boat - Wooden - Bowsprit",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 256 ],
+    "objectIds": [ "FRONTMAST" ],
     "uvType": "BOX",
     "uvScale": 1.1,
     "uvOrientation": 512
@@ -19760,7 +19760,7 @@
   {
     "description": "Plank Boat - Wooden - Ship's Ladder",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 245, 246, 272, 273 ],
+    "objectIds": [ "SHIPLADDER_ANGLED", "SHIPLADDER_TOP_ANGLED", "SHIP_LADDER", "SHIP_LADDERTOP" ],
     "uvType": "BOX",
     "uvScale": 1.1,
     "uvOrientation": 512
@@ -19769,9 +19769,9 @@
     "description": "Plank Boat - Wooden - Mast and Helm",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      252,
-      262,
-      263
+      "STEERINGWHEEL",
+      "MAST2",
+      "MAST3"
     ],
     "uvType": "BOX"
   },
@@ -19779,14 +19779,14 @@
     "description": "Object - Metal - Anchor",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      271
+      "ANCHOR"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Fishing Trawler Boat - Wooden - Deck Opening",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 291, 292, 9459 ],
+    "objectIds": [ "SHIP_HOLD_CORNER", "SHIP_HOLD_STRAIGHT", "SARIM_SHIPFLOOR_HOLE" ],
     "uvType": "BOX",
     "uvScale": 1.1,
     "uvOrientation": 512
@@ -19795,20 +19795,20 @@
     "description": "Object - Wooden - Gang Plank",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      69, 70, 2081, 2082,
-      2083, 2084, 2085, 2086,
-      2087, 2088, 2412, 2413,
-      2593, 2594, 4977, 4978,
-      11211, 11212, 14304, 14305,
-      17392, 17393, 17394, 17395,
-      17396, 17397, 17398, 17399,
-      17400, 17401, 17402, 17403,
-      17404, 17405, 17406, 17407,
-      17408, 17409, 27777, 27778,
-      29723, 29724, 31756, 34667,
-      34668, 34669, 34670, 34671,
-      34672, 50063, 50064, 50065,
-      50066
+      "ARHEIN_SHIP_ON", "ARHEIN_SHIP_OFF", "SARIMSHIPPLANK_ON", "SARIMSHIPPLANK_OFF",
+      "KARAMJASHIPPLANK_ON", "KARAMJASHIPPLANK_OFF", "BRIMHAVENSHIPPLANK_ON", "BRIMHAVENSHIPPLANK_OFF",
+      "ARDOUGNESHIPPLANK_ON", "ARDOUGNESHIPPLANK_OFF", "SHIP_TO_ENTRANA_ON", "SHIP_TO_ENTRANA_OFF",
+      "DRAGONSHIPGANGPLANK_ON", "DRAGONSHIPGANGPLANK_OFF", "TRAWLER_GANGPLANK", "TRAWLER_GANGPLANKOFF",
+      "FEVER_GANGPLANK_HARMLESS", "FEVER_GANGPLANK_EXIT_HARMLESS", "PEST_SHIP_SARIM_ON", "PEST_SHIP_SARIM_OFF",
+      "SAILING_PHANTASMYS_SHIPPLANK_ON", "SAILING_PHANTASMYS_SHIPPLANK_OFF", "SAILING_CATHERBY_SHIPPLANK_ON", "SAILING_CATHERBY_SHIPPLANK_OFF",
+      "SAILING_SHIPYARD_SHIPPLANK_ON", "SAILING_SHIPYARD_SHIPPLANK_OFF", "SAILING_KARAMJA_SHIPPLANK_ON", "SAILING_KARAMJA_SHIPPLANK_OFF",
+      "SAILING_BRIMHAVEN_SHIPPLANK_ON", "SAILING_BRIMHAVEN_SHIPPLANK_OFF", "SAILING_PORT_KHAZARD_SHIPPLANK_ON", "SAILING_PORT_KHAZARD_SHIPPLANK_OFF",
+      "SAILING_PORT_SARIM_SHIPPLANK_ON", "SAILING_PORT_SARIM_SHIPPLANK_OFF", "SAILING_PORT_HARMLESS_SHIPPLANK_ON", "SAILING_PORT_HARMLESS_SHIPPLANK_OFF",
+      "SAILING_PORT_TYRAS_SHIPPLANK_ON", "SAILING_PORT_TYRAS_SHIPPLANK_OFF", "ZEAH_TRAVEL_KOUREND_SHIPPLANK_ON", "ZEAH_TRAVEL_KOUREND_SHIPPLANK_OFF",
+      "ZEAH_TRAVEL_LANDSEND_SHIPPLANK_ON", "ZEAH_TRAVEL_LANDSEND_SHIPPLANK_OFF", "DS2_CORSAIR_COVE_SHIPPLANK", "SAILING_RIMMINGTON_SHIPPLANK_ON",
+      "SAILING_RIMMINGTON_SHIPPLANK_OFF", "SAILING_RIMMINGTON_SHIPPLANK2_ON", "SAILING_RIMMINGTON_SHIPPLANK2_OFF", "SAILING_SARIM_VEOS_SHIPPLANK_ON",
+      "SAILING_SARIM_VEOS_SHIPPLANK_OFF", "ZEAH_TRAVEL_KOUREND_SHIPPLANK_ON_2", "ZEAH_TRAVEL_KOUREND_SHIPPLANK_OFF_2", "ZEAH_TRAVEL_LANDSEND_SHIPPLANK_ON_2",
+      "ZEAH_TRAVEL_LANDSEND_SHIPPLANK_OFF_2"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -19817,14 +19817,14 @@
   {
     "description": "Port Phasmatys - Object - Wooden - Rotting Gang Plank",
     "baseMaterial": "WOOD_GRAIN_2",
-    "objectIds": [ 5304, 5305 ],
+    "objectIds": [ "AHOY_SHIP_GANGPLANK_GET_ON", "AHOY_SHIP_GANGPLANK_GET_OFF" ],
     "uvType": "BOX",
     "uvScale": 0.75
   },
   {
     "description": "Mos LeHarmless - Large Boat - Walls - Wooden - Hull",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 11251, 11252, 11255, 11257, 11259, 11260 ],
+    "objectIds": [ "FEVER_SHIPHULL_TALL", "FEVER_SHIPHULL", "FEVER_SHIPHULL_DIAG", "FEVER_SHIPHULL_FILLER", "FEVER_SHIPHIGHERWALL_LOW", "FEVER_SHIPHIGHERWALL_LOW2" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientationZ": 512,
@@ -19833,7 +19833,7 @@
   {
     "description": "Mos LeHarmless - Large Boat - Walls - Wooden - Hull Aft",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 11261, 11262, 11263 ],
+    "objectIds": [ "FEVER_SHIPHIGHERWALL_BACK", "FEVER_SHIPHIGHERWALL_BACKEDGEL", "FEVER_SHIPHIGHERWALL_BACKEDGER" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientation": 512
@@ -19841,7 +19841,7 @@
   {
     "description": "Mos LeHarmless - Large Boat - Walls - Wooden - Hull with Porthole",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 11253 ],
+    "objectIds": [ "FEVER_SHIPHULL_PORTHOLE" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientationZ": 512,
@@ -19850,7 +19850,7 @@
   {
     "description": "Mos LeHarmless - Large Boat - Walls - Wooden - Hull with Bow Supports",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 11284, 11285 ],
+    "objectIds": [ "FEVER_FRONTMAST_SUPPORTL", "FEVER_FRONTMAST_SUPPORTR" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientationZ": 512,
@@ -19859,7 +19859,7 @@
   {
     "description": "Mos LeHarmless - Large Boat - Wooden - Deck",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 11264 ],
+    "objectIds": [ "FEVER_SHIPFLOOR" ],
     "uvType": "BOX",
     "uvScale": 1.0,
     "uvOrientation": 512
@@ -19867,7 +19867,7 @@
   {
     "description": "Port Phasmatys - Large Boat - Walls - Wooden - Hull",
     "baseMaterial": "WOOD_GRAIN_2",
-    "objectIds": [ 5385, 5387, 5388, 5399 ],
+    "objectIds": [ "AHOY_GHOSTSHIPHULL", "AHOY_GHOSTSHIPHULL_DIAG", "AHOY_GHOSTSHIPHULL_FILLER", "AHOY_GHOSTSHIPHIGHERWALL_LOW" ],
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientationY": 512
@@ -19875,7 +19875,7 @@
   {
     "description": "Port Phasmatys - Large Boat - Walls - Wooden - Hull with Porthole",
     "baseMaterial": "WOOD_GRAIN_2",
-    "objectIds": [ 5386 ],
+    "objectIds": [ "AHOY_GHOSTSHIPHULL_PORTHOLE" ],
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientationY": 512
@@ -19883,7 +19883,7 @@
   {
     "description": "Port Phasmatys - Large Boat - Walls - Wooden - Hull with Bow Supports",
     "baseMaterial": "WOOD_GRAIN_2",
-    "objectIds": [ 5395, 5396 ],
+    "objectIds": [ "AHOY_GHOSTSHIPFRONTMAST_SUPPORTL", "AHOY_GHOSTSHIPFRONTMAST_SUPPORTR" ],
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientationY": 512
@@ -19891,7 +19891,7 @@
   {
     "description": "Port Phasmatys - Large Boat - Wooden - Deck",
     "baseMaterial": "WOOD_GRAIN_2",
-    "objectIds": [ 5389, 5390, 5391 ],
+    "objectIds": [ "AHOY_GHOSTSHIPFLOOR", "AHOY_GHOSTSHIPFLOOR_MIRROR", "AHOY_GHOSTSHIPFLOOR_HALF" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 512
@@ -19899,14 +19899,14 @@
   {
     "description": "Port Phasmatys - Large Boat - Wooden - Rails",
     "baseMaterial": "WOOD_GRAIN_2",
-    "objectIds": [ 5398 ],
+    "objectIds": [ "AHOY_GHOSTSHIPRAIL" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Isle of Souls Dungeon - Walls - Rock Walls",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 37854, 37859 ],
+    "objectIds": [ "SANCTUARY_CAVE_WALL_OUTER", "SANCTUARY_CAVE_WALL_UPPER" ],
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientation": 768
@@ -19914,7 +19914,7 @@
   {
     "description": "Isle of Souls Dungeon - Objects - Dungeon Entrance",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 40737 ],
+    "objectIds": [ "SW_DUNGEON_EXIT" ],
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientation": 768
@@ -19922,14 +19922,14 @@
   {
     "description": "Objects - Rock - Brown Rock - Mineable rock models",
     "baseMaterial": "ROCK_5",
-    "objectIds": [ 8828, 8829, 8830 ],
+    "objectIds": [ "MOURNING_ROCKS1", "MOURNING_ROCKS2", "MOURNING_ROCKS3" ],
     "uvType": "BOX",
     "uvOrientation": 128
   },
   {
     "description": "Temple of Light Walls",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 9748, 9977, 9978, 9979, 10023, 10024, 10025, 10026, 10027, 10032 ],
+    "objectIds": [ "MOURNING_TEMPLE_LIGHT_WALL_COLLECTOR", "MOURNING_TEMPLE_LIGHT_WALL_WITH_HOLE", "MOURNING_TEMPLE_LADDER_WALL", "MOURNING_TEMPLE_LADDER_WALL_TOP", "MOURNING_TEMPLE_WALL_HOLE", "MOURNING_TEMPLE_WALL", "MOURNING_TEMPLE_WALL_TABLET", "MOURNING_TEMPLE_WALL_TOP", "MOURNING_TEMPLE_WALL_DAMAGED", "MOURNING_TEMPLE_WALL_SUPPORT" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientation": 128
@@ -19937,7 +19937,7 @@
   {
     "description": "Temple of Light Walls - Trapt",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 10034],
+    "objectIds": [ "MOURNING_TEMPLE_BLADE_WALL"],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientation": 128
@@ -19945,7 +19945,7 @@
   {
     "description": "Temple of Light - Objects - Stairs - Narrow",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 10017, 10018 ],
+    "objectIds": [ "MOURNING_TEMPLE_STAIRS_BASE", "MOURNING_TEMPLE_STAIRS_TOP" ],
     "uvType": "BOX",
     "uvScale": 0.7,
     "uvOrientation": 338
@@ -19953,13 +19953,13 @@
   {
     "description": "Temple of Light - Objects - Stairs - Wide",
     "baseMaterial": "MARBLE_1",
-    "objectIds": [ 10015, 10016 ],
+    "objectIds": [ "MOURNING_TEMPLE_CIRCLE_STAIRS_BASE", "MOURNING_TEMPLE_CIRCLE_STAIRS_TOP" ],
     "uvType": "BOX"
   },
   {
     "description": "Temple of Light - Objects - Wall Rubble - Huge",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 9990 ],
+    "objectIds": [ "MOURNING_LIGHT_BLOCK1" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 370
@@ -19967,28 +19967,28 @@
   {
     "description": "Temple of Light - Objects - Wall Rubble - Medium",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 10028 ],
+    "objectIds": [ "MOURNING_TEMPLE_BRICKS_LOOSE" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Temple of Light - Objects - Low Wall",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 10035 ],
+    "objectIds": [ "MOURNING_TEMPLE_WALL_JUMP" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Temple of Light - Objects - Rope Rock",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 10036 ],
+    "objectIds": [ "MOURNING_TEMPLE_WAY_DOWN" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Temple of Light - Objects - Stone Pillars",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
-    "objectIds": [ 10019, 10020, 10021, 10022 ],
+    "objectIds": [ "MOURNING_TEMPLE_PILLAR", "MOURNING_TEMPLE_PILLAR_BASE", "MOURNING_TEMPLE_PILLAR_MIDDLE", "MOURNING_TEMPLE_PILLAR_TOP" ],
     "uvType": "BOX"
   },
   {
@@ -19996,30 +19996,30 @@
     "baseMaterial": "ABYSSAL",
     "areas": [ "ABYSSAL_AREAS" ],
     "objectIds": [
-      20737,
-      25382,
-      25384,
-      26150,
-      26151,
-      26152,
-      26153,
-      26155,
-      26156,
-      26157,
-      26158,
-      26961,
-      26962,
-      26963,
-      26964,
-      26965,
-      26966,
-      26967,
-      26968,
-      26969,
-      26970,
-      26971,
-      27027,
-      27054
+      "BARROWS_MOUNTAIN_CAVEWALL_TOP",
+      "RCU_OUTER_ENTRANCE_ACTIVE_INNER",
+      "RCU_OUTER_ENTRANCE",
+      "RCU_ABYSSAL_WALL",
+      "RCU_ABYSSAL_WALL_HIGH",
+      "RCU_ABYSSAL_WALL_TEST",
+      "RCU_ABYSSAL_WALL_BULGE",
+      "RCU_ABYSSALWALL_TOP5",
+      "RCU_ABYSSALWALL_TOP_OUTER",
+      "RCU_ABYSSALWALL_TOP5_OUTER",
+      "RCU_ABYSSALWALL_TOP5_OUTER2",
+      "NEXUS_ABYSS_WALL_01",
+      "NEXUS_ABYSS_WALL_02",
+      "NEXUS_ABYSS_WALL_03",
+      "NEXUS_ABYSS_WALL_04",
+      "NEXUS_ABYSS_WALL_05",
+      "NEXUS_ABYSS_WALL_06",
+      "NEXUS_ABYSS_WALL_TOP_EDGE",
+      "NEXUS_ABYSS_WALL_TOP_CORNER",
+      "NEXUS_ABYSS_WALL_TOP_EDGE_2",
+      "NEXUS_ABYSS_WALL_TOP_CORNER_2",
+      "NEXUS_ABYSS_WALL_CORNER_01",
+      "ABYSSALSIRE_EXIT_LEVER",
+      "RCU_ABYSS_TO_OVERSEER"
     ],
     "uvType": "BOX",
     "uvScale": 0.9
@@ -20028,7 +20028,7 @@
     "description": "Abyss - Wall",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      26154
+      "RCU_ABYSSALWALL_TOP"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 1.1
@@ -20037,18 +20037,18 @@
     "description": "Abyss - Puddle",
     "hide": true,
     "objectIds": [
-      26174,
-      26176,
-      26177
+      "RCU_ABYSSAL_SPLAT_1",
+      "RCU_ABYSSAL_SPLAT_2",
+      "RCU_ABYSSAL_SPLAT_3"
     ]
   },
   {
     "description": "Abyss - Agility Gap",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      25428,
-      25381,
-      27055
+      "RCU_ABYSSAL_BARRIER_AGILITY",
+      "RCU_BLANKMODEL",
+      "RCU_OVERSEER_TO_ABYSS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -20058,8 +20058,8 @@
     "description": "Abyss - Rocks",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      25422,
-      25424
+      "RCU_ABYSSAL_BARRIER_TEETH1",
+      "RCU_ABYSSAL_BARRIER_TEETH3"
 
     ],
     "uvType": "BOX",
@@ -20070,17 +20070,17 @@
     "description": "Abyss - Tendrils - Large",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      25425,
-      25427
+      "RCU_ABYSSAL_BARRIER_TENDRILS1",
+      "RCU_ABYSSAL_BARRIER_TENDRILS3"
     ]
   },
   {
     "description": "Abyss - Eyes",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      26146,
-      26147,
-      26148
+      "RCU_ABYSSAL_BARRIER_EYES1",
+      "RCU_ABYSSAL_BARRIER_EYES2",
+      "RCU_ABYSSAL_BARRIER_EYES3"
     ],
     "colorOverrides": [
       {
@@ -20095,8 +20095,8 @@
     "description": "Abyss - Boil",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      25590,
-      26144
+      "RCU_ABYSSAL_BARRIER_BOIL1",
+      "RCU_ABYSSAL_BARRIER_BOIL2"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -20105,7 +20105,7 @@
     "description": "Abyss - Blockage",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      25383
+      "RCU_OUTER_ENTRANCE_BLOCKSQUARE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -20114,7 +20114,7 @@
     "description": "Abyss - Object - Ground Sucker",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      26159
+      "RCU_ABYSSAL_EXIT_HOLE"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.33,
@@ -20124,25 +20124,25 @@
     "description": "Abyss - Object - Ground Tendrils - Small",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      26167,
-      26168,
-      26169
+      "RCU_ABYSSAL_TENDRILS",
+      "RCU_ABYSSAL_TENDRILS_FALLOFF",
+      "RCU_ABYSSAL_TENDRILS_CORNER"
     ]
   },
   {
     "description": "Abyss - Object - Popped Pustules - Small",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      26161,
-      26162,
-      26163,
-      26164,
-      26165,
-      26166,
-      27021,
-      27022,
-      27023,
-      27024
+      "RCU_ABYSSAL_BOILS_1",
+      "RCU_ABYSSAL_BOILS_2",
+      "RCU_ABYSSAL_BOILS_3",
+      "RCU_ABYSSAL_BOILS_1_DARK",
+      "RCU_ABYSSAL_BOILS_2_DARK",
+      "RCU_ABYSSAL_BOILS_3_DARK",
+      "NEXUS_ABYSS_BOIL_01",
+      "NEXUS_ABYSS_BOIL_02",
+      "NEXUS_ABYSS_BOIL_03",
+      "NEXUS_ABYSS_BOIL_04"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -20152,8 +20152,8 @@
     "description": "Abyss - Decoration - Veins",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      26170,
-      26173
+      "RCU_ABYSSAL_VEINS",
+      "RCU_ABYSSAL_VEINS2_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -20163,12 +20163,12 @@
     "description": "Abyss - Peak Eye",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      27048,
-      27049,
-      27050,
-      27051,
-      27052,
-      27053
+      "NEXUS_EYE_YELLOW_MIDDLE",
+      "NEXUS_EYE_YELLOW_LEFT",
+      "NEXUS_EYE_YELLOW_RIGHT",
+      "NEXUS_EYE_GREEN_MIDDLE",
+      "NEXUS_EYE_GREEN_LEFT",
+      "NEXUS_EYE_GREEN_RIGHT"
     ],
     "colorOverrides": [
       {
@@ -20183,99 +20183,99 @@
     "description": "Abyssal Nexus - Green-tipped Tendrils & Pustules",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      27014,
-      27015,
-      27016,
-      27017,
-      27018,
-      27019,
-      27020
+      "NEXUS_TENDRILS",
+      "NEXUS_TENDRILS_CORNER",
+      "NEXUS_TENDRILS_FALLOFF",
+      "NEXUS_BOIL_01",
+      "NEXUS_BOIL_02",
+      "NEXUS_BOIL_03",
+      "NEXUS_BOIL_04"
     ]
   },
   {
     "description": "Abyssal Nexus - Flesh",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      26935,
-      26922,
-      26923,
-      26902,
-      26903,
-      26905,
-      26908,
-      26911,
-      26912,
-      26913,
-      26914,
-      26918,
-      26919,
-      26920,
-      26927,
-      26928,
-      26929,
-      26930,
-      26933,
-      26936,
-      26938,
-      26937,
-      26931,
-      26932,
-      26934,
-      26939,
-      26915,
-      26917,
-      26925,
-      26921,
-      26904,
-      26910,
-      26909,
-      26907,
-      26906,
-      26890,
-      26891,
-      26896,
-      26901,
-      26892,
-      20249,
-      26899,
-      26889,
-      26895,
-      26898,
-      26924,
-      26994,
-      26995,
-      26996,
-      26997,
-      26975,
-      26976,
-      26977,
-      26979,
-      26978,
-      26998,
-      26999,
-      27000,
-      27003,
-      27005,
-      27004,
-      27006,
-      27007,
-      27008,
-      27002,
-      27001,
-      26981,
-      26988,
-      26985,
-      26986,
-      26989,
-      26984,
-      26982,
-      26983,
-      26980,
-      26900,
-      26897,
-      26893,
-      26926,
-      26974
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_05",
+      "NEXUS_FLOOR_BLOCK_PINK_2X2_01",
+      "NEXUS_FLOOR_BLOCK_PINK_2X2_02",
+      "NEXUS_FLOOR_WALK_BLOCK_01",
+      "NEXUS_FLOOR_WALK_BLOCK_02",
+      "NEXUS_FLOOR_WALK_BLOCK_04",
+      "NEXUS_FLOOR_WALK_BLOCK_CORNER_03",
+      "NEXUS_FLOOR_WALK_BLOCK_CORNER_06",
+      "NEXUS_FLOOR_BLOCK_PURPLE_01",
+      "NEXUS_FLOOR_BLOCK_PURPLE_02",
+      "NEXUS_FLOOR_BLOCK_PURPLE_03",
+      "NEXUS_FLOOR_BLOCK_PURPLE_PINK_02",
+      "NEXUS_FLOOR_BLOCK_PURPLE_PINK_CORNER_01",
+      "NEXUS_FLOOR_BLOCK_PURPLE_PINK_CORNER_02",
+      "NEXUS_FLOOR_WALL_PINK_PURPLE_01",
+      "NEXUS_FLOOR_WALL_PINK_PURPLE_02",
+      "NEXUS_FLOOR_WALL_PURPLE_01",
+      "NEXUS_FLOOR_WALL_PINK_CORNER_01",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_03",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_06",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_08",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_07",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_01",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_02",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_04",
+      "NEXUS_FLOOR_TENTACLE_BOTTOM_09",
+      "NEXUS_FLOOR_BLOCK_PURPLE_04",
+      "NEXUS_FLOOR_BLOCK_PURPLE_PINK_01",
+      "NEXUS_FLOOR_WALL_PINK_01",
+      "NEXUS_FLOOR_BLOCK_PURPLE_PINK_CORNER_03",
+      "NEXUS_FLOOR_WALK_BLOCK_03",
+      "NEXUS_FLOOR_WALK_BLOCK_CORNER_05",
+      "NEXUS_FLOOR_WALK_BLOCK_CORNER_04",
+      "NEXUS_FLOOR_WALK_BLOCK_CORNER_02",
+      "NEXUS_FLOOR_WALK_BLOCK_CORNER_01",
+      "NEXUS_FLOOR_SLIME_03",
+      "NEXUS_FLOOR_SLIME_04",
+      "NEXUS_FLOOR_SLIME_09",
+      "NEXUS_FLOOR_WALK_04",
+      "NEXUS_FLOOR_SLIME_05",
+      "NEXUS_FLOOR_SLIME_01",
+      "NEXUS_FLOOR_WALK_02",
+      "NEXUS_FLOOR_SLIME_02",
+      "NEXUS_FLOOR_SLIME_08",
+      "NEXUS_FLOOR_WALK_01",
+      "NEXUS_FLOOR_BLOCK_PINK_1X1",
+      "NEXUS_STASIS_CHAMBER_21",
+      "NEXUS_STASIS_CHAMBER_22",
+      "NEXUS_STASIS_CHAMBER_23",
+      "NEXUS_STASIS_CHAMBER_24",
+      "NEXUS_STASIS_CHAMBER_02",
+      "NEXUS_STASIS_CHAMBER_03",
+      "NEXUS_STASIS_CHAMBER_04",
+      "NEXUS_STASIS_CHAMBER_06",
+      "NEXUS_STASIS_CHAMBER_05",
+      "NEXUS_STASIS_CHAMBER_25",
+      "NEXUS_STASIS_CHAMBER_26",
+      "NEXUS_STASIS_CHAMBER_27",
+      "NEXUS_STASIS_CHAMBER_30",
+      "NEXUS_STASIS_CHAMBER_32",
+      "NEXUS_STASIS_CHAMBER_31",
+      "NEXUS_STASIS_CHAMBER_33",
+      "NEXUS_STASIS_CHAMBER_34",
+      "NEXUS_STASIS_CHAMBER_35",
+      "NEXUS_STASIS_CHAMBER_29",
+      "NEXUS_STASIS_CHAMBER_28",
+      "NEXUS_STASIS_CHAMBER_08",
+      "NEXUS_STASIS_CHAMBER_15",
+      "NEXUS_STASIS_CHAMBER_12",
+      "NEXUS_STASIS_CHAMBER_13",
+      "NEXUS_STASIS_CHAMBER_16",
+      "NEXUS_STASIS_CHAMBER_11",
+      "NEXUS_STASIS_CHAMBER_09",
+      "NEXUS_STASIS_CHAMBER_10",
+      "NEXUS_STASIS_CHAMBER_07",
+      "NEXUS_FLOOR_WALK_03",
+      "NEXUS_FLOOR_SLIME_11",
+      "NEXUS_FLOOR_SLIME_06",
+      "NEXUS_FLOOR_WALL_PINK_02",
+      "NEXUS_STASIS_CHAMBER_01"
     ],
     "uvType": "BOX",
     "uvScale": 0.45
@@ -20284,28 +20284,28 @@
     "description": "Abyssal Nexus - Flesh with Bone",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      26940,
-      26941,
-      26942,
-      26943,
-      26944,
-      26945,
-      26946,
-      26948,
-      26949,
-      26950,
-      26951,
-      26952,
-      26990,
-      26991,
-      26992,
-      26993,
-      27010,
-      27011,
-      27012,
-      27013,
-      26972,
-      26973
+      "NEXUS_WALL_PINK_01",
+      "NEXUS_WALL_PINK_02",
+      "NEXUS_WALL_PINK_PURPLE_01",
+      "NEXUS_WALL_PINK_PURPLE_02",
+      "NEXUS_WALL_PURPLE_01",
+      "NEXUS_WALL_PINK_CORNER_01",
+      "NEXUS_WALL_PINK_CORNER_02",
+      "NEXUS_WALL_PINK_CORNER_03",
+      "NEXUS_WALL_PINK_CORNER_04",
+      "NEXUS_WALL_PINK_PURPLE_CORNER_01",
+      "NEXUS_WALL_PINK_PURPLE_CORNER_02",
+      "NEXUS_WALL_PURPLE_CORNER_01",
+      "NEXUS_STASIS_CHAMBER_17",
+      "NEXUS_STASIS_CHAMBER_18",
+      "NEXUS_STASIS_CHAMBER_19",
+      "NEXUS_STASIS_CHAMBER_20",
+      "NEXUS_STASIS_CHAMBER_37",
+      "NEXUS_STASIS_CHAMBER_38",
+      "NEXUS_STASIS_CHAMBER_39",
+      "NEXUS_STASIS_CHAMBER_40",
+      "NEXUS_ABYSS_WALL_CORNER_02",
+      "NEXUS_ABYSS_WALL_CORNER_03"
     ],
     "uvType": "BOX",
     "uvScale": 0.65,
@@ -20320,11 +20320,11 @@
     "description": "Abyssal Nexus - Bile Pool Edges",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      26956,
-      26957,
-      26958,
-      26959,
-      26960
+      "NEXUS_ABYSS_FLOOR_CORNER_INNER",
+      "NEXUS_ABYSS_FLOOR_CORNER_OUTER",
+      "NEXUS_ABYSS_FLOOR_EDGE_OUTER",
+      "NEXUS_ABYSS_FLOOR_EDGE_WALL",
+      "NEXUS_ABYSS_FLOOR_EDGE_WALL_FLIPPED"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -20338,50 +20338,50 @@
   {
     "description": "Abyssal Nexus - Respiratory System",
     "baseMaterial": "GRAY_75",
-    "objectIds": [ 26953, 26954 ],
-    "npcIds": [ 5915 ]
+    "objectIds": [ "NEXUS_LUNG_WHEEZING", "NEXUS_LUNG_DEAD" ],
+    "npcIds": [ "ABYSSALSIRE_LUNG_DYING" ]
   },
   {
     "description": "Walls - Law Altar",
     "baseMaterial": "ROCK_2",
     "objectIds": [
-      34806,
-      34807,
-      34808
+      "LAWTEMPLE_CAVEWALL_FACE1",
+      "LAWTEMPLE_CAVEWALL_TOP",
+      "LAWTEMPLE_CAVEWALL_TOP5"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Disable shadow casting for Pest Control center platform to help with transparent shadows",
-    "objectIds": [ 14282 ],
+    "objectIds": [ "PEST_PLINTH_TOP_PLAIN" ],
     "castShadows": false
   },
   {
     "description": "Disable shadow casting for Pest Control center platform to help with transparent shadows",
-    "objectIds": [ 14282 ],
+    "objectIds": [ "PEST_PLINTH_TOP_PLAIN" ],
     "seasonalTheme": "AUTUMN",
     "castShadows": true
   },
   {
     "description": "The Scar brain matter",
     "objectIds": [
-      47592,
-      49206,
-      49223,
-      49224,
-      49225,
-      49226,
-      49227,
-      49232,
-      49233,
-      49234,
-      49235,
-      49236,
-      49918,
-      49919,
-      49920,
-      49922,
-      49925
+      "LEVIATHAN_WALL_CLIMB",
+      "DT2_SCAR_MAZE_CLOSED",
+      "DT2_SCAR_WALLKIT01",
+      "DT2_SCAR_WALLKIT01_SHORT",
+      "DT2_SCAR_WALLTOP_SHORT_01",
+      "DT2_SCAR_WALLTOP_SHORT_02",
+      "DT2_SCAR_WALLTOP_SHORT_03",
+      "DT2_SCAR_WALLTOP",
+      "DT2_SCAR_WALLTOP02",
+      "DT2_SCAR_WALLTOP03",
+      "DT2_SCAR_WALLTOP04",
+      "DT2_SCAR_WALLTOP05",
+      "SCAR_VENTRICULUS_INPUT",
+      "SCAR_VENTRICULUS_OUTPUT_EXTRACTS",
+      "SCAR_VENTRICULUS_OUTPUT_ESSENCE",
+      "SCAR_EXIT",
+      "SCAR_VENTRICULUS_ENTRY_WITH_OP"
     ],
     "baseMaterial": "BLANK_GLOSS"
   },
@@ -20389,9 +20389,9 @@
     "description": "Disable shadows for footprints in Defender of Varrock",
     "castShadows": false,
     "objectIds": [
-      50098,
-      50099,
-      50100
+      "DOV_HUNTING_TRAIL",
+      "DOV_HUNTING_TRAIL_CORNER",
+      "DOV_HUNTING_TRAIL_CORNER_MIRROR"
     ]
   },
   {
@@ -20399,37 +20399,37 @@
     "baseMaterial": "ROCK_3",
     "uvType": "BOX",
     "objectIds": [
-      50154,
-      50155,
-      50156,
-      50159,
-      50160,
-      50164,
-      50165,
-      50166,
-      50167,
-      50168,
-      50170,
-      50171,
-      50172,
-      50174,
-      50175,
-      50176,
-      50177,
-      50178,
-      50179,
-      50180,
-      50185,
-      50544,
-      50553,
-      50554,
-      50555,
-      50556,
-      50557,
-      50558,
-      50559,
-      50560,
-      50561
+      "DOV_BASE_BALCONY_1",
+      "DOV_BASE_BALCONY_1_MIDDLE",
+      "DOV_BASE_BALCONY_1_M",
+      "DOV_BASE_BALCONY_2",
+      "DOV_BASE_BALCONY_2_M",
+      "ZEMO_BASE_LVL1_WALL_V1",
+      "ZEMO_BASE_LVL2_WALL_V2",
+      "ZEMO_BASE_LVL2_WALL_V3",
+      "ZEMO_BASE_LVL2_WALL_GATE",
+      "ZEMO_BASE_LVL2_WALL_GATE_JOINER",
+      "ZEMO_BASE_TORCH",
+      "ZEMO_BASE_LVL2_WALL_GATE_M",
+      "ZEMO_BASE_LVL2_WALL_GATE_JOINER_M",
+      "ZEMO_BASE_LVL1_DOOR",
+      "ZEMO_BASE_WALL_LVL1",
+      "ZEMO_BASE_WALL2_LVL1",
+      "ZEMO_BASE_WALL_LVL2",
+      "ZEMO_BASE_LVL2_BALCONY_WALL",
+      "ZEMO_BASE_LVL2_BALCONY_WALL2",
+      "ZEMO_BASE_LVL2_BALCONY_WALL3",
+      "ZEMO_BASE_STALAGMITES",
+      "MAH3_BASE_STEPS_UP",
+      "MAH3_BASE_WALL_STEPS1",
+      "MAH3_BASE_WALL_STEPS1_MIRROR",
+      "MAH3_BASE_WALL_STEPS2",
+      "MAH3_BASE_WALL_STEPS2_MIRROR",
+      "MAH3_BASE_WALL_STEPS3",
+      "MAH3_BASE_WALL_STEPS3_MIRROR",
+      "MAH3_BASE_WALL_BARS",
+      "MAH3_BASE_WALL_BARS_MIRROR",
+      "MAH3_BASE_WALL_TOP"
     ]
   },
   {
@@ -20437,14 +20437,14 @@
     "baseMaterial": "METALLIC_1",
     "flatNormals": true,
     "objectIds": [
-      50152
+      "DOV_BASE_DOOR_CLOSED"
     ]
   },
   {
     "description": "Body Altar - Veins - Huge",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      1388
+      "BODY_ROOT1"
     ],
     "uvType": "BOX",
     "uvOrientation": 156
@@ -20453,7 +20453,7 @@
     "description": "Body Altar - Veins - Double",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      1389
+      "BODY_ROOT2"
     ],
     "uvType": "BOX",
     "uvOrientation": 156
@@ -20462,7 +20462,7 @@
     "description": "Body Altar - Veins - Medium",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      1385
+      "BODY_ROOTS_1"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -20472,7 +20472,7 @@
     "description": "Body Altar - Veins - Small Loop",
     "baseMaterial": "ABYSSAL",
     "objectIds": [
-      1386
+      "BODY_ROOTS_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -20482,7 +20482,7 @@
     "description": "Body Altar - Veins - Ground",
     "baseMaterial": "ABYSSAL_2",
     "objectIds": [
-      1232, 1233, 1234, 1235, 1236, 1237, 1238, 1239, 1240
+      "BODYVINE_STRAIGHT", "BODYVINE_CORNER", "BODYVINE_JUNCTION", "BODYVINE_DIAG1", "BODYVINE_DIAG2", "BODYVINE_DIAG3", "BODYVINE_DIAGFILLER", "BODYVINE_END", "BODYVINE_END_DIAG"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -20491,7 +20491,7 @@
   {
     "description": "Body Altar - Pink Rock like Object 1 - Diamond",
     "baseMaterial": "ABYSSAL",
-    "objectIds": [ 343 ],
+    "objectIds": [ "DUGUPSOIL1_BODY" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 2187
@@ -20499,7 +20499,7 @@
   {
     "description": "Body Altar - Pink Rock like Object 2 - Tiny",
     "baseMaterial": "ABYSSAL",
-    "objectIds": [ 344 ],
+    "objectIds": [ "DUGUPSOIL2_BODY" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 256
@@ -20507,7 +20507,7 @@
   {
     "description": "Body Altar - Pink Rock like Object 3",
     "baseMaterial": "ABYSSAL_2",
-    "objectIds": [ 345 ],
+    "objectIds": [ "DUGUPSOIL3_BODY" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 256
@@ -20515,7 +20515,7 @@
   {
     "description": "Body Altar - Walls",
     "baseMaterial": "ABYSSAL_2",
-    "objectIds": [ 1479, 1484 ],
+    "objectIds": [ "CAVEWALL_FACE1_BODY", "CAVEWALL_TOP_BODY" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 256
@@ -20524,7 +20524,7 @@
     "description": "Keldagrim Stone Walls",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      5966, 5989, 5998, 6000, 6001, 6002, 6003, 6004, 6005, 6006, 6010, 6011, 8881, 8882, 8883, 8884, 8905, 8907, 8909
+      "DWARF_BLOCKED_PASSAGE", "DWARF_GOLD_MINE", "DWARF_CAVE_ENTRANCE", "DWARF_CAVEWALL", "DWARF_CAVEWALL_INSIDE_EDGE", "DWARF_CAVEWALL_TOP", "DWARF_CAVEWALL_TOP5", "DWARF_CAVEWALL_TOP_HIGHER", "DWARF_CAVEWALL_BLEND", "DWARF_CAVEWALL_BLEND_MIRROR", "DWARF_CITY_WALL", "DWARF_CITY_WALL_DAMAGED", "FORGET_PUZZLE_ENTRANCE", "FORGET_PUZZLE_EXIT", "FORGET_STORY_EXIT_PREV", "FORGET_STORY_EXIT_NEXT", "DWARF_CAVEWALL_FADE_DOWN", "DWARF_CAVEWALL_DOUBLE_HEIGHT_FADE_DOWN", "DWARF_CAVEWALL_2NDLEVEL"
     ],
     "uvType": "BOX",
     "uvOrientation": 128
@@ -20533,7 +20533,7 @@
     "description": "Keldagrim - Metallic - Metal Walls - Exterior",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      6981, 6982, 6098, 6099
+      "DWARF_KELDAGRIM_PALACE_JOIN", "DWARF_KELDAGRIM_PALACE_JOIN_MIRROR", "DWARF_KELDAGRIM_WALL", "DWARF_KELDAGRIM_WINDOW"
     ],
     "uvType": "BOX",
     "uvOrientation": 1224,
@@ -20543,7 +20543,7 @@
     "description": "Keldagrim Stone House Walls - Exterior",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      6132, 6133, 6134, 6135, 6136, 6137, 6983
+      "DWARF_KELDAGRIM_HOUSE_WALL", "DWARF_KELDAGRIM_HOUSE_WINDOW", "DWARF_KELDAGRIM_POOR_HOUSE_WALL", "DWARF_KELDAGRIM_POOR_HOUSE_WINDOW", "DWARF_KELDAGRIM_HOUSE_WALL_LVL2", "DWARF_KELDAGRIM_HOUSE_WINDOW_LVL2", "DWARF_KELDAGRIM_HOUSE_WINDOW_OPEN"
     ],
     "uvType": "BOX",
     "uvOrientation": 1224,
@@ -20553,7 +20553,7 @@
     "description": "Keldagrim Stone House Walls - Interior",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      6145
+      "DWARF_KELDAGRIM_INTERIOR_WALL"
     ],
     "uvType": "BOX",
     "uvOrientation": 768,
@@ -20563,14 +20563,14 @@
     "description": "Keldagrim Wooden Supports",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      5993, 5994, 5995, 5996, 5997
+      "DWARF_PITPROP", "DWARF_PITPROP2", "DWARF_PITPROP3", "DWARF_PITPROP_L", "DWARF_PITPROP_R"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Objects - Stone - Table - Keldagrim Table",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6198 ],
+    "objectIds": [ "DWARF_KELDAGRIM_TABLE_BIG" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 128
@@ -20578,7 +20578,7 @@
   {
     "description": "Objects - Stone - Table - Keldagrim Large Square Table",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6200 ],
+    "objectIds": [ "DWARF_KELDAGRIM_TABLE_POSH" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 256
@@ -20586,7 +20586,7 @@
   {
     "description": "Objects - Stone - Table - Keldagrim Large Square Table with lamp",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6201 ],
+    "objectIds": [ "DWARF_KELDAGRIM_TABLE_POSH_LAMP" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 256
@@ -20594,7 +20594,7 @@
   {
     "description": "Objects - Stone - Table - Keldagrim Small Square Table",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6196 ],
+    "objectIds": [ "DWARF_KELDAGRIM_TABLE_SMALL" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 256
@@ -20602,7 +20602,7 @@
   {
     "description": "Objects - Stone - Table - Keldagrim Small Square Table with Lamp",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6197 ],
+    "objectIds": [ "DWARF_KELDAGRIM_TABLE_SMALL_LAMP" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 256
@@ -20610,7 +20610,7 @@
   {
     "description": "Objects - Stone - Table - Keldagrim Table with Cutting Board",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6211 ],
+    "objectIds": [ "DWARF_KELDAGRIM_CHOPPING_BOARD" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 128
@@ -20618,7 +20618,7 @@
   {
     "description": "Objects - Stone - Table - Keldagrim Table with Lamp",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6199 ],
+    "objectIds": [ "DWARF_KELDAGRIM_TABLE_BIG_LAMP" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 128
@@ -20626,7 +20626,7 @@
   {
     "description": "Objects - Stone - Stairs - Keldagrim Single Staircase",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6085, 6086, 10287, 10288 ],
+    "objectIds": [ "DWARF_KELDAGRIM_STAIRS_LOWER", "DWARF_KELDAGRIM_STAIRS_UPPER", "VC_KELDAGRIM_STAIRS_LOWER", "VC_KELDAGRIM_STAIRS_UPPER" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 512
@@ -20634,7 +20634,7 @@
   {
     "description": "Objects - Stone - Stairs - Keldagrim Double Staircase",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 6087, 6088, 6089, 6090, 9084, 9138 ],
+    "objectIds": [ "DWARF_KELDAGRIM_WIDE_STAIRS_LOWER", "DWARF_KELDAGRIM_WIDE_STAIRS_UPPER", "DWARF_KELDAGRIM_WIDE_STAIRS_3_LOWER", "DWARF_KELDAGRIM_WIDE_STAIRS_3_UPPER", "DWARF_KELDAGRIM_FACTORY_STAIRS", "BLAST_FURNACE_STAIRS_UP" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 512
@@ -20642,28 +20642,28 @@
   {
     "description": "Objects - Stone - Dwarf Statue",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 7006, 7007 ],
+    "objectIds": [ "DWARF_KELDAGRIM_BIG_STATUE_PALACE", "DWARF_KELDAGRIM_BIG_STATUE_PALACE_MIRROR" ],
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Objects - Metallic - Door",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 6102, 6103, 6104, 6105, 6106, 6107, 6108, 6109, 6110, 6111 ],
+    "objectIds": [ "DWARF_KELDAGRIM_DOOR_INTERIOR_POOR", "DWARF_KELDAGRIM_DOOR_INTERIOR_POOR_OPEN", "DWARF_KELDAGRIM_DOOR_INTERIOR", "DWARF_KELDAGRIM_DOOR_INTERIOR_OPEN", "DWARF_KELDAGRIM_DOOR", "DWARF_KELDAGRIM_DOOR_OPEN", "DWARF_KELDAGRIM_DOOR_POOR", "DWARF_KELDAGRIM_DOOR_POOR_OPEN", "DWARF_KELDAGRIM_DOOR_ORNATE", "DWARF_KELDAGRIM_DOOR_ORNATE_OPEN" ],
     "uvType": "BOX",
     "uvOrientation": 128
   },
   {
     "description": "Objects - Metallic - Door",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 1742, 6100, 6101, 6138, 6139, 6140, 6141, 6142, 6975, 6976, 6977, 6978 ],
+    "objectIds": [ "DWARF_KELDAGRIM_DOOR_PALACE_OPEN_PERM", "DWARF_KELDAGRIM_DOOR_INTERIOR_PALACE", "DWARF_KELDAGRIM_DOOR_INTERIOR_PALACE_OPEN", "DWARF_KELDAGRIM_HOUSE_RAIL", "DWARF_KELDAGRIM_HOUSE_RAIL_END", "DWARF_KELDAGRIM_HOUSE_RAIL_END_MIRROR", "DWARF_KELDAGRIM_HOUSE_RAIL_END2", "DWARF_KELDAGRIM_HOUSE_RAIL_END2_MIRROR", "DWARF_KELDAGRIM_DOOR_INTERIOR_FACTORY", "DWARF_KELDAGRIM_DOOR_INTERIOR_FACTORY_OPEN", "DWARF_KELDAGRIM_FACTORY_DOOR", "DWARF_KELDAGRIM_FACTORY_DOOR_OPEN" ],
     "uvType": "BOX",
     "uvOrientation": 128
   },
   {
     "description": "Objects - Cloth - Bentamirs Bed ",
     "baseMaterial": "CARPET",
-    "objectIds": [ 6184 ],
+    "objectIds": [ "DWARF_KELDAGRIM_VERY_POOR_BED" ],
     "uvType": "BOX",
     "uvOrientation": 88
   },
@@ -20671,7 +20671,7 @@
     "description": "Objects - Rock Column - Huge",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      6148, 6149
+      "DWARF_ROCKCOLUMN2", "DWARF_ROCKCOLUMN3"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -20680,7 +20680,7 @@
     "description": "Objects - Rock Column - Tan - Huge",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      11184, 11185, 11186
+      "ROCKCOLUMN1", "ROCKCOLUMN2", "ROCKCOLUMN3"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -20690,7 +20690,7 @@
     "description": "Objects - Stone - Stone Slab Bridge Guards",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      6143, 6144
+      "DWARF_KELDAGRIM_LOW_WALL", "DWARF_KELDAGRIM_LOW_WALL_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -20699,7 +20699,7 @@
     "description": "Objects - Metallic - Keldagrim Roof",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      6116, 6118, 6119, 6120, 6121, 6122, 6123, 6124, 6125, 6126, 6127, 6128, 6129, 6130, 6131
+      "DWARF_KELDAGRIM_HOUSE_POOR_SIDE_CHIMNEY", "DWARF_KELDAGRIM_HOUSE_CHIMNEY_TOP_POOR", "DWARF_KELDAGRIM_HOUSE_CHIMNEY_TOP", "DWARF_KELDAGRIM_HOUSE_POOR_ROOF", "DWARF_KELDAGRIM_HOUSE_POOR_ROOF_LOW", "DWARF_KELDAGRIM_HOUSE_POOR_ROOF_CORNER", "DWARF_KELDAGRIM_HOUSE_POOR_ROOF_FIVE", "DWARF_KELDAGRIM_HOUSE_POOR_ROOF_FIVE_MIRROR", "DWARF_KELDAGRIM_HOUSE_POOR_ROOF_UPPER", "DWARF_KELDAGRIM_HOUSE_ROOF", "DWARF_KELDAGRIM_HOUSE_ROOF_LOW", "DWARF_KELDAGRIM_HOUSE_ROOF_CORNER", "DWARF_KELDAGRIM_HOUSE_ROOF_FIVE", "DWARF_KELDAGRIM_HOUSE_ROOF_FIVE_MIRROR", "DWARF_KELDAGRIM_HOUSE_ROOF_UPPER"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -20709,7 +20709,7 @@
     "description": "Objects - Rock - Unfinished Statues",
     "baseMaterial": "ROCK_5",
     "objectIds": [
-      7008, 7009, 7010
+      "DWARF_KELDAGRIM_STATUE_SCULPTORS_HOUSE", "DWARF_KELDAGRIM_STATUE_SCULPTORS_HOUSE2", "DWARF_KELDAGRIM_STATUE_SCULPTORS_HOUSE3"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -20718,8 +20718,8 @@
     "description": "Blast Furnace - Objects - Metallic - Sink",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      6151,
-      9143
+      "DWARF_KELDAGRIM_SINK",
+      "BLAST_FURNACE_SINK"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -20728,7 +20728,7 @@
     "description": "Blast Furnace - Objects - Metallic - Scaffolding",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      9109, 9110, 9111, 9112, 9113
+      "BLAST_FURNACE_SCAFFOLDING1", "BLAST_FURNACE_SCAFFOLDING2", "BLAST_FURNACE_SCAFFOLDING3", "BLAST_FURNACE_SCAFFOLDING4", "BLAST_FURNACE_SCAFFOLDING5"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -20738,7 +20738,7 @@
     "description": "Blast Furnace - Walls - Wooden - Double Slat Fence",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      9139
+      "PIER_RAIL_DOUBLE"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -20748,7 +20748,7 @@
     "description": "Blast Furnace - Walls - Wooden - Gate",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      9141
+      "SMITHING_GUILD_DOOR"
     ],
     "uvType": "BOX"
   },
@@ -20756,7 +20756,7 @@
     "description": "Objects - Wooden - Keldagrim Cart Trapdoor",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16168
+      "GE_KELDAGRIM_TRAPDOOR"
     ],
     "uvType": "BOX",
     "uvScale": 0.86
@@ -20765,7 +20765,7 @@
     "description": "Varlamore - quetzal landing site",
     "baseMaterial": "HAY",
     "objectIds": [
-      52815
+      "QUETZAL_LANDING_SITE_BUILT"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -20774,8 +20774,8 @@
     "description": "Acacia Tree",
     "baseMaterial": "LIGHT_BARK_STONEPINE",
     "objectIds": [
-      51768,
-      51769
+      "AVIUM_ACACIA_1",
+      "AVIUM_ACACIA_CANOPY_1"
     ],
     "uvType": "BOX",
     "uvScale": 0.55
@@ -20784,10 +20784,10 @@
     "description": "Stonepine Tree",
     "baseMaterial": "LIGHT_BARK_STONEPINE",
     "objectIds": [
-      51464,
-      51465,
-      51770,
-      51771
+      "ROR_TEMPLE_TREE01_CANOPY01",
+      "ROR_TEMPLE_TREE01_TRUNK01",
+      "AVIUM_STONEPINE_BASE_1",
+      "AVIUM_STONEPINE_CANOPY_1"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -20796,33 +20796,33 @@
     "description": "Varlamore - Avium Savannah - Plants",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      47370,
-      51819,
-      51070,
-      51071,
-      51072,
-      51073,
-      51085,
-      51086
+      "GROUNDCOVER_PLANT5_WITHERED",
+      "BUSH_SAVANNAH01_SPIKEY02",
+      "PLANT_FERN_ECLIPSE01",
+      "PLANT_FERN_ECLIPSE02",
+      "PLANT_FERN_ECLIPSE03",
+      "PLANT_FERN_ECLIPSE04",
+      "PLANT_SUNFLOWER01_DEFAULT01",
+      "PLANT_SUNFLOWER01_DEFAULT02"
     ]
   },
   {
     "description": "Varlamore Rugs and carpets",
     "baseMaterial": "CARPET",
     "objectIds": [
-      52467,
-      52468,
-      52469,
-      52470,
-      52471,
-      52472,
-      52473,
-      52474,
-      52475,
-      52476,
-      52573,
-      52574,
-      52575
+      "RUG_VARLAMORE01_CORNER01",
+      "RUG_VARLAMORE01_CORNER02",
+      "RUG_VARLAMORE01_SIDE01",
+      "RUG_VARLAMORE01_SIDE02",
+      "RUG_VARLAMORE01_MIDDLE01",
+      "RUG_VARLAMORE01_MIDDLE02",
+      "RUG_VARLAMORE01_CORNER01_RED01",
+      "RUG_VARLAMORE01_CORNER02_RED01",
+      "RUG_VARLAMORE01_SIDE01_RED01",
+      "RUG_VARLAMORE01_SIDE02_RED01",
+      "FORTIS_RUGCORNER",
+      "FORTIS_RUGSIDE",
+      "FORTIS_RUGMIDDLE"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -20830,9 +20830,9 @@
     "description": "Varlamore Cushions",
     "baseMaterial": "CARPET",
     "objectIds": [
-      53012,
-      52436,
-      52437
+      "AFL_CATBED_NOOP",
+      "PILLOW_VARLAMORE01_DEFAULT01",
+      "PILLOW_VARLAMORE01_STACK01"
     ],
     "uvType": "BOX",
     "uvOrientation": 256,
@@ -20842,7 +20842,7 @@
     "description": "Varlamore Awnings Small Red",
     "baseMaterial": "CARPET",
     "objectIds": [
-      51944
+      "TENT_BAZAAR01_COVER01"
     ],
     "uvType": "BOX"
   },
@@ -20850,24 +20850,24 @@
     "description": "Varlamore Awnings Large Red, MODEL_XZ is used with intent",
     "baseMaterial": "CARPET",
     "objectIds": [
-      51940,
-      51941,
-      51942,
-      44896,
-      44897,
-      44898,
-      44899,
-      44900,
-      44901,
-      44902,
-      44903,
-      44904,
-      44905,
-      44906,
-      44907,
-      44908,
-      44909,
-      44910
+      "TENT_BAZAAR01_CORNER01",
+      "TENT_BAZAAR01_CORNER01_OFFSET",
+      "TENT_BAZAAR01_SIDE01",
+      "ARENA_TENT_POST01",
+      "ARENA_TENT_POST02",
+      "ARENA_TENT_POST03",
+      "ARENA_TENT_BOTTOM01",
+      "ARENA_TENT_BOTTOM02",
+      "ARENA_TENT_BOTTOM03",
+      "ARENA_TENT_EDGE01",
+      "ARENA_TENT_EDGE02",
+      "ARENA_TENT_EDGE03",
+      "ARENA_TENT_MIDDLE01",
+      "ARENA_TENT_DIAG01",
+      "ARENA_TENT_DIAG02",
+      "ARENA_TENT_DIAG03",
+      "ARENA_TENT_DIAG04",
+      "ARENA_TENT_DIAG05"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -20875,7 +20875,7 @@
     "description": "Varlamore Tent Walls",
     "baseMaterial": "CARPET",
     "objectIds": [
-      44853
+      "ARENA_DESERT01_TENT01"
     ],
     "uvType": "BOX"
   },
@@ -20883,7 +20883,7 @@
     "description": "Varlamore Circular Awning, MODEL_XZ is used with intent",
     "baseMaterial": "CARPET",
     "objectIds": [
-      51943
+      "TENT_BAZAAR01_MIDDLE01"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -20891,10 +20891,10 @@
     "description": "Varlamore Banners",
     "baseMaterial": "CARPET",
     "objectIds": [
-      51946,
-      51947,
-      51948,
-      52314
+      "TENT_BAZAAR01_WALL02",
+      "TENT_BAZAAR01_WALL02_OFFSET",
+      "TENT_BAZAAR01_WALL03",
+      "BANNER_VARLAMORE01_DEFAULT02"
     ],
     "uvType": "MODEL_YZ"
   },
@@ -20902,11 +20902,11 @@
     "description": "Colossal Wyrm Agility Course Hay Bale",
     "baseMaterial": "HD_HAY",
     "objectIds": [
-      55173,
-      55174,
-      55175,
-      46309,
-      46311
+      "AVIUM_BUNDLE_HAY01_LANDING01",
+      "AVIUM_BUNDLE_HAY01_FLOOR01",
+      "AVIUM_HAY_1",
+      "HW22_BUNDLE_HAY01_BALE01",
+      "HW22_BUNDLE_HAY01_STACK01"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -20915,11 +20915,11 @@
     "description": "Colossal Wyrm Agility Course Skull",
     "baseMaterial": "BONE",
     "objectIds": [
-      51910,
-      51911,
-      51912,
-      51913,
-      55142
+      "SKELETON_WYRM01_ENTRANCE_JAW01",
+      "SKELETON_WYRM01_ENTRANCE_JAW02",
+      "SKELETON_WYRM01_ENTRANCE_TOP01",
+      "SKELETON_WYRM01_ENTRANCE_TOP02",
+      "SKELETON_WYRM01_SKULL01"
     ],
     "uvType": "BOX",
     "uvScale": 0.85
@@ -20928,11 +20928,11 @@
     "description": "Colossal Wyrm Agility Course Bones",
     "baseMaterial": "BONE",
     "objectIds": [
-      55138,
-      55139,
-      55140,
-      55141,
-      55143
+      "SKELETON_WYRM01_RIB01",
+      "SKELETON_WYRM01_RIB01_DIAGONAL",
+      "SKELETON_WYRM01_RIB02",
+      "SKELETON_WYRM01_RIB03",
+      "SKELETON_WYRM01_VERTEBRAE01"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -20941,8 +20941,8 @@
     "description": "Colossal Wyrm Agility Course Bones with Dirt",
     "baseMaterial": "BONE",
     "objectIds": [
-      55144,
-      55145
+      "SKELETON_WYRM01_VERTEBRAE02",
+      "SKELETON_WYRM01_VERTEBRAE03"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -20957,7 +20957,7 @@
     "description": "Colossal Wyrm Agility Course Bones with Wood",
     "baseMaterial": "BONE",
     "objectIds": [
-      55146
+      "SKELETON_WYRM01_VERTEBRAE04"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -20975,10 +20975,10 @@
     "description": "Colossal Wyrm Agility Course Scaffolding Floor",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      46803,
-      55147,
-      55148,
-      55194
+      "SKEWSTEPS_WOOD01_OASIS",
+      "WALLKIT_SCAFFOLD01_DECKING01",
+      "WALLKIT_SCAFFOLD01_DECKING03",
+      "VARLAMORE_WYRM_AGILITY_ADVANCED_BALANCE_1_TRIGGER"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -20987,12 +20987,12 @@
     "description": "Colossal Wyrm Agility Course Scaffolding",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      55149,
-      55150,
-      55151,
-      55158,
-      55160,
-      55161
+      "WALLKIT_SCAFFOLD01_DEFAULT01",
+      "WALLKIT_SCAFFOLD01_JUNCTION01",
+      "WALLKIT_SCAFFOLD01_JUNCTION01_M",
+      "WALLKIT_SCAFFOLD01_SUPPORT01",
+      "WALLKIT_SCAFFOLD01_SUPPORT03",
+      "WALLKIT_SCAFFOLD01_PILLAR01"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -21002,12 +21002,12 @@
     "description": "Colossal Wyrm Agility Course Wooden Decorations",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      55037,
-      15832,
-      55162,
-      55163,
-      55164,
-      55165
+      "ALDARIN_STOOL01_DEFAULT01",
+      "LOTR_MINE_SUPPORT_WALL",
+      "AVIUM_STACK01_LOGS01",
+      "CART_AVIUM01_DIGSITE01",
+      "AVIUM_SCAFFOLD01_PLANKS01",
+      "AVIUM_SCAFFOLD01_PLANKS02"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -21017,15 +21017,15 @@
     "description": "Colossal Wyrm Agility Course Scaffolding with Ropes",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      55152,
-      55153,
-      55154,
-      55155,
-      55156,
-      55178,
-      55190,
-      55191,
-      55196
+      "WALLKIT_SCAFFOLD01_FENCE01",
+      "WALLKIT_SCAFFOLD01_FENCE01_M",
+      "WALLKIT_SCAFFOLD01_FENCE02",
+      "WALLKIT_SCAFFOLD01_FENCE03",
+      "WALLKIT_SCAFFOLD01_FENCE03_M",
+      "VARLAMORE_WYRM_AGILITY_START_LADDER_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_BASIC_LADDER_1_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_ADVANCED_LADDER_1_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_ADVANCED_MONKEYBARS_1_TRIGGER"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -21043,19 +21043,19 @@
     "description": "Colossal Wyrm Agility Course Tightrope",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      42239,
-      55166,
-      55168,
-      55180,
-      55182,
-      55184,
-      55186,
-      55188,
-      55170,
-      55171,
-      55172,
-      55179,
-      55192
+      "SHAYZIEN_AGILITY_TIGHTROPE_MID01",
+      "OBSTACLE_TIGHTROPE_AVIUM01",
+      "OBSTACLE_TIGHTROPE_AVIUM01_CONNECTOR01",
+      "VARLAMORE_WYRM_AGILITY_BALANCE_1_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_MULTIJUMP_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_BASIC_BALANCE_1_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_BASIC_MONKEYBARS_1_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_BASIC_JUMP_1_TRIGGER",
+      "OBSTACLE_TIGHTROPE_AVIUM01_DIAGONAL02_FILLER01",
+      "OBSTACLE_TIGHTROPE_AVIUM01_DIAGONAL02_FILLER02",
+      "OBSTACLE_TIGHTROPE_AVIUM01_DIAGONAL03",
+      "VARLAMORE_WYRM_AGILITY_END_ZIPLINE_TRIGGER",
+      "VARLAMORE_WYRM_AGILITY_ADVANCED_JUMP_1_TRIGGER"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -21074,7 +21074,7 @@
     "description": "Colossal Wyrm Agility Course Scaffolding Rotated",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      55169
+      "OBSTACLE_TIGHTROPE_AVIUM01_DIAGONAL01"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -21093,8 +21093,8 @@
     "description": "Colossal Wyrm Agility Course Scaffolding Rope Support",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      42233,
-      42234
+      "SHAYZIEN_AGILITY_SUPPORT01",
+      "SHAYZIEN_AGILITY_SUPPORT02"
     ],
     "colorOverrides": [
       {
@@ -21112,41 +21112,41 @@
     "uvType": "BOX",
     "uvScale": 0.33,
     "objectIds": [
-      55135,
-      55136,
-      55137
+      "MOUND_TERMITE01_SMALL01",
+      "MOUND_TERMITE01_MEDIUM01",
+      "MOUND_TERMITE01_LARGE01"
     ]
   },
   {
     "description": "Perilous Moons Murals",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      51380,
-      51382,
-      51384
+      "ROR_GATE_BLOODMOON_CLOSED",
+      "ROR_GATE_BLUEMOON_CLOSED",
+      "ROR_GATE_SOLARECLIPSE_CLOSED"
     ]
   },
   {
     "description": "Perilous Moons Statues",
     "baseMaterial": "MARBLE_2_GLOSS",
     "objectIds": [
-      51309,
-      51310,
-      51311,
-      51329,
-      51330,
-      51332,
-      51333,
-      51334,
-      51336,
-      51337,
-      51338,
-      51339,
-      51340,
-      51341,
-      51372,
-      51373,
-      51374
+      "STATUES_NAGUA01_BLOOD01",
+      "STATUES_NAGUA01_BLUE01",
+      "STATUES_NAGUA01_ECLIPSE01",
+      "STATUES_DUNGEON01_JAGUAR01",
+      "STATUES_DUNGEON01_JAGUAR02",
+      "STATUES_DUNGEON01_EAGLE02",
+      "STATUES_DUNGEON01_EAGLE03",
+      "STATUES_DUNGEON01_SNAKE01",
+      "STATUES_NAGUA01_BLOOD01_PRISON01",
+      "STATUES_NAGUA01_BLOOD01_PRISON02",
+      "STATUES_NAGUA01_BLUE01_MOONLIGHT01",
+      "STATUES_NAGUA01_BLUE01_MOONLIGHT02",
+      "STATUES_NAGUA01_BLUE01_VERDANT01",
+      "STATUES_NAGUA01_BLUE01_VERDANT02",
+      "PMOON_ENTRY_STATUE_BLOOD",
+      "PMOON_ENTRY_STATUE_BLUE",
+      "PMOON_ENTRY_STATUE_ECLIPSE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -21155,7 +21155,7 @@
     "description": "Perilous Moons Giant Eagle Statue, separate because no gloss",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      51331
+      "STATUES_DUNGEON01_EAGLE01"
     ],
     "uvType": "BOX",
     "uvScale": 0.7
@@ -21164,70 +21164,70 @@
     "description": "Perilous Moons Braziers and Chains",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      25121,
-      51342,
-      51343,
-      51344,
-      51345,
-      51345,
-      51398,
-      51399
+      "DRAGON_SLAYER_QIP_BROKEN_CHAINS",
+      "BRAZIER_DUNGEON01_PMOON01",
+      "BRAZIER_DUNGEON01_PMOON02",
+      "BRAZIER_DUNGEON01_PMOON03",
+      "BRAZIER_DUNGEON01_PMOON04",
+      "BRAZIER_DUNGEON01_PMOON04",
+      "ROR_CHAIN_PRISON01",
+      "ROR_SHACKLES_PRISON01"
     ]
   },
   {
     "description": "Perilous Moons Plants",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      36220,
-      39680,
-      39681,
-      39682,
-      51081,
-      51082,
-      51083,
-      51084,
-      51257,
-      51258,
-      51261,
-      51262,
-      51263,
-      51264,
-      51326,
-      51327,
-      51328,
-      51358,
-      51365,
-      51433,
-      51434,
-      51435,
-      51436,
-      51437,
-      51438,
-      51466,
-      51467,
-      51468,
-      51470,
-      51471,
-      51472,
-      51473,
-      51585,
-      51586
+      "PRIF_MINE_MUSHROOM_1",
+      "WILDY_HUB_BUSH_01",
+      "WILDY_HUB_BUSH_02",
+      "WILDY_HUB_BUSH_03",
+      "PLANT_MOSS01_SUN01",
+      "PLANT_MOSS01_SUN02",
+      "PLANT_MOSS01_SUN03",
+      "PLANT_MOSS01_SUN04",
+      "DUNGEONKIT_MOSS01_BUILDUP01",
+      "DUNGEONKIT_MOSS01_BUILDUP02",
+      "DUNGEONKIT_MOSS01_BUILDUP03",
+      "DUNGEONKIT_MOSS01_BUILDUP04",
+      "DUNGEONKIT_MOSS01_BUILDUP03_MIRROR",
+      "DUNGEONKIT_MOSS01_BUILDUP04_MIRROR",
+      "BUSH_GRASS01_SUNFLOWER01",
+      "BUSH_GRASS01_SUNFLOWER02",
+      "BUSH_GRASS01_SUNFLOWER03",
+      "PMOON_LIZARD_BUSH",
+      "PMOON_GRUB_SAPLING",
+      "PLANT_FERN01_SMALL01",
+      "PLANT_FERN01_LARGE01",
+      "PLANT_FERN_MOONLIGHT01",
+      "PLANT_FERN_MOONLIGHT02",
+      "PLANT_FERN_MOONLIGHT03",
+      "PLANT_FERN_MOONLIGHT04",
+      "ROR_VINE01_HANGING01",
+      "ROR_VINE01_HANGING01_PRISON01",
+      "ROR_IVY01_LARGE01",
+      "ROR_IVY01_MEDIUM01",
+      "ROR_IVY01_MEDIUM01_DARK01",
+      "ROR_IVY01_SMALL01",
+      "ROR_IVY01_SMALL01_DARK01",
+      "FLORA_MUSHROOM01_IMCANDO01",
+      "FLORA_MUSHROOM01_IMCANDO02"
     ]
   },
   {
     "description": "Streambound Cavern Bridges",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      51348,
-      51349,
-      51350,
-      51351,
-      51352,
-      51353,
-      51354,
-      51355,
-      51356,
-      51357
+      "BRIDGEKIT_CAVE_PLANKS01",
+      "BRIDGEKIT_CAVE_PLANKS01_MIRROR",
+      "BRIDGEKIT_CAVE_PLANKS02",
+      "BRIDGEKIT_CAVE_PLANKS02_MIRROR",
+      "BRIDGEKIT_CAVE_PLANKS03",
+      "BRIDGEKIT_CAVE_PLANKS03_MIRROR",
+      "BRIDGEKIT_CAVE_PLANKS04",
+      "BRIDGEKIT_CAVE_PLANKS04_MIRROR",
+      "BRIDGEKIT_CAVE_PLANKS05",
+      "BRIDGEKIT_CAVE_PLANKS05_MIRROR"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.9
@@ -21236,16 +21236,16 @@
     "description": "Perilous Moons Monolith and Gates",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      51379,
-      51392,
-      51393
+      "PMOON_ICOSAHEDRON",
+      "ROR_GATE_WANMOON_CLOSED",
+      "ROR_GATE_WANMOON_OPEN"
     ]
   },
   {
     "description": "Perilous Moons Carvings",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      51400
+      "SHRINE_VARLAMORE_PRISON01"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -21254,35 +21254,35 @@
     "description": "Perilous Moons Ancient Shrine Dirt",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      51097,
-      51098,
-      51272,
-      51273,
-      51274,
-      51275,
-      51276,
-      51277,
-      51279,
-      51280,
-      51281,
-      51282,
-      51283,
-      51284,
-      51285,
-      51286,
-      51287,
-      51288,
-      51289,
-      51290,
-      51291,
-      51292,
-      51293,
-      51294,
-      51295,
-      51296,
-      51297,
-      51298,
-      51299
+      "DUGUPSOIL02_SUN",
+      "DUGUPSOIL03_SUN",
+      "FLOORKIT_SUN01_STRAIGHT01",
+      "FLOORKIT_SUN01_STRAIGHT01A",
+      "FLOORKIT_SUN01_STRAIGHT01B",
+      "FLOORKIT_SUN01_STRAIGHT01C",
+      "FLOORKIT_SUN01_STRAIGHT01C_MIRROR",
+      "FLOORKIT_SUN01_STRAIGHT01D",
+      "FLOORKIT_SUN01_STRAIGHT01E",
+      "FLOORKIT_SUN01_HALF01A",
+      "FLOORKIT_SUN01_TRIANGLE01",
+      "FLOORKIT_SUN01_TRIANGLE01_MIRROR",
+      "FLOORKIT_SUN01_TRIANGLE02",
+      "FLOORKIT_SUN01_TRIANGLE02_MIRROR",
+      "FLOORKIT_SUN01_TRIANGLE02A",
+      "FLOORKIT_SUN01_TRIANGLE02A_MIRROR",
+      "FLOORKIT_SUN01_TRIANGLE02B",
+      "FLOORKIT_SUN01_TRIANGLE02B_MIRROR",
+      "FLOORKIT_SUN01_DIAGONAL02",
+      "FLOORKIT_SUN01_DIAGONAL02_MIRROR",
+      "FLOORKIT_SUN01_DIAGONAL02A",
+      "FLOORKIT_SUN01_DIAGONAL02A_MIRROR",
+      "FLOORKIT_SUN01_DIAGONAL02B",
+      "FLOORKIT_SUN01_DIAGONAL02C",
+      "FLOORKIT_SUN01_DIAGONAL02C_MIRROR",
+      "FLOORKIT_SUN01_DIAGONAL02D",
+      "FLOORKIT_SUN01_DIAGONAL02D_MIRROR",
+      "FLOORKIT_SUN01_DIAGONAL02E",
+      "FLOORKIT_SUN01_CORNER01"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.75
@@ -21294,34 +21294,34 @@
     "castShadows": false,
     "receiveShadows": false,
     "objectIds": [
-      51097,
-      51098
+      "DUGUPSOIL02_SUN",
+      "DUGUPSOIL03_SUN"
     ]
   },
   {
     "description": "Blue Moon Arena Ice Spikes",
     "baseMaterial": "ICE_4",
     "objectIds": [
-      51301,
-      51302,
-      51303,
-      51304,
-      51305,
-      51306
+      "ICE03_SHARD01_STALAGMITE01",
+      "ICE03_SHARD01_STALAGMITE02",
+      "ICE03_SHARD01_STALAGMITE03",
+      "ICE03_SHARD01_STALAGMITE04",
+      "ICE03_SHARD01_STALAGMITE05",
+      "ICE03_SHARD01_STALAGMITE06"
     ]
   },
   {
     "description": "Blood Moon Arena Bloody Wall",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      51249,
-      51250,
-      51251,
-      51252,
-      51253,
-      51254,
-      51255,
-      51256
+      "DUNGEONKIT_BLOOD02_SPLATTER01",
+      "DUNGEONKIT_BLOOD02_SPLATTER02",
+      "DUNGEONKIT_BLOOD02_SPLATTER03",
+      "DUNGEONKIT_BLOOD02_SPLATTER04",
+      "DUNGEONKIT_BLOOD02_SPLATTER05",
+      "DUNGEONKIT_BLOOD02_SPLATTER06",
+      "DUNGEONKIT_BLOOD02_SPLATTER07",
+      "DUNGEONKIT_BLOOD02_SPLATTER08"
     ],
     "uvType": "MODEL_XY",
     "uvOrientation": 512,
@@ -21331,12 +21331,12 @@
     "description": "Cam Torum Dirt Decorations",
     "baseMaterial": "GRAVEL_LIGHT",
     "objectIds": [
-      51592,
-      51593,
-      51594,
-      51595,
-      51596,
-      51597
+      "DECAL_DIRT01_CRACKS03",
+      "DECAL_DIRT01_CRACKS03_MIRROR",
+      "DECAL_DIRT01_CRACKS05",
+      "DECAL_DIRT01_CRACKS05_MIRROR",
+      "DECAL_DIRT01_CRACKS06",
+      "DECAL_DIRT01_CRACKS06_MIRROR"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 512,
@@ -21346,8 +21346,8 @@
     "description": "Cam Torum Stairs",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      51606,
-      51607
+      "SKEWSTEPS_STONE_IMCANDO02",
+      "SKEWSTEPS_STONE_IMCANDO02_DARK01"
     ],
     "uvType": "BOX"
   },
@@ -21355,23 +21355,23 @@
     "description": "Perilous Moons - Dragon Head Wall Fountains",
     "baseMaterial": "GRAY_65",
     "objectIds": [
-      51424,
-      51425,
-      51426,
-      51427,
-      51428,
-      51429,
-      51430,
-      51431,
-      52580
+      "ROR_TEMPLE_WATERFALL01",
+      "ROR_TEMPLE_WATERFALL01_ODD01",
+      "ROR_TEMPLE_WATERFALL01_MOONLIGHT01",
+      "ROR_TEMPLE_WATERFALL01_MOONLIGHT01_ODD01",
+      "ROR_TEMPLE_WATERFALL01_PRISON01",
+      "ROR_TEMPLE_WATERFALL01_PRISON01_ODD01",
+      "ROR_TEMPLE_WATERFALL01_LAVA01",
+      "ROR_TEMPLE_WATERFALL01_LAVA01_ODD01",
+      "FORTIS_CRYPT_FOUNTAIN"
     ]
   },
   {
     "description": "Perilous Moons - Camp - Barrier and Stove",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      51362,
-      51364
+      "PMOON_RANGE",
+      "PMOON_BARRIER_FABRIC01_SHORT01"
     ],
     "uvType": "BOX"
   },
@@ -21379,7 +21379,7 @@
     "description": "Perilous Moons - Camp - Supply Crates",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      51371
+      "PMOON_SUPPLY_CRATE"
     ],
     "uvType": "BOX",
     "uvOrientation": 520
@@ -21388,105 +21388,105 @@
     "description": "Hunter Guild cave, Cam Torum, Perilous Moons, Giants Den and Escape Caves - Walls, Rocky objects and Stairs",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      42250,
-      42251,
-      42255,
-      42256,
-      42257,
-      42258,
-      42259,
-      42261,
-      42266,
-      42267,
-      42268,
-      42269,
-      42270,
-      42271,
-      42272,
-      42273,
-      42275,
-      42276,
-      47117,
-      47147,
-      47148,
-      47151,
-      47157,
-      47158,
-      47170,
-      47171,
-      50906,
-      50907,
-      50908,
-      50909,
-      50910,
-      50911,
-      50912,
-      50913,
-      50914,
-      50915,
-      50916,
-      50917,
-      50918,
-      50919,
-      50920,
-      50921,
-      50922,
-      50923,
-      50924,
-      50925,
-      50926,
-      50927,
-      50931,
-      51108,
-      51109,
-      51110,
-      51111,
-      51112,
-      51113,
-      51313,
-      51314,
-      51315,
-      51316,
-      51317,
-      51318,
-      51319,
-      51320,
-      51378,
-      51485,
-      51486,
-      51487,
-      51489,
-      51490,
-      51491,
-      51492,
-      51394,
-      51395,
-      51396,
-      51402,
-      51404,
-      51405,
-      51407,
-      51408,
-      51409,
-      51410,
-      51411,
-      51412,
-      51415,
-      51418,
-      51421,
-      51432,
-      51446,
-      51452,
-      51457,
-      51458,
-      51460,
-      51474,
-      51475,
-      51476,
-      51477,
-      51479,
-      51482,
-      53003
+      "GIANTS_DEN_CATACOMB_ENTRANCE_BLOCKED",
+      "CAVEKIT_ROCK01_DEFAULT01",
+      "CAVEKIT_ROCK01_LOW01",
+      "CAVEKIT_ROCK01_WALLTOP01",
+      "CAVEKIT_ROCK01_WALLTOP02",
+      "CAVEKIT_ROCK01_WALLTOP03",
+      "CAVEKIT_ROCK01_WALLTOP04",
+      "CAVEKIT_ROCK01_FALLOFF01",
+      "DECOKIT_ROCK01_MIDDLE01",
+      "DECOKIT_ROCK01_MIDDLE02",
+      "DECOKIT_ROCK01_CORNER01",
+      "DECOKIT_ROCK01_CORNER02",
+      "DECOKIT_ROCK01_CORNER03",
+      "DECOKIT_ROCK01_EDGE01",
+      "DECOKIT_ROCK01_EDGE02",
+      "DECOKIT_ROCK01_EDGE03",
+      "DECOKIT_ROCK01_JOIN01",
+      "DECOKIT_ROCK01_JOIN02",
+      "CAVEKIT_ROCK02_LOW02",
+      "WILD_BOSS_ESCAPE_CAVE_EXIT01",
+      "WILD_BOSS_ESCAPE_CAVE_EXIT02",
+      "WILD_BOSS_ESCAPE_CAVE_EXIT_NOOP",
+      "WILD_ESCAPECAVE_STALAGMITE01",
+      "WILD_ESCAPECAVE_STALAGMITE02",
+      "WILD_ESCAPECAVE_DUGUPSOIL_1",
+      "WILD_ESCAPECAVE_DUGUPSOIL_2",
+      "CAVEKIT_ROCK01_VARIANT01",
+      "CAVEKIT_ROCK01_VARIANT02",
+      "CAVEKIT_ROCK01_DOUBLE01",
+      "CAVEKIT_ROCK01_TRANSITION01",
+      "CAVEKIT_ROCK01_TRANSITION02",
+      "CAVEKIT_ROCK01_BACKGROUND01",
+      "CAVEKIT_ROCK01_DEFAULT01_DARK01",
+      "CAVEKIT_ROCK01_DEFAULT01_DARK02",
+      "CAVEKIT_ROCK01_DEFAULT01_DARK03",
+      "CAVEKIT_ROCK01_LOW03",
+      "CAVEKIT_ROCK01_CHASM01",
+      "CAVEKIT_ROCK01_CHASM01_LIGHT01",
+      "CAVEKIT_ROCK01_CHASM01_LIGHT02",
+      "CAVEKIT_ROCK01_CHASM01_DARK01",
+      "CAVEKIT_ROCK01_CHASM01_DARK02",
+      "CAVEKIT_ROCK01_CHASM01_DARK03",
+      "CAVEKIT_ROCK01_FALLOFF01_LEDGE01",
+      "CAVEKIT_ROCK01_FALLOFF01_LEDGE01_DARK01",
+      "CAVEKIT_ROCK01_FALLOFF01_LEDGE01_DARK02",
+      "CAVEKIT_ROCK01_FALLOFF01_LEDGE01_DARK03",
+      "CAVEKIT_ROCK01_FALLOFF01_LEDGE01_PILLAR01",
+      "CAVEKIT_ROCK01_FALLOFF01_LEDGE02",
+      "DECOKIT_ROCK01_MIDDLE01_DARK02",
+      "PMOON_TEMPLE_BLOOD_TALL",
+      "PMOON_TEMPLE_BLUE_TALL",
+      "PMOON_TEMPLE_ECLIPSE_TALL",
+      "PMOON_TEMPLE_MOSS01_TALL",
+      "PMOON_TEMPLE_MOSS02_TALL",
+      "PMOON_TEMPLE_MOSS03_TALL",
+      "ROCK_LAVA01_LARGE01",
+      "ROCK_LAVA01_LARGE02",
+      "ROCK_LAVA01_LARGE03",
+      "ROCK_LAVA01_MEDIUM01",
+      "ROCK_LAVA01_MEDIUM02",
+      "ROCK_LAVA01_MEDIUM03",
+      "ROCK_LAVA01_SMALL01",
+      "ROCK_LAVA01_SMALL02",
+      "PMOON_TELEBOX_CAVE",
+      "VARLAMORE_MINING_ROCK",
+      "VARLAMORE_MINING_ROCK_EMPTY",
+      "VARLAMORE_MINING_ROCK02",
+      "VARLAMORE_MINING_ROCK03",
+      "VARLAMORE_MINING_ROCK_EMPTY03",
+      "VARLAMORE_MINING_ROCK04",
+      "VARLAMORE_MINING_ROCK_EMPTY04",
+      "ROR_RUBBLE01_LARGE01",
+      "ROR_RUBBLE01_MEDIUM01",
+      "ROR_RUBBLE01_SMALL01",
+      "ROR_TEMPLE_TALL",
+      "ROR_TEMPLE_PILLAR01_BROKEN02",
+      "ROR_TEMPLE_TALL_DARK01",
+      "ROR_TEMPLE_TALL_DARK02",
+      "ROR_TEMPLE_SHORT_DARK01",
+      "ROR_TEMPLE_TALL_ARCH01",
+      "ROR_TEMPLE_TALL_ARCH01_DARK01",
+      "ROR_TEMPLE_TALL_ARCH01_DARK02",
+      "ROR_TEMPLE01_LOW01",
+      "ROR_TEMPLE_LOW02",
+      "ROR_TEMPLE_CRUMBLE01",
+      "ROR_TEMPLE_CRUMBLE02",
+      "DUNGEONKIT_ECLIPSE01_FALLOFF01",
+      "ROR_TEMPLE_TALL_ECLIPSE",
+      "ROR_TEMPLE_TALL_BLUE",
+      "ROR_TEMPLE_BLOOD_TALL",
+      "ROR_TEMPLE_BLOOD_TALL_DARK01",
+      "ROR_TEMPLE_BLOOD_SHORT_DARK01",
+      "STEPS_ROR_DEFAULT01",
+      "STEPS_ROR_DEFAULT01_DARK01",
+      "STEPS_ROR_DEFAULT01_DARK02",
+      "STEPS_ROR_CORNER01",
+      "STEPS_ROR_CORNER01_DARK02",
+      "STEPS_ROR_CORNER02_DARK02",
+      "PMOON_BOSS_EXIT_STAIRS"
     ],
     "uvType": "BOX",
     "uvScale": 0.86
@@ -21495,9 +21495,9 @@
     "description": "Hunter Guild Entrance Bone Arches, Colossal Wyrm Ribs",
     "baseMaterial": "BONE",
     "objectIds": [
-      51657,
-      51658,
-      51659
+      "BONES_WYRM01_COLOSSAL01",
+      "BONES_WYRM01_COLOSSAL02",
+      "BONES_WYRM01_COLOSSAL03"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -21506,10 +21506,10 @@
     "description": "Hunter Guild Wooden Fence Walls",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      51639,
-      51663,
-      51668,
-      51672
+      "WALLKIT_ROOKERY01_FENCE01",
+      "WALLKIT_PALISADE01_DEFAULT01",
+      "WALLKIT_PALISADE01_DEFAULT04",
+      "WALLKIT_PALISADE01_TALL01"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -21523,33 +21523,33 @@
     "description": "Hunter Guild Big Tree",
     "baseMaterial": "BARK",
     "objectIds": [
-      51619,
-      51620,
-      51621,
-      51622,
-      51623,
-      51624,
-      51625,
-      51627,
-      51628,
-      51629,
-      51631,
-      51633,
-      51635,
-      51637,
-      51638,
-      51646,
-      51646,
-      51647,
-      51648,
-      51649,
-      51650,
-      51651,
-      51652,
-      51653,
-      51654,
-      51655,
-      51656
+      "WALLKIT_ROOKERY01_DEFAULT01",
+      "WALLKIT_ROOKERY02_DEFAULT01",
+      "WALLKIT_ROOKERY01_ROOT01",
+      "WALLKIT_ROOKERY01_BRANCH01",
+      "WALLKIT_ROOKERY01_EDGE01",
+      "WALLKIT_ROOKERY02_EDGE01",
+      "WALLKIT_ROOKERY01_CORNER01",
+      "WALLKIT_ROOKERY02_CORNER01",
+      "WALLKIT_ROOKERY01_INNER01",
+      "WALLKIT_ROOKERY01_INNER02",
+      "WALLKIT_ROOKERY01_INNER03",
+      "WALLKIT_ROOKERY01_ENTRANCE02",
+      "WALLKIT_ROOKERY01_ENTRANCE04",
+      "WALLKIT_ROOKERY02_ENTRANCE02",
+      "WALLKIT_ROOKERY03_PILLAR01",
+      "FLOORKIT_ROOKERY01_CENTER01",
+      "FLOORKIT_ROOKERY01_CENTER01",
+      "FLOORKIT_ROOKERY01_CORNER01",
+      "FLOORKIT_ROOKERY01_CORNER01_M",
+      "FLOORKIT_ROOKERY01_CORNER02",
+      "FLOORKIT_ROOKERY01_CORNER03",
+      "FLOORKIT_ROOKERY01_CORNER03_M",
+      "FLOORKIT_ROOKERY01_CORNER04",
+      "FLOORKIT_ROOKERY01_EDGE01",
+      "FLOORKIT_ROOKERY01_EDGE01_M",
+      "FLOORKIT_ROOKERY01_EDGE02",
+      "FLOORKIT_ROOKERY01_EDGE02_M"
     ],
     "uvType": "BOX",
     "uvScale": 1.2
@@ -21558,9 +21558,9 @@
     "description": "Hunter Guild Big Tree with Leaves",
     "baseMaterial": "BARK",
     "objectIds": [
-      51632,
-      51634,
-      51636
+      "WALLKIT_ROOKERY01_ENTRANCE01",
+      "WALLKIT_ROOKERY01_ENTRANCE03",
+      "WALLKIT_ROOKERY02_ENTRANCE01"
     ],
     "uvType": "BOX",
     "uvScale": 1.2,
@@ -21575,7 +21575,7 @@
     "description": "Hunter Guild Big Tree with Banners",
     "baseMaterial": "BARK",
     "objectIds": [
-      51630
+      "WALLKIT_ROOKERY01_INNER02_FUR01"
     ],
     "uvType": "BOX",
     "uvScale": 1.2,
@@ -21592,7 +21592,7 @@
     "description": "Hunter Guild Big Tree with Carving",
     "baseMaterial": "BARK",
     "objectIds": [
-      51641
+      "HUNTERGUILD_STAIRS_DOWN01_COMBINED"
     ],
     "uvType": "BOX",
     "uvScale": 1.2,
@@ -21609,7 +21609,7 @@
     "description": "Hunter Guild Big Tree Rope",
     "baseMaterial": "ROPE",
     "objectIds": [
-      51643
+      "HUNTERGUILD_ROPE_UP01"
     ],
     "uvType": "BOX",
     "uvOrientation": -50,
@@ -21619,14 +21619,14 @@
     "description": "Hunter Guild blue rug",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      51737,
-      51738,
-      51739,
-      51740,
-      51741,
-      51742,
-      51743,
-      51744
+      "HG_RUG_ANTELOPE01_CORNER01",
+      "HG_RUG_ANTELOPE01_CORNER02",
+      "HG_RUG_ANTELOPE01_CORNER03",
+      "HG_RUG_ANTELOPE01_CORNER04",
+      "HG_RUG_ANTELOPE01_EDGE01",
+      "HG_RUG_ANTELOPE01_EDGE02",
+      "HG_RUG_ANTELOPE01_EDGE03",
+      "HG_RUG_ANTELOPE01_EDGE04"
     ],
     "uvType": "WORLD_XZ",
     "uvScale": 0.3
@@ -21635,10 +21635,10 @@
     "description": "Hunter Guild Cavern Counter",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      51718,
-      51719,
-      51720,
-      51721
+      "HG_TABLE_TAVERN02_DEFAULT01",
+      "HG_TABLE_TAVERN02_CORNER01",
+      "HG_TABLE_TAVERN02_TAPS01",
+      "HG_TABLE_TAVERN02_DOOR01"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512
@@ -21647,7 +21647,7 @@
     "description": "Hunter Guild Wooden Pillars",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      51745
+      "HG_PILLAR_HUNTERGUILD01_DEFAULT01"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -21656,8 +21656,8 @@
     "description": "Varlamore and Hunter Guild Wooden Barrels",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      52425,
-      52430
+      "BARREL_WOODEN01_CIVITAS01",
+      "BARREL_WOODEN01_AVIUM01"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -21666,8 +21666,8 @@
     "description": "Varlamore and Hunter Guild Wooden Crates",
     "baseMaterial": "WOOD_GRAIN_3_LIGHT",
     "objectIds": [
-      52431,
-      52432
+      "CRATE_CIVITAS01_SINGLE01",
+      "CRATE_CIVITAS01_STACK01"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -21676,7 +21676,7 @@
     "description": "Hunter Guild Bank Chest",
     "baseMaterial": "WOOD_GRAIN_2_LIGHT",
     "objectIds": [
-      53015
+      "FORTIS_BANK_CHEST_SMALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -21685,7 +21685,7 @@
     "description": "Hunter Guild Caverns Stairs",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      51642
+      "HUNTERGUILD_STAIRS_UP01"
     ],
     "uvType": "BOX",
     "uvScale": 1.5
@@ -21694,12 +21694,12 @@
     "description": "Varlamore, Stools and tables covered in furs, MODEL_XZ is used with intent",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      51722,
-      51723,
-      51724,
-      51725,
-      51726,
-      51727
+      "HG_TABLE_TAVERN02_SQUARE01",
+      "HG_TABLE_TAVERN02_SQUARE01_FUR02",
+      "HG_CHAIR_TAVERN02_DEFAULT01",
+      "HG_CHAIR_TAVERN02_SEWING01",
+      "HG_CHAIR_TAVERN02_HIDE01",
+      "HG_CHAIR_TAVERN02_HIDE02"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.4
@@ -21708,7 +21708,7 @@
     "description": "Varlamore - Well",
     "baseMaterial": "STONE",
     "objectIds": [
-      46805
+      "WELL_OASIS"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -21724,8 +21724,8 @@
     "description": "Varlamore, 'Take-log' Roots in Hunter Guild Caverns",
     "baseMaterial": "BARK",
     "objectIds": [
-      51746,
-      51747
+      "HG_CAVEKIT_ROOTS01_BOTTOM01",
+      "HG_CAVEKIT_ROOTS01_TOP01"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -21734,10 +21734,10 @@
     "description": "Hunter Pitfall Spiked Pit - Snowy",
     "baseMaterial": "SNOW_2",
     "objectIds": [
-      19249,
-      19250,
-      19251,
-      19252
+      "HUNTING_PITFALL_POLAR_LARGE_SW",
+      "HUNTING_PITFALL_POLAR_LARGE_SE",
+      "HUNTING_PITFALL_POLAR_LARGE_NW",
+      "HUNTING_PITFALL_POLAR_LARGE_NE"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 1.2
@@ -21746,14 +21746,14 @@
     "description": "Hunter Pitfall Spiked Pit - Mossy",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      19241,
-      19242,
-      19243,
-      19244,
-      53029,
-      53030,
-      53031,
-      53032
+      "HUNTING_PITFALL_WOODLAND_LARGE_SW",
+      "HUNTING_PITFALL_WOODLAND_LARGE_SE",
+      "HUNTING_PITFALL_WOODLAND_LARGE_NW",
+      "HUNTING_PITFALL_WOODLAND_LARGE_NE",
+      "HUNTING_PITFALL_SAVANNAH_LARGE_SW",
+      "HUNTING_PITFALL_SAVANNAH_LARGE_SE",
+      "HUNTING_PITFALL_SAVANNAH_LARGE_NW",
+      "HUNTING_PITFALL_SAVANNAH_LARGE_NE"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.25
@@ -21762,10 +21762,10 @@
     "description": "Hunter Pitfall Spiked Pit - Wooden",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      53025,
-      53026,
-      53027,
-      53028
+      "HUNTING_PITFALL_CAVE_LARGE_SW",
+      "HUNTING_PITFALL_CAVE_LARGE_SE",
+      "HUNTING_PITFALL_CAVE_LARGE_NW",
+      "HUNTING_PITFALL_CAVE_LARGE_NE"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.65,
@@ -21775,10 +21775,10 @@
     "description": "Hunter Pitfall Spiked Pit - Sandy",
     "baseMaterial": "SAND_3",
     "objectIds": [
-      19245,
-      19246,
-      19247,
-      19248
+      "HUNTING_PITFALL_DESERT_LARGE_SW",
+      "HUNTING_PITFALL_DESERT_LARGE_SE",
+      "HUNTING_PITFALL_DESERT_LARGE_NW",
+      "HUNTING_PITFALL_DESERT_LARGE_NE"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.25,
@@ -21788,9 +21788,9 @@
     "description": "Hunter Guild Pitfall - Pit",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      53033,
-      53034,
-      53035
+      "CAVEKIT_ROCK01_FLOOR_END",
+      "CAVEKIT_ROCK01_FLOOR_END_MIRROR",
+      "CAVEKIT_ROCK01_FLOOR_EDGE"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.65,
@@ -21800,50 +21800,50 @@
     "description": "Hunter - Young trees, Net traps",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      8730,
-      8732,
-      8733,
-      8734,
-      8972,
-      8973,
-      8974,
-      8985,
-      8986,
-      8987,
-      8988,
-      8989,
-      8990,
-      8991,
-      8993,
-      8996,
-      8997,
-      8998,
-      8999,
-      9000,
-      9001,
-      9003,
-      9004,
-      9005,
-      9158,
-      9257,
-      9341,
-      9342,
-      50716,
-      50717,
-      50719,
-      50720,
-      50721,
-      50722
-  ],
-  "uvType": "BOX",
-  "uvScale": 0.5
+      "HUNTING_SAPLING_SET_ORANGE",
+      "HUNTING_SAPLING_UP_ORANGE",
+      "HUNTING_SAPLING_SETTING_ORANGE",
+      "HUNTING_SAPLING_FULL_ORANGE",
+      "HUNTING_SAPLING_CATCHING_ORANGE",
+      "HUNTING_SAPLING_FAILED_ORANGE",
+      "HUNTING_SAPLING_FAILING_ORANGE",
+      "HUNTING_SAPLING_CATCHING_RED",
+      "HUNTING_SAPLING_FULL_RED",
+      "HUNTING_SAPLING_FAILING_RED",
+      "HUNTING_SAPLING_FAILED_RED",
+      "HUNTING_SAPLING_SET_RED",
+      "HUNTING_SAPLING_UP_RED",
+      "HUNTING_SAPLING_SETTING_RED",
+      "HUNTING_SAPLING_CATCHING_BLACK",
+      "HUNTING_SAPLING_FULL_BLACK",
+      "HUNTING_SAPLING_FAILING_BLACK",
+      "HUNTING_SAPLING_FAILED_BLACK",
+      "HUNTING_SAPLING_SET_BLACK",
+      "HUNTING_SAPLING_UP_BLACK",
+      "HUNTING_SAPLING_SETTING_BLACK",
+      "HUNTING_SAPLING_CATCHING_GREEN",
+      "HUNTING_SAPLING_FULL_GREEN",
+      "HUNTING_SAPLING_FAILING_SWAMP",
+      "HUNTING_SAPLING_FAILED_SWAMP",
+      "HUNTING_SAPLING_SET_SWAMP",
+      "HUNTING_SAPLING_UP_SWAMP",
+      "HUNTING_SAPLING_SETTING_SWAMP",
+      "HUNTING_SAPLING_CATCHING_MOUNTAIN",
+      "HUNTING_SAPLING_FULL_MOUNTAIN",
+      "HUNTING_SAPLING_FAILED_MOUNTAIN",
+      "HUNTING_SAPLING_SET_MOUNTAIN",
+      "HUNTING_SAPLING_UP_MOUNTAIN",
+      "HUNTING_SAPLING_SETTING_MOUNTAIN"
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.5
   },
   {
     "description": "Hunter Tracking Burrows",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      19593,
-      19552
+      "HUNTING_TRAIL_SPAWN_JUNGLE1",
+      "HUNTING_TRAIL_SPAWN_DESERT1"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -21852,7 +21852,7 @@
     "description": "Hunter Kharidian Desert Tracking Disturbed Sand",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      19430
+      "HUNTING_TRAIL_END_DESERT"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -21861,23 +21861,23 @@
     "description": "Hunter Kharidian Desert Tracking Cacti",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      19389,
-      19391,
-      19392,
-      19394,
-      19395,
-      19398,
-      19399,
-      19401
+      "HUNTING_TRAIL_CLUE4_8",
+      "HUNTING_TRAIL_CLUE5_1",
+      "HUNTING_TRAIL_CLUE5_2",
+      "HUNTING_TRAIL_CLUE5_4",
+      "HUNTING_TRAIL_CLUE5_5",
+      "HUNTING_TRAIL_CLUE5_8",
+      "HUNTING_TRAIL_CLUE5_9",
+      "HUNTING_TRAIL_CLUE6_1"
     ]
   },
   {
     "description": "Hunter Kharidian Desert Tracking Brown Rock",
     "baseMaterial": "ROCK_1",
     "objectIds": [
-      19396,
-      19400,
-      19402
+      "HUNTING_TRAIL_CLUE5_6",
+      "HUNTING_TRAIL_CLUE6_0",
+      "HUNTING_TRAIL_CLUE6_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -21886,21 +21886,21 @@
     "description": "Bear Rugs",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      946,
-      947,
-      948,
-      949,
-      950,
-      951,
-      952,
-      953
+      "FUR1",
+      "FUR2",
+      "FUR3",
+      "FUR4",
+      "FUR_A",
+      "FUR_B",
+      "FUR_C",
+      "FUR_D"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.4
   },
   {
     "description": "Obelisk of Earth",
-    "objectIds": [ 2150 ],
+    "objectIds": [ "OBELISK_EARTH" ],
     "baseMaterial": "ROCK_5",
     "uvType": "BOX",
     "uvOrientation": 700,
@@ -21908,7 +21908,7 @@
   },
   {
     "description": "Obelisk of Water",
-    "objectIds": [ 2151 ],
+    "objectIds": [ "OBELISK_WATER" ],
     "flatNormals": true,
     "retainVanillaUvs": false,
     "materialOverrides": {
@@ -21922,13 +21922,13 @@
   },
   {
     "description": "Obelisk of Air",
-    "objectIds": [ 2152 ],
+    "objectIds": [ "OBELISK_AIR" ],
     "flatNormals": true,
     "receiveShadows": false
   },
   {
     "description": "Obelisk of Fire",
-    "objectIds": [ 2153 ],
+    "objectIds": [ "OBELISK_FIRE" ],
     "flatNormals": true,
     "retainVanillaUvs": false,
     "materialOverrides": {
@@ -21943,7 +21943,7 @@
     "description": "Objects - Stone - Keldagrim Pillars - Twisted",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      7016
+      "DWARF_KELDAGRIM_PALACE_PILLAR"
     ],
     "uvType": "BOX",
     "uvScale": 0.86,
@@ -21953,7 +21953,7 @@
     "description": "Objects - Stone - Keldagrim Pillars - Straight",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      7017
+      "DWARF_KELDAGRIM_PALACE_PILLAR2"
     ],
     "uvType": "BOX",
     "uvScale": 0.86,
@@ -21963,7 +21963,7 @@
     "description": "Metal Street Lanturn",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      6202
+      "DWARF_KELDAGRIM_LAMP"
     ],
     "uvType": "BOX",
     "uvOrientation": 96,
@@ -21974,7 +21974,7 @@
     "description": "Keldagrim Fireplace",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      6093
+      "DWARF_KELDAGRIM_KEBAB_FIREPLACE"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -21984,7 +21984,7 @@
     "description": "Keldagrim Fireplace with Spit - Empty",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      6094
+      "DWARF_KELDAGRIM_POOR_FIREPLACE"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -21994,7 +21994,7 @@
     "description": "Keldagrim Fireplace with Spit and Meat",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      6095
+      "DWARF_KELDAGRIM_FIREPLACE"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22004,7 +22004,7 @@
     "description": "White Wolf Mountain Wall Supports",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      17082, 17083, 17084, 17085
+      "XBOWS_INSIDE_WALL_A", "XBOWS_INSIDE_WALL_A_MIRROR", "XBOWS_INSIDE_WALL_B", "XBOWS_INSIDE_WALL_B_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -22014,7 +22014,7 @@
     "description": "Wooden Cupboard Empty",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7018
+      "DWARF_KELDAGRIM_SMALL_CUPBOARD"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -22024,7 +22024,7 @@
     "description": "Wooden Cabinet Empty",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7019
+      "DWARF_KELDAGRIM_BEER_EMPTY"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -22034,7 +22034,7 @@
     "description": "Rat Wall",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      10342, 10343
+      "VC_DWARFRAT_WALL1", "VC_DWARFRAT_WALL2"
     ],
     "uvType": "BOX",
     "uvScale": 1.1,
@@ -22044,7 +22044,7 @@
     "description": "Strange Box - Metal",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      8879, 8880
+      "KELDAGRIM_TRACK_JUNCTION_CARD_BOX", "KELDAGRIM_TRACK_JUNCTION_CARD_BOX_OPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22054,7 +22054,7 @@
     "description": "Scaffolding - Metal",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      8899, 8900, 8901, 8902, 8903, 8904
+      "KELDAGRIM_TRACK_SUPPORTS", "KELDAGRIM_TRACK_SUPPORTS2", "KELDAGRIM_TRACK_SUPPORTS3", "KELDAGRIM_TRACK_SUPPORTS4", "KELDAGRIM_TRACK_SUPPORTS5", "KELDAGRIM_TRACK_SUPPORTS6"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22064,7 +22064,7 @@
     "description": "Struts - Metal",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      8917
+      "DWARF_METAL_PITPROP"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22074,7 +22074,7 @@
     "description": "Zeah Battlefield - Objects - Stone - Pillars",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      34358
+      "BRIMSTONE_ELEVATOR_PILLAR"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -22083,7 +22083,7 @@
     "description": "Zeah Battlefield - Objects - Stone - Tiles",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      23106
+      "BROKEN_GREY_TILE_01"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22093,7 +22093,7 @@
     "description": "Zeah Battlefield - Objects - Stone - Ancient Grave",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      33579
+      "ARCQUEST_GRAVE_NOOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -22104,7 +22104,7 @@
     "description": "Zeah Battlefield - Objects - Stone - Ornate Fountain",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      10827
+      "DRAYNOR_FOUNTAIN"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -22115,7 +22115,7 @@
     "description": "Zeah Battlefield - Walls - Metal Fence",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      27926
+      "ARCHEUUS_FENCE_01"
     ],
     "uvType": "BOX"
   },
@@ -22123,7 +22123,7 @@
     "description": "Zeah - Rough Plank Walls",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8695, 8696, 8704
+      "FARMDOOR", "FARMDOOROPEN", "FARM_BARN_WALL"
     ],
     "uvType": "BOX",
     "uvOrientation": 1024,
@@ -22133,7 +22133,7 @@
     "description": "Zeah - Rough Plank Roofs",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8705, 8706, 8707
+      "FARM_BARN_ROOF1", "FARM_BARN_ROOF2", "FARM_BARN_ROOF"
     ],
     "uvType": "BOX",
     "uvOrientationY": 1024,
@@ -22144,7 +22144,7 @@
     "description": "Zeah - Rough Plank Roofs - Corners",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8708, 8709, 8710, 8711
+      "FARM_BARN_ROOF_EDGE", "FARM_BARN_ROOF_EDGE_2", "FARM_BARN_ROOF_EDGE_2_MIRROR", "FARM_BARN_ROOF_EDGE_MIRROR"
     ],
     "uvType": "BOX",
     "uvOrientationX": 1024,
@@ -22156,7 +22156,7 @@
     "description": "Objects - Metal Milk Urn",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      8690
+      "MILK_URNS"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -22166,7 +22166,7 @@
     "description": "Zeah - Wooden Spiral Staircase",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      34502
+      "KEBOS_SPIRALSTAIRS_BOTTOM"
     ],
     "uvType": "BOX",
     "uvOrientation": 88,
@@ -22176,27 +22176,27 @@
     "description": "Zeah - Kourend - Plants",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      42398,
-      42399,
-      42400,
-      42401,
-      42402,
-      42403,
-      42404
+      "GROUNDCOVER_PLANT1_WITHERED",
+      "GROUNDCOVER_PLANT2_WITHERED",
+      "GROUNDCOVER_PLANT3_WITHERED",
+      "GROUNDCOVER_PLANT4_WITHERED",
+      "GROUNDCOVER_PLANT1_ROTTEN",
+      "GROUNDCOVER_PLANT2_ROTTEN",
+      "GROUNDCOVER_PLANT3_ROTTEN"
     ]
   },
   {
     "description": "Kourend - Hosidius - Tithe Farm - Greenhouse Walls",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      1755,
-      1756,
-      1757,
-      1758,
-      1759,
-      1760,
-      1761,
-      27472
+      "TITHE_ROOF_A",
+      "TITHE_ROOF_A2",
+      "TITHE_ROOF_G",
+      "TITHE_ROOF_G2",
+      "TITHE_ROOF_F",
+      "TITHE_ROOF_F2",
+      "TITHE_ROOF_H",
+      "VINE_GLASS_HOUSE_WALL"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -22206,7 +22206,7 @@
     "description": "Kourend - Hosidius - Tithe Farm - Seed Table",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      27430
+      "TITHE_PLANT_SEED_TABLE"
     ],
     "colorOverrides": [
       {
@@ -22221,7 +22221,7 @@
     "description": "Kourend - Hosidius - Tithe Farm - Table with Dishes",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      2998
+      "FAI_VARROCK_DIRTY_TABLE"
     ],
     "colorOverrides": [
       {
@@ -22236,7 +22236,7 @@
     "description": "Kourend - Hosidius - Tithe Farm - Water Barrel",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      5598
+      "WATER_BARREL1"
     ],
     "colorOverrides": [
       {
@@ -22252,7 +22252,7 @@
     "description": "Kourend - Hosidius - Tithe Farm - Cart with covering",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      27429
+      "TITHE_PLANT_CART"
     ],
     "uvType": "BOX",
     "uvOrientationX": -165,
@@ -22269,7 +22269,7 @@
     "description": "Kourend - Hosidius - Tithe Farm - Bed - Sleeping Bag",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      6250
+      "FEUD_POORBED"
     ],
     "colorOverrides": [
       {
@@ -22284,9 +22284,9 @@
     "description": "Kourend - Hosidius - Tithe Farm - Baskets",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      27521,
-      27522,
-      27524
+      "HOS_BASKET",
+      "HOS_BASKET_APPLE",
+      "HOS_BASKET_ONION"
     ],
     "colorOverrides": [
       {
@@ -22299,8 +22299,8 @@
     "description": "Kourend - Hosidius - Tithe Farm - Fruit Sacks",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      27431,
-      27432
+      "TITHE_SACK_OF_FRUIT_EMPTY",
+      "TITHE_SACK_OF_FRUIT"
     ],
     "colorOverrides": [
       {
@@ -22315,7 +22315,7 @@
     "description": "Kourend - Hosidius - Tithe Farm - Small Sacks",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      10313
+      "VC_SACKS"
     ],
     "colorOverrides": [
       {
@@ -22330,7 +22330,7 @@
     "description": "Kourend - Hosidius - Tithe Farm - Spades and Rakes",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      7516
+      "FARMING_TOOLS"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -22346,13 +22346,13 @@
     "description": "Kourend - Hosidius - Tithe Farm - Giant Fruits",
     "baseMaterial": "GRUNGE_3_DARK",
     "objectIds": [
-      27384, 27385, 27386, 27387, 27388, 27389,
-      27390, 27391, 27392, 27393, 27394, 27395,
-      27396, 27397, 27398, 27399, 27400, 27401,
-      27402, 27403, 27404, 27405, 27406, 27407,
-      27408, 27409, 27410, 27411, 27412, 27413,
-      27414, 27415, 27416, 27417, 27418, 27419,
-      27420, 27421, 27422, 27423, 27424
+      "HOSIDIUS_TITHE_A_1_DRY", "HOSIDIUS_TITHE_A_1_WET", "HOSIDIUS_TITHE_A_1_DEAD", "HOSIDIUS_TITHE_A_2_DRY", "HOSIDIUS_TITHE_A_2_WET", "HOSIDIUS_TITHE_A_2_DEAD",
+      "HOSIDIUS_TITHE_A_3_DRY", "HOSIDIUS_TITHE_A_3_WET", "HOSIDIUS_TITHE_A_3_DEAD", "HOSIDIUS_TITHE_A_4", "HOSIDIUS_TITHE_A_4_DEAD", "HOSIDIUS_TITHE_B_1_DRY",
+      "HOSIDIUS_TITHE_B_1_WET", "HOSIDIUS_TITHE_B_1_DEAD", "HOSIDIUS_TITHE_B_2_DRY", "HOSIDIUS_TITHE_B_2_WET", "HOSIDIUS_TITHE_B_2_DEAD", "HOSIDIUS_TITHE_B_3_DRY",
+      "HOSIDIUS_TITHE_B_3_WET", "HOSIDIUS_TITHE_B_3_DEAD", "HOSIDIUS_TITHE_B_4", "HOSIDIUS_TITHE_B_4_DEAD", "HOSIDIUS_TITHE_C_1_DRY", "HOSIDIUS_TITHE_C_1_WET",
+      "HOSIDIUS_TITHE_C_1_DEAD", "HOSIDIUS_TITHE_C_2_DRY", "HOSIDIUS_TITHE_C_2_WET", "HOSIDIUS_TITHE_C_2_DEAD", "HOSIDIUS_TITHE_C_3_DRY", "HOSIDIUS_TITHE_C_3_WET",
+      "HOSIDIUS_TITHE_C_3_DEAD", "HOSIDIUS_TITHE_C_4", "HOSIDIUS_TITHE_C_4_DEAD", "HOSIDIUS_TITHE_A_1_SCENERY", "HOSIDIUS_TITHE_A_2_SCENERY", "HOSIDIUS_TITHE_A_3_SCENERY",
+      "HOSIDIUS_TITHE_A_4_SCENERY", "HOSIDIUS_TITHE_B_1_SCENERY", "HOSIDIUS_TITHE_B_2_SCENERY", "HOSIDIUS_TITHE_B_3_SCENERY", "HOSIDIUS_TITHE_B_4_SCENERY"
     ],
     "uvType": "BOX"
   },
@@ -22360,7 +22360,7 @@
     "description": "Kourend - Hosidius - Vinery - Grape Arbor",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      27510
+      "HOS_GRAPE_ARBOUR"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -22371,7 +22371,7 @@
     "description": "Kourend - Hosidius - Vinery - Stacked Barrels",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      27520
+      "HOS_BARREL_RACK_01"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -22380,8 +22380,8 @@
     "description": "Kourend - Hosidius - Vinery - Big Wine Barrels",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      11808,
-      41928
+      "HOS_BIG_WINE_BARREL_1",
+      "AKD_HOSIDIUS_OFFICE_ENTRY_OP"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -22396,7 +22396,7 @@
     "description": "Kourend - Hosidius - Vinery - Arching Grape Vine",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      1754
+      "GRAPEVINE_OLD"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -22412,34 +22412,34 @@
     "description": "Kourend - Hosidius - Vinery - Grape Vine",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      1750,
-      1751,
-      1752,
-      1753,
-      11166,
-      11167,
-      11168,
-      11169,
-      11170,
-      11171,
-      11172,
-      11173,
-      11744,
-      11745,
-      11746,
-      11747,
-      11748,
-      11749,
-      11751,
-      11752,
-      11753,
-      11754,
-      11755,
-      11756,
-      11757,
-      11758,
-      11759,
-      22351
+      "GRAPEVINE_SUPPORT",
+      "GRAPEVINE_SUPPORT_L",
+      "GRAPEVINE_SUPPORT_R",
+      "GRAPEVINE_LORD_HOSIDIUS",
+      "GRAPEVINE_CLICKZONE_SEEDLING",
+      "GRAPEVINE_GROWING_1",
+      "GRAPEVINE_CLICKZONE_GROWING_1",
+      "GRAPEVINE_GROWING_2",
+      "GRAPEVINE_CLICKZONE_GROWING_2",
+      "GRAPEVINE_GROWING_3",
+      "GRAPEVINE_CLICKZONE_GROWING_3",
+      "GRAPEVINE_GROWING_4",
+      "GRAPEVINE_GROWING_5",
+      "GRAPEVINE_CLICKZONE_GROWING_5",
+      "GRAPEVINE_GROWING_6",
+      "GRAPEVINE_CLICKZONE_GROWING_6",
+      "GRAPEVINE_CLICKZONE_XP",
+      "GRAPEVINE_GRAPES_5",
+      "GRAPEVINE_GRAPES_4",
+      "GRAPEVINE_CLICKZONE_GRAPES_4",
+      "GRAPEVINE_GRAPES_3",
+      "GRAPEVINE_CLICKZONE_GRAPES_3",
+      "GRAPEVINE_GRAPES_2",
+      "GRAPEVINE_CLICKZONE_GRAPES_2",
+      "GRAPEVINE_GRAPE_1",
+      "GRAPEVINE_CLICKZONE_GRAPE_1",
+      "GRAPEVINE_DEAD",
+      "BRAIN_MUD_DUGUPSOIL_07"
     ],
     "uvType": "BOX",
     "uvScale": 0.2,
@@ -22454,7 +22454,7 @@
     "description": "Old Ones Tent",
     "baseMaterial": "CARPET",
     "objectIds": [
-      46324
+      "TGOD_TENT"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -22463,11 +22463,11 @@
     "description": "Hollow Log 1",
     "baseMaterial": "BARK",
     "objectIds": [
-      1322,
-      1334,
-      1335,
-      1338,
-      1378
+      "HOLLOWTREE",
+      "HOLLOWLOG",
+      "HOLLOWLOGSMALLER",
+      "HOLLOWLOG_VERYSMALL",
+      "HOLLOWLOG_WILDERNESS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22477,7 +22477,7 @@
     "description": "Hollow Log Light",
     "baseMaterial": "LIGHT_BARK",
     "objectIds": [
-      1379
+      "HOLLOWLOGSMALLER_WILDERNESS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22487,7 +22487,7 @@
     "description": "Old Ones Hole",
     "baseMaterial": "DIRT_2",
     "objectIds": [
-      46326, 46329, 46332, 46335
+      "TGOD_GARDEN_1_ENTRY", "TGOD_GARDEN_2_ENTRY_VIS", "TGOD_GARDEN_3_ENTRY_VIS", "TGOD_GARDEN_4_ENTRY_VIS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22497,7 +22497,7 @@
     "description": "Objects - Yellow Rocks - Rock - Small",
     "baseMaterial": "ROCK_5",
     "objectIds": [
-      7116, 7117, 7118
+      "FAI_VARROCK_DUGUPSOIL_04", "FAI_VARROCK_DUGUPSOIL_05", "FAI_VARROCK_DUGUPSOIL_06"
     ],
     "uvType": "BOX",
     "uvScale": 0.25
@@ -22506,7 +22506,7 @@
     "description": "Objects - Yellow Rocks - Rock - Medium",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      30787, 30788, 30789
+      "FOSSIL_U_ROCKS_SMALL_SOFT_01", "FOSSIL_U_ROCKS_SMALL_SOFT_02", "FOSSIL_U_ROCKS_SMALL_SOFT_03"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -22516,7 +22516,7 @@
     "description": "Objects - Yellow Rocks - Rock - Large",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      30784, 30785, 30786
+      "FOSSIL_U_ROCKS_BIG_SOFT_01", "FOSSIL_U_ROCKS_BIG_SOFT_02", "FOSSIL_U_ROCKS_BIG_SOFT_03"
     ],
     "uvType": "BOX",
     "uvScale": 0.33
@@ -22525,7 +22525,7 @@
     "description": "Old Ones Dungeon Ruined Walls",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      5475, 5477, 5478, 5479, 5480, 5481, 46337
+      "AHOY_TOMB_WALL", "AHOY_TOMB_WALL_LEV2", "AHOY_TOMB_WALL_TABLET_LEV2", "AHOY_TOMB_WALL_DAMAGE", "AHOY_TOMB_BLOCKPILE1", "AHOY_TOMB_WALL_TOP", "TGOD_GARDEN_BLOCKS_NOOP"
     ],
     "uvType": "BOX"
   },
@@ -22533,7 +22533,7 @@
     "description": "Old Ones Dungeon Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      8931, 8935
+      "DAGANNOTH_CAVEWALL_FACE1", "DAGANNOTH_MOUNTAIN_CAVEWALL_TOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 100
@@ -22542,85 +22542,85 @@
     "description": "Waterbirth Island Stairs",
     "baseMaterial": "STONE",
     "objectIds": [
-      8928,
-      8966
+      "DAGANNOTH_SKEWSTEPS",
+      "DAGANNOTH_ROCKY_STEPS"
     ]
   },
   {
     "description": "Waterbirth Metallic Objects - Dungeon Gates, Buttons and Ladders",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      4384,
-      8956,
-      8957,
-      8958,
-      8959,
-      8960,
-      8963,
-      8964,
-      8965,
-      10177,
-      10193,
-      10194,
-      10195,
-      10196,
-      10197,
-      10198,
-      10199,
-      10200,
-      10201,
-      10202,
-      10203,
-      10204,
-      10205,
-      10206,
-      10207,
-      10208,
-      10209,
-      10210,
-      10211,
-      10212,
-      10213,
-      10214,
-      10215,
-      10216,
-      10217,
-      10219,
-      10220,
-      10221,
-      10222,
-      10223,
-      10224,
-      10225,
-      10226,
-      10227,
-      10228
+      "HORROR_LADDER_JOIN",
+      "DAGANNOTH_LADDER_BASE",
+      "DAGANNOTH_PRESSURE_DOOR_FLOOR",
+      "DAGANNOTH_PRESSURE_DOOR",
+      "DAGANNOTH_PRESSURE_DOOR2",
+      "DAGANNOTH_PRESSURE_DOOR3",
+      "DAGANNOTH_PRESSURE_OPEN",
+      "DAGANNOTH_PRESSURE_PAD_1",
+      "DAGANNOTH_PRESSURE_PAD_2",
+      "DAGANNOTH_LADDER_BASE_EXT2",
+      "DAGEXP_ENTRANCE_LADDER",
+      "DAGEXP_EXIT_LADDER",
+      "DAGEXP_LADDER1",
+      "DAGEXP_LADDER2",
+      "DAGEXP_LADDER3",
+      "DAGEXP_LADDER4",
+      "DAGEXP_LADDER5",
+      "DAGEXP_LADDER6",
+      "DAGEXP_LADDER7",
+      "DAGEXP_LADDER8",
+      "DAGEXP_LADDER9",
+      "DAGEXP_LADDER10",
+      "DAGEXP_LADDER11",
+      "DAGEXP_LADDER12",
+      "DAGEXP_LADDER13",
+      "DAGEXP_LADDER14",
+      "DAGEXP_LADDER15",
+      "DAGEXP_LADDER16",
+      "DAGEXP_LADDER17",
+      "DAGEXP_LADDER18",
+      "DAGEXP_LADDER19",
+      "DAGEXP_LADDER20",
+      "DAGEXP_LADDER21",
+      "DAGEXP_LADDER22",
+      "DAGEXP_LADDER23",
+      "DAGEXP_LADDER25",
+      "DAGEXP_LADDER26",
+      "DAGEXP_LADDER27",
+      "DAGEXP_LADDER28",
+      "DAGEXP_LADDER29",
+      "DAGEXP_LADDER30",
+      "DAGEXP_LADDER31",
+      "DAGEXP_LADDER32",
+      "DAGEXP_LADDER33",
+      "DAGEXP_LADDER34"
     ]
   },
   {
     "description": "Waterbirth Dungeon Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      8932,
-      8933,
-      8939,
-      8940,
-      8941,
-      10180,
-      10181,
-      10182,
-      10183,
-      10184,
-      10187,
-      10231,
-      10232,
-      10233,
-      10234,
-      10235,
-      10236,
-      10238,
-      10239,
-      53258
+      "DAGANNOTH_CAVEWALL_FACE1_GLOW",
+      "DAGANNOTH_CAVEWALL_FACE1_FALLOFF",
+      "DAGANNOTH_CAVEWALL_FACE1_SHORTER",
+      "DAGANNOTH_CAVEWALL_FACE1_SHORTER_GLOW",
+      "DAGANNOTH_CAVEWALL_TOP_SHORTER",
+      "DAGANNOTH_CAVEWALL_PITTED_FACE1",
+      "DAGANNOTH_CAVEWALL_PITTED_FACE1_GLOW",
+      "DAGANNOTH_CAVEWALL_WATERY_FACE1_GLOW",
+      "DAGANNOTH_CAVEWALL_TORCH_FACE1",
+      "DAGANNOTH_CAVEWALL_TORCH_FACE1_GLOW",
+      "DAGANNOTH_CAVEWALL_CONCAVE_FACE1_GLOW",
+      "DAGANNOTH_CAVEWALL_FACE1_L2",
+      "DAGANNOTH_CAVEWALL_PITTED_FACE1_L2",
+      "DAGANNOTH_CAVEWALL_PITTED_FACE1_GLOW_L2",
+      "DAGANNOTH_CAVEWALL_WATERY_FACE1_GLOW_L2",
+      "DAGANNOTH_CAVEWALL_TORCH_FACE1_L2",
+      "DAGANNOTH_CAVEWALL_TORCH_FACE1_GLOW_L2",
+      "DAGANNOTH_CAVEWALL_FACE1_GLOW_L2",
+      "DAGANNOTH_CAVEWALL_FACE1_FALLOFF_L2",
+      "DAGANNOTH_CREVICE"
     ],
     "uvType": "BOX"
   },
@@ -22628,15 +22628,15 @@
     "description": "Waterbirth Dungeon Stalagmite",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      8947,
-      8948
+      "DAGANNOTH_STALAGMITE_TWIN",
+      "DAGANNOTH_STALAGMITE_SMALL"
     ]
   },
   {
     "description": "Waterbirth Dungeon Peak Crack",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      30169
+      "DK_PEEK_CRACK"
     ],
     "uvType": "BOX"
   },
@@ -22644,43 +22644,43 @@
     "description": "Waterbirth Dungeon Stone Chips",
     "baseMaterial": "STONE",
     "objectIds": [
-      8944,
-      8945,
-      8946
+      "DAGANNOTH_DUGUPSOIL_1",
+      "DAGANNOTH_DUGUPSOIL_2",
+      "DAGANNOTH_DUGUPSOIL_3"
     ]
   },
   {
     "description": "Waterbirth Rocks with Seaweed",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      8950,
-      8951,
-      8952
+      "DAGANNOTH_SEAWEEDROCK_LARGE",
+      "DAGGANOTH_SEAWEEDROCK_1",
+      "DAGGANOTH_SEAWEEDROCK_2"
     ]
   },
   {
     "description": "Waterbirth Water Puddles",
     "baseMaterial": "TRANSPARENT",
     "objectIds": [
-      10188,
-      10189,
-      10190,
-      10191,
-      10192
+      "DAGANNOTH_PUDDLE1",
+      "DAGANNOTH_PUDDLE_1B",
+      "DAGANNOTH_PUDDLE5",
+      "DAGANNOTH_PUDDLE_5B",
+      "DAGANNOTH_PUDDLE"
     ],
     "uvType": "BOX"
   },  {
   "description": "Waterbirth Water Leak",
   "baseMaterial": "SLIME_GRUNGE",
   "objectIds": [
-    10186
+    "DAGANNOTH_CAVEWALL_ANIMATED_WATER"
   ]
 },
   {
     "description": "Stone-  Ruined Steps",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      34354, 34355, 46407
+      "BRIMSTONE_SKEW_STEPS", "BRIMSTONE_ROCK_SKEW_STEPS", "TGOD_GARDEN_TEMPLE_STEPS"
     ],
     "uvType": "BOX"
   },
@@ -22688,7 +22688,7 @@
     "description": "Old Ones Vines",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      41817, 41818, 46381, 46382
+      "AKD_FORTHOS_VINES_END_LEFT", "AKD_FORTHOS_VINES_END_RIGHT", "TGOD_VINES_CUT", "TGOD_VINES_SQUEEZE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -22698,7 +22698,7 @@
     "description": "Old Ones Stone Pillar",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      46415
+      "TGOD_PILLAR01"
     ],
     "uvType": "BOX",
     "uvOrientation": 202
@@ -22707,7 +22707,7 @@
     "description": "Old Ones Stone Table",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46361
+      "TGOD_GARDEN_SMALL_TABLE_1_NOOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 202
@@ -22716,7 +22716,7 @@
     "description": "Old Ones Stone Table - Big",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46356
+      "TGOD_GARDEN_BIG_TABLE_1_NOOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 88
@@ -22725,7 +22725,7 @@
     "description": "Old Ones Stone Table - Big with objects",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46357, 46358, 46360, 46371
+      "TGOD_GARDEN_BIG_TABLE_2_NOOP", "TGOD_GARDEN_BIG_TABLE_3_NOOP", "TGOD_GARDEN_BIG_TABLE_5_NOOP", "TGOD_GARDEN_BIG_TABLE_2_OP"
     ],
     "uvType": "BOX",
     "uvOrientation": 88
@@ -22734,7 +22734,7 @@
     "description": "Old Ones Stone Table - Long",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46348
+      "TGOD_GARDEN_TABLE_1_NOOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 202
@@ -22743,7 +22743,7 @@
     "description": "Old Ones Stone Table - Long with Objects",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46349, 46350, 46355, 46365, 46366, 46376, 46377, 46378, 46379
+      "TGOD_GARDEN_TABLE_2_NOOP", "TGOD_GARDEN_TABLE_3_NOOP", "TGOD_GARDEN_TABLE_8_NOOP", "TGOD_GARDEN_TABLE_4_OP", "TGOD_GARDEN_TABLE_5_OP", "TGOD_GARDEN_1_TABLET_TABLE", "TGOD_GARDEN_2_TABLET_TABLE", "TGOD_GARDEN_3_TABLET_TABLE", "TGOD_GARDEN_4_TABLET_TABLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 202
@@ -22752,7 +22752,7 @@
     "description": "Old Ones Stone Chest",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46339, 46340, 46341
+      "TGOD_GARDEN_CHEST_NOOP", "TGOD_GARDEN_CHEST_OP", "TGOD_GARDEN_CHEST_CLOSED_NOOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 202
@@ -22761,7 +22761,7 @@
     "description": "Old Ones Stone Vase",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46342, 46343
+      "TGOD_GARDEN_VASE_NOOP", "TGOD_GARDEN_VASE_OP"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22771,7 +22771,7 @@
     "description": "Stone Olmic Pillar",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      34401
+      "MOLCH_TEMPLE_PILLAR_HEAD"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22781,7 +22781,7 @@
     "description": "Molch Ruins Floor",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      34413, 34414, 34415, 34416
+      "MOLCH_TEMPLE_PATH_1", "MOLCH_TEMPLE_PATH_2", "MOLCH_TEMPLE_PATH_3", "MOLCH_TEMPLE_PATH_4"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22791,7 +22791,7 @@
     "description": "Olmic Halfwall",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46425
+      "MOLCH_LOW_WALL_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22801,9 +22801,9 @@
     "description": "Varlamore stone chips on the ground",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      51826,
-      51827,
-      51828
+      "AVIUM_DUGUPSOIL01",
+      "AVIUM_DUGUPSOIL02",
+      "AVIUM_DUGUPSOIL03"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.2
@@ -22812,19 +22812,19 @@
     "description": "Ralos rise, Big door",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      50959,
-      50960,
-      50962,
-      50963,
-      50964,
-      50965
+      "ENTRANCE_CAMTORUM_CLOSED01",
+      "ENTRANCE_CAMTORUM_SIDE01",
+      "ENTRANCE_CAMTORUM_CORNER01_M",
+      "ENTRANCE_CAMTORUM_TOP01",
+      "ENTRANCE_CAMTORUM_TOP02",
+      "ENTRANCE_CAMTORUM_TOP03"
     ]
   },
   {
     "description": "Varlamore - Objects - Stone - Stone block walls",
     "baseMaterial": "ROCK_3_SMOOTH",
     "objectIds": [
-      42097, 42098, 42099, 42100, 42101, 42102, 52795, 52796
+      "SHAYZIEN_TEMPLE_FLATSKEW_LVL0", "SHAYZIEN_TEMPLE_FLATSKEW_CORN_LVL0", "SHAYZIEN_TEMPLE_FLATSKEW_LVL1", "SHAYZIEN_TEMPLE_FLATSKEW_CORN_LVL1", "SHAYZIEN_TEMPLE_FLATSKEW_LVL2", "SHAYZIEN_TEMPLE_FLATSKEW_CORN_LVL2", "CIVITAS_PALACE_FLATSKEW_LVL1", "CIVITAS_PALACE_FLATSKEW_CORN_LVL1"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22834,7 +22834,7 @@
     "description": "Varlamore - Objects - Stone - Stone block steps",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      52345
+      "SKEWSTEPS_STONE02_CIVITAS01"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -22844,7 +22844,7 @@
     "description": "Varlamore - Objects - Stone - Short column railing",
     "baseMaterial": "MARBLE_2_SEMIGLOSS",
     "objectIds": [
-      52032
+      "WALLKIT_CIVITAS01_FENCE01"
     ],
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -22852,7 +22852,7 @@
   },
   {
     "description": "Hunter Guild ceiling lantern",
-    "objectIds": [ 51731 ],
+    "objectIds": [ "HG_LANTERN_HANGING_LARGE01" ],
     "flatNormals": true,
     "hideVanillaShadows": true
   },
@@ -22860,7 +22860,7 @@
     "description": "Object - Textured Brick Fireplace",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      24969
+      "FIREPLACE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -22870,7 +22870,7 @@
     "description": "Objects - Wooden - Hat Rack",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      374
+      "HATSTAND"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22880,9 +22880,9 @@
     "description": "Objects - Wooden - Bookcase - Textured - Wide",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      380,
-      387,
-      4617
+      "BOOKCASE",
+      "SPOOKYBOOKSHELVES",
+      "HORROR_BOOKCASE"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22893,15 +22893,15 @@
     "description": "Objects - Metallic - Range on textured bricks - Textured",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      9736,
-      26181
+      "NEWBIERANGE",
+      "RANGE"
     ]
   },
   {
     "description": "Objects - WOODEN - Textured Torch",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      198
+      "CAVE_TORCH"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -22911,7 +22911,7 @@
     "description": "Decoration - Textured Lumbridge Heraldry",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      899, 901
+      "HANGINGBANNERL", "HANGINGBANNERR"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22919,13 +22919,13 @@
   },
   {
     "description": "Wooden Step Ladder",
-    "objectIds": [ 17390 ],
+    "objectIds": [ "STEPLADDER" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX"
   },
   {
     "description": "Ceramic Big Vase",
-    "objectIds": [ 5621 ],
+    "objectIds": [ "ORNATE_VASE1" ],
     "baseMaterial": "GRUNGE_1",
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -22933,7 +22933,7 @@
   },
   {
     "description": "Sheep Shearer fence and gate",
-    "objectIds": [ 12982, 12983, 12986, 12987, 12988, 12989 ],
+    "objectIds": [ "QIP_SHEEP_SHEARER_FULLSTYLE", "QIP_SHEEP_SHEARER_FENCING", "QIP_SHEEP_SHEARER_FENCEGATE_L", "QIP_SHEEP_SHEARER_FENCEGATE_R", "QIP_SHEEP_SHEARER_OPENFENCEGATE_L", "QIP_SHEEP_SHEARER_OPENFENCEGATE_R" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22941,7 +22941,7 @@
   },
   {
     "description": "Wooden food trough",
-    "objectIds": [ 301, 3644 ],
+    "objectIds": [ "FOODTROUGH", "FAI_VARROCK_FOODTROUGH" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -22950,7 +22950,7 @@
   {
     "description": "Sheep Shearer Fred the Farmers house walls",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 12990, 12991 ],
+    "objectIds": [ "QIP_SHEEP_SHEARER_WALLS", "QIP_SHEEP_SHEARER_WALLS_WINDOW" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "flatNormals": true,
@@ -22959,7 +22959,7 @@
   {
     "description": "Sheep Shearer Fred the Farmers house Roof",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 12992, 12993, 12994, 12995, 12996, 12997, 12998, 12999, 13000 ],
+    "objectIds": [ "QIP_SHEEP_SHEARER_ROOFTOPEDGE", "QIP_SHEEP_SHEARER_ROOFTOPEDGE_MIRROR", "QIP_SHEEP_SHEARER_ROOFTOP1", "QIP_SHEEP_SHEARER_ROOFTOP2", "QIP_SHEEP_SHEARER_ROOFTOP3", "QIP_SHEEP_SHEARER_ROOFTOP1_MIRROR", "QIP_SHEEP_SHEARER_ROOFTOP2_MIRROR", "QIP_SHEEP_SHEARER_ROOFTOP3_MIRROR", "QIP_SHEEP_SHEARER_POOR_ROOF1" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -22969,7 +22969,7 @@
   {
     "description": "Textured hay carpet",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 920, 921 ],
+    "objectIds": [ "POORRUG2CORNER", "POORRUG2SIDE" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "retainVanillaUvs": false
@@ -22977,7 +22977,7 @@
   {
     "description": "Wooden shelves - Empty or with pottery",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1023, 7506, 8692, 12980 ],
+    "objectIds": [ "COOKINGSHELFEMPTY", "FARMING_SHELVES_EMPTY", "FARM_SHELF", "QIP_SHEEP_SHEARER_COOKINGSHELVESEMPTY" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -22994,11 +22994,11 @@
     "description": "Freestanding shelves with pots and pans - Lumbridge",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1013,
-      4505,
-      14869,
-      15685,
-      15686
+      "COOKINGSHELVES",
+      "FAI_VARROCK_COOKING_SHELVES",
+      "QIP_COOK_COOKINGSHELVES",
+      "AIDE_COOKINGSHELVES",
+      "AIDE_COOKINGSHELVES_EMPTY"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23016,8 +23016,8 @@
     "description": "Cooking Shelves - Lumbridge kitchen",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1022,
-      14870
+      "COOKINGSHELF",
+      "QIP_COOK_COOKINGSHELF"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23035,8 +23035,8 @@
     "description": "Cooking rack - Lumbridge kitchen",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      391,
-      14871
+      "COOKINGUTENSILS",
+      "QIP_COOK_COOKINGSHELF_UTENSILS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23053,7 +23053,7 @@
   {
     "description": "Wooden hat stand",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 7166, 12981 ],
+    "objectIds": [ "FAI_VARROCK_HAT_STAND", "QIP_SHEEP_SHEARER_HATSTAND" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -23062,7 +23062,7 @@
   {
     "description": "Wooden shelf wall mounted",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 4513, 12976 ],
+    "objectIds": [ "FAI_VARROCK_SHELF_EMPTY_LOW", "QIP_SHEEP_SHEARER_COOKINGSHELFEMPTY" ],
     "uvType": "BOX",
     "uvScale": 0.5,
     "uvOrientationX": 512,
@@ -23070,50 +23070,50 @@
   },
   {
     "description": "Earthbound Cavern rock traps",
-    "objectIds": [ 51359 ],
+    "objectIds": [ "PMOON_LIZARD_ROCK" ],
     "baseMaterial": "ROCK_3",
     "uvType": "BOX"
   },
   {
     "description": "Disable shadows for fishing spots at Molch",
-    "npcIds": [ 8523 ],
+    "npcIds": [ "FISHING_SPOT_AERIAL" ],
     "castShadows": false
   },
   {
     "description": "Disable shadows for Colosseum entrance walls",
-    "objectIds": [ 38847, 50764, 50765, 50766, 50767 ],
+    "objectIds": [ "HS_INVISWALL_ACTIVE", "WALLKIT_COLOSSEUM10_ARCH01", "WALLKIT_COLOSSEUM10_ARCH02", "WALLKIT_COLOSSEUM10_ARCH01_M", "WALLKIT_COLOSSEUM10_ARCH02_M" ],
     "receiveShadows": false,
     "flatNormals": true
   },
   {
     "description": "Disable shadows for Colosseum entrance white backdrop",
-    "objectIds": [ 50769 ],
+    "objectIds": [ "WALLKIT_COLOSSEUM10_WALLTOP02" ],
     "receiveShadows": false,
     "flatNormals": true
   },
   {
     "description": "Make Perilous Moons entrances pure black",
-    "objectIds": [ 51376 ],
+    "objectIds": [ "PMOON_TELEBOX_DIAGONAL" ],
     "baseMaterial": "PURE_BLACK",
     "castShadows": false,
     "receiveShadows": false
   },
   {
     "description": "Fix shadow transparency performance with black boxes in the Hunter Guild & Perilous Moons, and improve looks",
-    "objectIds": [ 42260, 51461, 51462 ],
+    "objectIds": [ "CAVEKIT_ROCK01_WALLTOP05", "ROR_TEMPLE_TALL_TOP", "ROR_TEMPLE_TALL_PILLAR" ],
     "baseMaterial": "PURE_BLACK",
     "castShadows": false,
     "receiveShadows": false
   },
   {
     "description": "Stop floating crystals in the Hunter Guild from casting shadows",
-    "objectIds": [ 51442, 51443, 51444, 51445 ],
+    "objectIds": [ "FX_SPORE_CYAN_MOONLIGHT01", "FX_SPORE_CYAN_MOONLIGHT02", "FX_SPORE_CYAN_SUNLIGHT01", "FX_SPORE_CYAN_SUNLIGHT02" ],
     "castShadows": false,
     "receiveShadows": false
   },
   {
     "description": "Marble statues at Lumbridge Entrance - Textured",
-    "objectIds": [ 5789, 9292],
+    "objectIds": [ "STATUE_LUMBRIDGE", "GARDEN_QUEEN_STATUE"],
     "baseMaterial": "MARBLE_2_SEMIGLOSS",
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -23121,7 +23121,7 @@
   },
   {
     "description": "Metal lamp post with candle lanturn",
-    "objectIds": [ 11468 ],
+    "objectIds": [ "DRAYNOR_OUTSIDE_LAMP" ],
     "baseMaterial": "METALLIC_1_LIGHT",
     "uvType": "BOX",
     "uvScale": 0.5,
@@ -23130,7 +23130,7 @@
   },
   {
     "description": "Misthalin Mystery Boat",
-    "objectIds": [ 30108, 30109 ],
+    "objectIds": [ "MISTMYST_BOAT_LUMBRIDGE", "MISTMYST_BOAT_ISLAND" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23143,7 +23143,7 @@
   },
   {
     "description": "Misthalin Mystery Barrel of Rainwater",
-    "objectIds": [ 30123, 30124 ],
+    "objectIds": [ "MISTMYST_BARREL_EMPTIED", "MISTMYST_BARREL_WATER" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23162,7 +23162,7 @@
   },
   {
     "description": "Misthalin Mystery Barrel of Gunpowder",
-    "objectIds": [ 30127, 30128 ],
+    "objectIds": [ "MISTMYST_EXPLOSIVE_BARREL_VIS", "MISTMYST_EXPLOSIVE_BARREL_REMAINS" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23184,7 +23184,7 @@
   },
   {
     "description": "Misthalin Mystery Staircase",
-    "objectIds": [ 30139 ],
+    "objectIds": [ "MISTMYST_STAIRS_UP" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23201,33 +23201,33 @@
   {
     "description": "Red wall paper and wooden panneled walls",
     "objectIds": [
-      11512,
-      11513,
-      11515,
-      11516,
-      11517,
-      11518,
-      11519,
-      11520,
-      11521,
-      11528,
-      11529,
-      11530,
-      11531,
-      11532,
-      11533,
-      11534,
-      11535,
-      11536,
-      11537,
-      11540,
-      11541,
-      11542,
-      11543,
-      11544,
-      30131,
-      30132,
-      30156
+      "DRAYNOR_WALLS",
+      "DRAYNOR_WALLS_JUNCTION1",
+      "DRAYNOR_WALLS_WIN",
+      "DRAYNOR_WALLS_PLASTER1",
+      "DRAYNOR_WALLS_PLASTER2",
+      "DRAYNOR_WALLS_PLASTER3",
+      "DRAYNOR_WALLS_PLASTER4",
+      "DRAYNOR_WALLS_PLASTER5",
+      "DRAYNOR_WALLS_PLASTER6",
+      "DRAYNOR_WALLS_BROKE",
+      "DRAYNOR_WALLS_BROKE_MIRROR",
+      "DRAYNOR_WALLS_BROKE2",
+      "DRAYNOR_WALLS_BROKE2_MIRROR",
+      "DRAYNOR_WALLS_BROKE3",
+      "DRAYNOR_WALLS_BROKE3_MIRROR",
+      "DRAYNOR_WALL_ARCH",
+      "DRAYNOR_WALL_ARCH_TOP",
+      "DRAYNOR_WALLS_EXT",
+      "DRAYNOR_WALL_JUNCTION_EXT1",
+      "DRAYNOR_WALL_TOP_DOOR",
+      "DRAYNOR_WALL_TOP_FRONT_DOOR",
+      "DRAYNOR_WALL_TOP_FRONT_DOOR_MIRROR",
+      "DRAYNOR_WALL_ARCH_TOP_EXT",
+      "DRAYNOR_WALL_TOP_NOT_ARCHED_EXT",
+      "MISTMYST_DESTRUCTABLE_WALL_CLIMBABLE_BROKEN",
+      "MISTMYST_DESTRUCTABLE_WALL_BROKEN",
+      "MISTMYST_KITCHEN_DOOR_TOP"
     ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
@@ -23245,21 +23245,21 @@
   },
   {
     "description": "Murder Mystery Wooden Double Doors",
-    "objectIds": [ 1146, 11447, 30110, 30111 ],
+    "objectIds": [ "TKBUSH_L", "HAUNTEDDOORR_INACTIVE", "MISTMYST_FRONT_DOORL", "MISTMYST_FRONT_DOORR" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Murder Mystery Wooden Doors",
-    "objectIds": [ 11470, 11471, 30112, 30113, 30114, 30115, 30116, 30117, 30118, 30119, 34650, 34651 ],
+    "objectIds": [ "DRAYNOR_PANELLED_DOOR", "DRAYNOR_PANELLED_DOOR_OPEN", "MISTMYST_DOOR_REDTOPAZ", "MISTMYST_DOOR_JADE", "MISTMYST_DOOR_OPAL", "MISTMYST_DOOR_DRAGONSTONE", "MISTMYST_DOOR_RUBY", "MISTMYST_DOOR_EMERALD", "MISTMYST_DOOR_DIAMOND", "MISTMYST_DOOR_SAPPHIRE", "MISTMYST_DOOR_RUBY_INACTIVE", "MISTMYST_DOOR_EMERALD_INACTIVE" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Fancy wooden table with alternating lines",
-    "objectIds": [ 11504 ],
+    "objectIds": [ "DRAYNOR_SMALLTABLE2" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -23267,21 +23267,21 @@
   },
   {
     "description": "Murder Mystery wooden wardrobes",
-    "objectIds": [ 5622, 5623, 5624 ],
+    "objectIds": [ "DRAYNOR_WARDROBE", "DRAYNOR_WARDROBE_OPEN", "DRAYNOR_WARDROBE_OPEN_SKELETON" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Murder Mystery wooden wardrobes Golden Trim",
-    "objectIds": [ 388, 389, 30141, 30142 ],
+    "objectIds": [ "SPOOKYWARDROBE", "SPOOKYWARDROBE_OPEN", "MISTMYST_BOSS_WARDROBE", "MISTMYST_BOSS_WARDROBE_OPEN" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.7
   },
   {
     "description": "Lumbridge - Restless Ghost - Coffin",
-    "objectIds": [ 2145, 15052, 15053 ],
+    "objectIds": [ "SHUTGHOSTCOFFIN", "OPENGHOSTCOFFIN_NO_HEAD", "OPENGHOSTCOFFIN_WITH_HEAD" ],
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "uvType": "BOX",
     "uvScale": 0.88
@@ -23289,7 +23289,7 @@
   {
     "description": "Lumbridge crypt stone block walls",
     "baseMaterial": "ROCK_3_SMOOTH",
-    "objectIds": [ 15058 ],
+    "objectIds": [ "RESTLESS_CRYPT_WALL" ],
     "uvType": "BOX",
     "uvOrientation": 144,
     "uvScale": 0.6
@@ -23297,7 +23297,7 @@
   {
     "description": "Lumbridge crypt ivy",
     "baseMaterial": "LEAF_VEINS",
-    "objectIds": [ 24160, 24161, 24162, 24163, 24164 ],
+    "objectIds": [ "FAI_FALADOR_IVY_LARGE", "FAI_FALADOR_IVY_MEDIUM", "FAI_FALADOR_IVY_SMALL", "FAI_FALADOR_IVY_MEDIUM_MIRROR", "FAI_FALADOR_IVY_SMALL_MIRRIOR" ],
     "uvType": "MODEL_YZ",
     "uvOrientation": 144,
     "uvScale": 0.1,
@@ -23312,8 +23312,8 @@
     "description": "Objects - Wooden - Brown Drawers with metallic handles",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      350,
-      351
+      "DRAWERS2",
+      "DRAWERS2OPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23330,9 +23330,9 @@
     "description": "Objects - Wooden - Brown Drawers with golden handles",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      352,
-      353,
-      5618
+      "DRAWERS3",
+      "DRAWERS3OPEN",
+      "DRAWERS4"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23348,7 +23348,7 @@
   {
     "description": "Flip UVs for HD Shingle full tiles",
     "objectIds": [
-      1642, 1924
+      "OLDROOF_REDSLATE", "ROOF_REDSLATE"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -23357,7 +23357,7 @@
   {
     "description": "Flip UVs for HD Shingle trim",
     "objectIds": [
-      1790, 1791, 5647, 5648, 5662, 5663, 5671, 5686, 5687, 5756, 5757
+      "ROOFEDGE_REDSLATE", "ROOFEDGE_GREYSLATE", "ROOFEDGE_ENDL", "ROOFEDGE_ENDR", "ROOFEDGE_ROUGH", "ROOFEDGE_ROUGH2", "ROOFEDGE_ENDL_GREYSLATE", "ROOFEDGE_ROUGH_GREYSLATE", "ROOFEDGE_ROUGH2_GREYSLATE", "OLDROOFEDGE_ROUGH_GREYSLATE", "OLDROOFEDGE_ROUGH2_GREYSLATE"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -23366,7 +23366,7 @@
   {
     "description": "Flip UVs for HD Shingle trim and rotate 45 degrees",
     "objectIds": [
-      5672
+      "ROOFEDGE_ENDR_GREYSLATE"
     ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
@@ -23375,7 +23375,7 @@
   {
     "description": "Objects - Wooden - Bettys Desk",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 9516 ],
+    "objectIds": [ "SARIM_COUNTER" ],
     "uvType": "BOX",
     "uvScale": 0.9,
     "uvOrientation": 512
@@ -23383,20 +23383,20 @@
   {
     "description": "Objects - Wooden - Bettys Chair",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 9514 ],
+    "objectIds": [ "SARIM_BETTYS_CHAIR" ],
     "uvType": "BOX",
     "uvScale": 0.9
   },
   {
     "description": "Port Sarim - Grums front deck",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 9453 ],
+    "objectIds": [ "SARIM_SHIPFLOOR" ],
     "uvType": "WORLD_XZ",
     "uvOrientation": 512
   },
   {
     "description": "Flip UVs for HD wood grain",
-    "objectIds": [ 1793 ],
+    "objectIds": [ "ROOFEDGE_WOODEN" ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
     "uvOrientation": 1024
@@ -23404,7 +23404,7 @@
   {
     "description": "Remmington House Walls",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 9626, 9627, 20002, 20003 ],
+    "objectIds": [ "RIMMINGTON_POOR_WALLS", "RIMMINGTON_POOR_WALLS_INTERNAL", "RIMMINGTON_WOOD_WALLS_WINDOW_SINGLE01", "RIMMINGTON_WOOD_WALLS_WINDOW_DOUBLE01" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationZ": 512,
@@ -23414,7 +23414,7 @@
   {
     "description": "Remmington House Roof - Corner",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 9633, 9634, 9635, 9636, 9644, 9646, 9647, 9648, 9649, 9656, 9657, 9658, 9659 ],
+    "objectIds": [ "RIMMINGTON_POOR_ROOF_EDGE", "RIMMINGTON_POOR_ROOF_EDGE_2", "RIMMINGTON_POOR_ROOF_EDGE_2_MIRROR", "RIMMINGTON_POOR_ROOF_EDGE_MIRROR", "RIMMINGTON_ROOFTOP3_FLAT", "RIMMINGTON_ROOFTOP1_MIRROR", "RIMMINGTON_ROOFTOP2_MIRROR", "RIMMINGTON_ROOFTOP3_MIRROR", "RIMMINGTON_ROOFTOP4_MIRROR", "RIMMINGTON_ROOFTOPEDGE", "RIMMINGTON_ROOFTOPEDGE_MIRROR", "RIMMINGTON_ROOFTOP2X2", "RIMMINGTON_ROOFTOP2X2_MIRROR" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -23423,7 +23423,7 @@
   {
     "description": "Remmington House Roof - some models have weird rotations",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 9629, 9628, 9630, 9637, 9640, 9641, 9642, 9643, 9645, 9650, 9651, 9652, 9653, 9654, 9655, 9660 ],
+    "objectIds": [ "RIMMINGTON_POOR_ROOF_EXTERNALWALL1", "RIMMINGTON_POOR_ROOF1", "RIMMINGTON_POOR_ROOF_EXTERNALWALL1_MIRROR", "RIMMINGTON_POOR_ROOF_MID2", "RIMMINGTON_ROOFTOP1", "RIMMINGTON_ROOFTOP2", "RIMMINGTON_ROOFTOP2_FLAT", "RIMMINGTON_ROOFTOP3", "RIMMINGTON_ROOFTOP4", "RIMMINGTON_ROOFTOP_EXTERNALWALL1", "RIMMINGTON_ROOFTOP_EXTERNALWALL2", "RIMMINGTON_ROOFTOP_EXTERNALWALL3", "RIMMINGTON_ROOFTOP_EXTERNALWALL1_MIRROR", "RIMMINGTON_ROOFTOP_EXTERNALWALL2_MIRROR", "RIMMINGTON_ROOFTOP_EXTERNALWALL3_MIRROR", "RIMMINGTON_ROOFTOP4X4" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "flatNormals": true
@@ -23432,8 +23432,8 @@
     "description": "Objects - Wooden - Wooden Chest - Broken",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      5108,
-      14854
+      "FAI_VARROCK_CHEST_CLOSED",
+      "FAI_VARROCK_POOR_CHEST"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -23442,7 +23442,7 @@
     "description": "Objects - Wooden - Beehive",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      20859
+      "MACRO_INACTIVE_BEEHIVE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -23451,7 +23451,7 @@
     "description": "Objects - Wooden - Juliets house hand rails",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      23847
+      "FAI_VARROCK_BANNISTER"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23460,7 +23460,7 @@
   },
   {
     "description": "Wooden Wardrobe",
-    "objectIds": [ 7193, 7198 ],
+    "objectIds": [ "FAI_VARROCK_WARDROBE", "FAI_VARROCK_WARDROBE_POSH2" ],
     "baseMaterial": "WOOD_GRAIN_3",
     "uvOrientationY": 512,
     "uvType": "BOX",
@@ -23470,7 +23470,7 @@
     "description": "Drawers with backsplash",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7194, 7442
+      "FAI_VARROCK_DRAWERS", "FAI_VARROCK_POSH_DRAWERS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -23480,7 +23480,7 @@
     "description": "Large Teak Table",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7405
+      "FAI_VARROCK_POSH_DININGTABLE_LARGE"
     ],
     "uvType": "BOX",
     "uvScale": 0.66,
@@ -23490,7 +23490,7 @@
     "description": "Wooden cabinet - Wide",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2721
+      "FAI_VARROCK_APOTHECARY_CABINET"
     ],
     "uvType": "BOX"
   },
@@ -23498,7 +23498,7 @@
     "description": "Stone slab",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      12132
+      "ROMEO_JULIET_CRYPT_TOMB"
     ],
     "uvType": "BOX"
   },
@@ -23506,7 +23506,7 @@
     "description": "Brown brick textured Stone Steps",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      12131
+      "ROMEO_JULIET_STAIRS_UP"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -23515,7 +23515,7 @@
     "description": "Red Vines",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      58, 2013, 2989, 2990, 2991, 2992, 2993, 2994
+      "RED_WORM_VINE", "RED_WORM_CORNER", "RED_WORM_END", "RED_WORM_JUNCTION", "RED_WORM_DIAG1", "RED_WORM_DIAG3", "RED_WORM_DIAGFILLER", "RED_WORM_END_DIAG"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -23525,9 +23525,9 @@
     "description": "Objects - Wooden - Crate - High poly mesh",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1990,
-      27532,
-      41424
+      "GOLRIE_CRATE_WATERFALL_QUEST",
+      "HOS_CRATE_01",
+      "HOS_CRATE_01_NOOP"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -23538,8 +23538,8 @@
     "description": "Objects - Wooden - Stacked Crates - High poly mesh",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      27533,
-      41425
+      "HOS_CRATE_02",
+      "HOS_CRATE_02_NOOP"
     ],
     "uvType": "BOX",
     "flatNormals": true,
@@ -23550,9 +23550,9 @@
     "description": "Tent - High poly mesh",
     "baseMaterial": "CARPET",
     "objectIds": [
-      23061,
-      23062,
-      42044
+      "SUROK_BANDIT_CAMP_TENT",
+      "SUROK_BANDIT_CAMP_TENT_DIAG",
+      "SHAYZIEN_MILITARY_TENT"
     ],
     "uvType": "BOX"
   },
@@ -23560,7 +23560,7 @@
     "description": "Lumber Yard  Crate NPC",
     "baseMaterial": "WOOD_GRAIN_3",
     "npcIds": [
-      3499
+      "KITTENS_MEW"
     ],
     "uvType": "BOX",
     "flatNormals": true
@@ -23568,7 +23568,7 @@
   {
     "description": "pile of logs - Banded",
     "baseMaterial": "BARK",
-    "objectIds": [ 23614 ],
+    "objectIds": [ "QIP_GERTRUDE_LOG_STACK" ],
     "uvType": "BOX",
     "uvOrientationX": 512,
     "uvScale": 0.8
@@ -23586,7 +23586,7 @@
         "uvScale": 0.5
       }
     ],
-    "objectIds": [ 2619, 5112, 5114, 5122, 5124, 9519, 9521, 27220, 27758, 49640 ]
+    "objectIds": [ "GERTRUDEEMPTY_BARREL", "FAI_VARROCK_RED_BARREL", "FAI_VARROCK_GREEN_BARREL", "FAI_VARROCK_BARREL", "FAI_VARROCK_BARREL_TAP", "SARIM_BARREL", "SARIM_BARREL_TAP", "SHAYZIEN_BARREL", "PISCARILIUS_BARREL", "POG_BARREL" ]
   },
   {
     "description": "Barrel with tarnished metal bands",
@@ -23603,7 +23603,7 @@
       }
     ],
     "objectIds": [
-      20431
+      "LOTR_MINE_BARREL"
     ]
   },
   {
@@ -23619,16 +23619,16 @@
         "uvScale": 0.5
       }
     ],
-    "objectIds": [ 5123, 27227 ]
+    "objectIds": [ "FAI_VARROCK_BARREL_STACKED", "SHAYZIEN_BARREL_STACKED" ]
   },
   {
     "description": "Wooden Cart - Empty",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      307,
-      3633,
-      5352,
-      5353
+      "CART",
+      "FAI_VARROCK_CART",
+      "AHOY_CART",
+      "AHOY_WHEEL_BARROW"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -23648,13 +23648,13 @@
       }
     ],
     "objectIds": [
-      5579
+      "CART_HAY"
     ]
   },
   {
     "description": "Lumbar yard - Pile of Wood",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 3209 ],
+    "objectIds": [ "FAI_VARROCK_WOODPILE" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientation": 128
@@ -23663,7 +23663,7 @@
     "description": "Camdozaal Cave Walls",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      41549, 41550, 41552, 41553, 41554, 41555, 41556, 41557, 41558, 41559, 41560, 41591, 48195
+      "CAMDOZAALROCK1_EMPTY", "CAMDOZAALROCK2_EMPTY", "CAVEKIT_IMCANDO_DEFAULT01", "CAVEKIT_IMCANDO_DEFAULT02", "CAVEKIT_IMCANDO_DEFAULT03", "CAVEKIT_IMCANDO_DEFAULT04", "CAVEKIT_IMCANDO_JOIN01", "CAVEKIT_IMCANDO_JOIN02", "CAVEKIT_IMCANDO_HOLE01", "CAVEKIT_IMCANDO_ROCK01", "CAVEKIT_IMCANDO_ROCK02", "CAVEKIT_FALLOFF_IMCANDO01", "DT2_LASSAR_ENTRY_ROCK_NOOP"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -23672,16 +23672,16 @@
     "description": "Camdozaal Carved Walls and Pillars",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      41466,
-      41469,
-      41470,
-      41471,
-      41472,
-      41473,
-      41474,
-      41475,
-      41486,
-      41569
+      "BIM_RUINS_WALLKIT_WORKSHOP01",
+      "BIM_RUINS_WALLKIT_CORNER01",
+      "BIM_RUINS_WALLKIT_CORNER02",
+      "BIM_RUINS_WALLKIT_CORNER03",
+      "BIM_RUINS_WALLKIT_CORNER04",
+      "BIM_RUINS_WALLKIT_FILLER01",
+      "BIM_RUINS_WALLKIT_FILLER02",
+      "BIM_RUINS_WALLKIT_FILLER03",
+      "BIM_RUINS_ENTRANCE_STATUE",
+      "DUNGEONKIT_IMCANDO_PILLAR01"
     ],
     "uvType": "BOX"
   },
@@ -23689,15 +23689,15 @@
     "description": "Camdozaal Vault Walls",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      41520,
-      41521,
-      41522,
-      41523,
-      41524,
-      41525,
-      41526,
-      41527,
-      41528
+      "BIM_VAULT_WALL01",
+      "BIM_VAULT_WALL02",
+      "BIM_VAULT_WALL03",
+      "BIM_VAULT_WALL04",
+      "BIM_VAULT_WALL05",
+      "BIM_VAULT_WALL06",
+      "BIM_VAULT_CORNER01",
+      "BIM_VAULT_CORNER02",
+      "BIM_VAULT_CORNER03"
     ],
     "uvType": "BOX"
   },
@@ -23708,7 +23708,7 @@
     "uvScale": 0.75,
     "uvOrientation": 42,
     "objectIds": [
-      41537
+      "CAMDOZAAL_VAULT_DOOR"
     ]
   },
   {
@@ -23725,11 +23725,11 @@
       }
     ],
     "objectIds": [
-      41461,
-      41462,
-      41463,
-      41464,
-      41465
+      "BIM_RUINS_WALLKIT_RESIDENTIAL01",
+      "BIM_RUINS_WALLKIT_RESIDENTIAL02",
+      "BIM_RUINS_WALLKIT_RESIDENTIAL03",
+      "BIM_RUINS_WALLKIT_RESIDENTIAL04",
+      "BIM_RUINS_WALLKIT_RESIDENTIAL05"
     ]
   },
   {
@@ -23747,7 +23747,7 @@
       }
     ],
     "objectIds": [
-      41468
+      "BIM_RUINS_WALLKIT_STATUE01"
     ]
   },
   {
@@ -23755,14 +23755,14 @@
     "baseMaterial": "GRUNGE_3",
     "uvType": "BOX",
     "objectIds": [
-      41467
+      "BIM_RUINS_WALLKIT_STREETLAMP01"
     ]
   },
   {
     "description": "Camdozaal Barronite Walls",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      41547, 41548
+      "CAMDOZAALROCK1", "CAMDOZAALROCK2"
     ],
     "uvType": "BOX",
     "uvOrientation": 256
@@ -23771,8 +23771,8 @@
     "description": "Camdozaal Sacred Forge",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      41411,
-      41412
+      "BIM_RUINS_WALLKIT_SACRED_FORGE_MULTI",
+      "BIM_RUINS_WALLKIT_SACRED_FORGE_OP"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -23782,9 +23782,9 @@
     "description": "Camdozaal Rock Piles - Large",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      27908,
-      27910,
-      27912
+      "ARCHEUUS_ROCKS_LARGE_02",
+      "ARCHEUUS_ROCKS_LARGE_03",
+      "ARCHEUUS_ROCKS_LARGE_04"
     ],
     "uvType": "BOX",
     "uvOrientation": 198,
@@ -23794,10 +23794,10 @@
     "description": "Camdozaal Rock Piles - Medium",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      27898,
-      27900,
-      27902,
-      27904
+      "ARCHEUUS_ROCKS_01",
+      "ARCHEUUS_ROCKS_02",
+      "ARCHEUUS_ROCKS_03",
+      "ARCHEUUS_ROCKS_04"
     ],
     "uvType": "BOX",
     "uvOrientation": 786,
@@ -23807,10 +23807,10 @@
     "description": "Camdozaal - Plant - Fern",
     "baseMaterial": "LEAF_VEINS_LIGHT",
     "objectIds": [
-      41581,
-      41582,
-      41583,
-      41584
+      "PLANT_FERN01_CAVE01",
+      "PLANT_FERN01_CAVE02",
+      "PLANT_FERN01_CAVE03",
+      "PLANT_FERN01_CAVE04"
     ],
     "uvType": "BOX",
     "uvOrientation": 128,
@@ -23820,10 +23820,10 @@
     "description": "Camdozaal Fish Bones",
     "baseMaterial": "BONE",
     "objectIds": [
-      18020,
-      18021,
-      18022,
-      18023
+      "MYQ3_FISHBONE1",
+      "MYQ3_FISHBONE2",
+      "MYQ3_FISHBONE3",
+      "MYQ3_FISHBONE4"
     ],
     "uvType": "MODEL_XZ",
     "uvScale": 0.7
@@ -23832,7 +23832,7 @@
     "description": "Camdozaal Metal Scaffold",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      41580
+      "CAVEKIT_IMCANDO_SCAFFOLDING"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -23842,7 +23842,7 @@
     "description": "Camdozaal metal floor crate",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      41579
+      "CAVEKIT_IMCANDO_METAL"
     ],
     "uvType": "BOX",
     "uvOrientationY": 512,
@@ -23852,8 +23852,8 @@
     "description": "Camdozaal Metal Fence",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      41577,
-      41578
+      "CAVEKIT_IMCANDO_RAIL01",
+      "CAVEKIT_IMCANDO_RAIL02"
     ],
     "uvType": "BOX",
     "uvOrientation": 512,
@@ -23863,8 +23863,8 @@
     "description": "Camdozaal Metal Sconce",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      41489,
-      41490
+      "BIM_RUINS_TORCH_HIGH01_INACTIVE",
+      "BIM_RUINS_TORCH_LOW01_INACTIVE"
     ],
     "uvType": "BOX",
     "uvOrientation": 300,
@@ -23874,8 +23874,8 @@
     "description": "Camdozaal Metal Sconce - Lit",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      41487,
-      41488
+      "BIM_RUINS_TORCH_HIGH01",
+      "BIM_RUINS_TORCH_LOW01"
     ],
     "uvType": "BOX",
     "uvOrientation": 300,
@@ -23885,7 +23885,7 @@
     "description": "Camdozaal Stone Steps",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      41567
+      "CAVEKIT_IMCANDO_SKEWSTEPS"
     ],
     "uvType": "BOX",
     "uvOrientation": 1138,
@@ -23895,7 +23895,7 @@
     "description": "Camdozaal Stone Tiles",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      41568
+      "CAVEKIT_IMCANDO_FLOOR"
     ],
     "uvType": "BOX",
     "uvOrientation": 300,
@@ -23905,7 +23905,7 @@
     "description": "Camdozaal Stone Edging",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      41566
+      "CAVEKIT_IMCANDO_BRIDGE"
     ],
     "uvType": "BOX",
     "uvOrientation": 700,
@@ -23924,7 +23924,7 @@
       }
     ],
     "objectIds": [
-      41545
+      "CAMDOZAAL_PREPARATION_TABLE"
     ],
     "uvType": "BOX",
     "uvOrientation": 768,
@@ -23948,17 +23948,17 @@
       }
     ],
     "objectIds": [
-      41546
+      "CAMDOZAAL_ALTAR"
     ]
   },
   {
     "description": "Camdozaal and Zanaris Mushrooms",
     "baseMaterial": "PLANT_GRUNGE_1",
     "objectIds": [
-      12056,
-      12057,
-      12058,
-      12059
+      "FAIRY_MUSHROOMS_LONG_RED",
+      "FAIRY_MUSHROOMS_LONG_BLUE",
+      "FAIRY_MUSHROOMS_COLD_TOP_RED",
+      "FAIRY_MUSHROOMS_COLD_TOP_BLUE"
     ],
     "uvType": "GEOMETRY"
   },
@@ -23978,8 +23978,8 @@
       }
     ],
     "objectIds": [
-      41443,
-      41444
+      "BIM_ENTRANCE_SIDE_R",
+      "BIM_ENTRANCE_SIDE_L"
     ]
   },
   {
@@ -24004,9 +24004,9 @@
       }
     ],
     "objectIds": [
-      41439,
-      41440,
-      41441
+      "BIM_DOOR",
+      "BIM_DOOR_CUTSCENE",
+      "BIM_ROCK"
     ]
   },
   {
@@ -24025,7 +24025,7 @@
       }
     ],
     "objectIds": [
-      41454
+      "BIM_RUBBLE_3"
     ]
   },
   {
@@ -24042,9 +24042,9 @@
       }
     ],
     "objectIds": [
-      41482,
-      41483,
-      41484
+      "BIM_RUINS_DOOR_CLOSED",
+      "BIM_RUINS_DOOR_OPEN_LEFT",
+      "BIM_RUINS_DOOR_OPEN_RIGHT"
     ]
   },
   {
@@ -24054,9 +24054,9 @@
     "uvScale": 0.4,
     "uvOrientation": 182,
     "objectIds": [
-      41458,
-      41459,
-      41460
+      "BIM_BOSS_ROCK",
+      "BIM_BOSS_ROCK_MINED",
+      "BIM_BOSS_ROCK_CUTSCENE"
     ]
   },
   {
@@ -24078,7 +24078,7 @@
       }
     ],
     "objectIds": [
-      41446
+      "BIM_EXIT"
     ]
   },
   {
@@ -24102,7 +24102,7 @@
       }
     ],
     "objectIds": [
-      41491
+      "BIM_RUINS_TENT_TOOLS01"
     ]
   },
   {
@@ -24119,7 +24119,7 @@
       }
     ],
     "objectIds": [
-      41593
+      "CAMDOZAAL_PICKAXE_BARREL"
     ]
   },
   {
@@ -24136,8 +24136,8 @@
       }
     ],
     "objectIds": [
-      30821,
-      41541
+      "FOSSIL_BARREL_EMPTY",
+      "CAMDOZAAL_VAULT_CHEST_SMALL_AVAILABLE"
     ]
   },
   {
@@ -24163,7 +24163,7 @@
       }
     ],
     "objectIds": [
-      41495
+      "BIM_RUINS_WORKBENCH01"
     ]
   },
   {
@@ -24194,7 +24194,7 @@
       }
     ],
     "objectIds": [
-      41565
+      "CAVEKIT_IMCANDO_STALAGMITE01"
     ]
   },
   {
@@ -24203,22 +24203,22 @@
     "uvType": "BOX",
     "uvOrientation": 343,
     "objectIds": [
-      6460,
-      6472,
-      6473,
-      6474,
-      13704
+      "ICE_MARKER",
+      "TROLLRESCUE_ICESLIDE1",
+      "TROLLRESCUE_ICESLIDE2",
+      "TROLLRESCUE_ICESLIDE3",
+      "KOUREND_ARCH_FOOTPATH_10"
     ]
   },
   {
     "description": "Seers Coal Mine Fence",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      15593,
-      15594,
-      15601,
-      15602,
-      15603
+      "MCANNON_RAILING4_MULTILOC",
+      "MCANNON_RAILING5_MULTILOC",
+      "MCANNON_DWARF_RAILING_FIXED",
+      "MCANNON_DWARF_RAILING_END",
+      "MCANNON_DWARF_RAILING_END_MIR"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -24228,9 +24228,9 @@
     "description": "Seers Coal Mine Fence - Bent",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      18,
-      19,
-      20
+      "MCANNONRAILING4",
+      "MCANNONRAILING5",
+      "MCANNONRAILING6"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -24240,10 +24240,10 @@
     "description": "Seers Coal Mine Gate",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
     "objectIds": [
-      15604,
-      15605,
-      15606,
-      15607
+      "MCANNON_DWARF_RAILING_GATE",
+      "MCANNON_DWARF_RAILING_GATE_MIR",
+      "MCANNON_DWARF_RAILING_GATE_MIR_INACT",
+      "MCANNON_DWARF_RAILING_GATE_INACT"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -24254,9 +24254,9 @@
     "description": "Kourend Decorative Metallic Rails",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      33553,
-      33554,
-      33555
+      "LOVAQUEST_RAIL",
+      "LOVAQUEST_RAIL_END",
+      "LOVAQUEST_RAIL_END_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -24266,8 +24266,8 @@
     "description": "Kourend Decorative Metallic Fence",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      27937,
-      27938
+      "ARCHEUUS_FENCE_TALL_01",
+      "ARCHEUUS_FENCE_TALL_02"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -24277,8 +24277,8 @@
     "description": "Falador Park Fence",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      24013,
-      24014
+      "FAI_FALADOR_ORNATERAIL",
+      "FAI_FALADOR_ORNATERAIL_SYMBOL"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -24287,7 +24287,7 @@
     "description": "Train Cart",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      7028
+      "KELDAGRIM_TRAIN_CART"
     ],
     "uvType": "BOX"
   },
@@ -24295,8 +24295,8 @@
     "description": "Wooden textured workbench",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      609,
-      610
+      "WORKBENCH",
+      "WORKBENCH2"
     ],
     "uvType": "BOX",
     "uvOrientationX": 512,
@@ -24305,21 +24305,21 @@
   {
     "description": "Pentagonal Stool",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1095 ],
+    "objectIds": [ "STOOL2" ],
     "uvType": "BOX",
     "uvScale": 0.80
   },
   {
     "description": "Dwarf Remains",
     "baseMaterial": "BONE",
-    "objectIds": [ 15596 ],
+    "objectIds": [ "MCANNONREMAINS_LOCATION" ],
     "uvType": "BOX",
     "uvScale": 0.80
   },
   {
     "description": "Mud Pile - Climbable",
     "baseMaterial": "DIRT_2_SHINY",
-    "objectIds": [ 13, 2533 ],
+    "objectIds": [ "MCANMUDPILE", "PLAGUEMUDPILE" ],
     "uvType": "BOX",
     "uvScale": 0.6
   },
@@ -24327,9 +24327,9 @@
     "description": "Goblin Cave Walls",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      18908,
-      21800,
-      21801
+      "TOURTRAP_QIP_MINE_WALL",
+      "SHADOW_MAJ_CRACK",
+      "TOURTRAP_QIP_MINE_WALL_JUTTING"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -24337,7 +24337,7 @@
   {
     "description": "Goblin Cave Walls - With Door",
     "baseMaterial": "DIRT_1",
-    "objectIds": [ 43261 ],
+    "objectIds": [ "LOTG_GOBLIN_STAIRCASE" ],
     "uvType": "BOX",
     "uvScale": 0.6
   },
@@ -24345,7 +24345,7 @@
     "description": "Goblin Cave walls with supports",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      18891
+      "TOURTRAP_QIP_MINE_WALL_LAMP_SINGLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -24354,7 +24354,7 @@
     "description": "Goblin Cave wall tops",
     "baseMaterial": "DIRT_1",
     "objectIds": [
-      18471
+      "TOURTRAP_QIP_MINE_WALL_TOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -24363,8 +24363,8 @@
     "description": "Skeleton with helmet named corpse",
     "baseMaterial": "BONE",
     "objectIds": [
-      4984,
-      7208
+      "SLAYER_CORPSE3",
+      "ROGUESDEN_CORPSE3"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -24373,14 +24373,14 @@
     "description": "Skeleton named corpse",
     "baseMaterial": "BONE",
     "objectIds": [
-      661,
-      662,
-      2176,
-      4983,
-      21802,
-      21803,
-      29493,
-      29494
+      "CORPSE2",
+      "CORPSE3",
+      "SLAYER_CORPSE1",
+      "SLAYER_CORPSE2",
+      "SHADOW_MAJ_CORPSE",
+      "SHADOW_MAJ_CORPSE2",
+      "HILLGIANT_BOSS_CORPSE2",
+      "HILLGIANT_BOSS_CORPSE3"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -24391,20 +24391,20 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "objectIds": [
-      11641,
-      11642
+      "WEREWOLF_SKULL_CLIMB_1",
+      "WEREWOLF_SKULL_CLIMB_2"
     ]
   },
   {
     "description": "Ramshackle Barrier",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1771 ],
+    "objectIds": [ "WOOD_WALL_BARRICADEL" ],
     "uvType": "BOX"
   },
   {
     "description": "Wooden shelves - Triple - Empty",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1015 ],
+    "objectIds": [ "WAREHOUSE_SHELVES" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -24413,7 +24413,7 @@
   {
     "description": "Wooden shelves - Triple - Filled",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1016, 1017, 1018, 7510, 7511 ],
+    "objectIds": [ "WAREHOUSE_SHELVES2", "WAREHOUSE_SHELVES3", "WAREHOUSE_SHELVES4", "FARMING_SHELVES_PROPS_4", "FARMING_SHELVES_PROPS_5" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -24422,13 +24422,13 @@
   {
     "description": "Earth Elemental",
     "baseMaterial": "DIRT_2_VERT",
-    "npcIds": [ 1363 ]
+    "npcIds": [ "SLAGILITH_HYBERNATE" ]
   },
   {
     "description": "Goblin Cave - Trapt Mage",
     "baseMaterial": "ROCK_4",
     "objectIds": [
-      5808
+      "FAVOUR_LADY_IN_WALL"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -24438,14 +24438,14 @@
     "description": "Grill",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      11422,
-      11423
+      "PLAGUE_GRILL",
+      "PLAGUE_GRILL_VIS"
     ]
   },
   {
     "description": "Wooden shelves with bottom cupboard - Empty",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 1014 ],
+    "objectIds": [ "COOKINGSHELVESEMPTY" ],
     "uvType": "BOX",
     "uvScale": 0.8,
     "uvOrientationX": 512,
@@ -24454,7 +24454,7 @@
   {
     "description": "Grill",
     "baseMaterial": "GRUNGE_2",
-    "objectIds": [ 2544 ],
+    "objectIds": [ "PLAGUEMANHOLEOPEN" ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
     "uvScale": 0.8
@@ -24462,21 +24462,21 @@
   {
     "description": "Gallows",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 649 ],
+    "objectIds": [ "GALLOWS" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Brown brick wall with metal spikes - Textured",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 1934 ],
+    "objectIds": [ "ARDOUNGEWALL" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Wall shackles - Textured",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 650 ],
+    "objectIds": [ "MANICALS" ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
     "uvScale": 0.8,
@@ -24485,7 +24485,7 @@
   {
     "description": "Wall shackles - Textured",
     "baseMaterial": "DIRT_1",
-    "objectIds": [ 11417 ],
+    "objectIds": [ "PLAGUE_HOLE" ],
     "uvType": "BOX",
     "uvScale": 0.9,
     "uvOrientation": 77
@@ -24493,21 +24493,21 @@
   {
     "description": "Long Oak Cabinet",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 35796 ],
+    "objectIds": [ "SOTE_CHEMICAL_CABINET" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Grandfather Clock",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 683 ],
+    "objectIds": [ "GRANDFATHERCLOCK" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Marble Pillar - Textured",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
-    "objectIds": [ 1869 ],
+    "objectIds": [ "MARBLEPILLAR" ],
     "uvType": "BOX",
     "uvScale": 0.6,
     "retainVanillaUvs": false,
@@ -24516,34 +24516,34 @@
   {
     "description": "Cooking Pot in textured brick fireplace",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 26180 ],
+    "objectIds": [ "FIREPLACECOOKINGPOT" ],
     "uvType": "BOX"
   },
   {
     "description": "Brown Bed with pillow",
     "baseMaterial": "CARPET",
-    "objectIds": [ 419 ],
+    "objectIds": [ "BROWNBED" ],
     "uvType": "BOX",
     "uvOrientation": 64
   },
   {
     "description": "Baby Blue Bed with pillow",
     "baseMaterial": "CARPET",
-    "objectIds": [ 418 ],
+    "objectIds": [ "BLUEBED" ],
     "uvType": "BOX",
     "uvOrientation": 64
   },
   {
     "description": "Wooden barrel with metal bands - textured",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 362, 2022 ],
+    "objectIds": [ "BARREL", "BARREL_WATERFALL_QUEST" ],
     "uvType": "BOX",
     "uvScale": 0.6
   },
   {
     "description": "Cauldron - with beige liquid",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 35945, 35946 ],
+    "objectIds": [ "MOURNERCAULDRON_OP", "MOURNERCAULDRON_NOOP" ],
     "uvType": "BOX",
     "uvScale": 0.6
   },
@@ -24551,8 +24551,8 @@
     "description": "Sink with textured water and wood paneling - textured",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      873,
-      874
+      "SINK",
+      "SINK2"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -24561,7 +24561,7 @@
     "description": "Pottery Oven",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      11601
+      "FAI_BARBARIAN_POTTERY_OVEN"
     ],
     "uvType": "BOX"
   },
@@ -24569,27 +24569,27 @@
     "description": "Drain and pipe - textured",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      876
+      "PIPE_DRAIN"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Fractionalising Still",
     "baseMaterial": "METALLIC_1_LIGHT",
-    "objectIds": [ 4026 ],
+    "objectIds": [ "REGICIDE_FRACTIONALIZING_STILL" ],
     "uvType": "BOX",
     "uvOrientation": 512
   },
   {
     "description": "Objects - Dirt - Manhole",
     "baseMaterial": "DIRT_2",
-    "objectIds": [ 10321 ],
+    "objectIds": [ "VC_MANHOLE_OPEN" ],
     "uvType": "BOX",
     "uvOrientation": 100
   },
   {
     "description": "Altar Slab - textured",
-    "objectIds": [ 1876 ],
+    "objectIds": [ "ALTAR_SLAB" ],
     "uvType": "BOX",
     "retainVanillaUvs": false,
     "uvOrientation": 512
@@ -24597,7 +24597,7 @@
   {
     "description": "Metal Sconce with candles - unlit",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
-    "objectIds": [ 4500 ],
+    "objectIds": [ "FAI_VARROCK_TWO_CANDLES" ],
     "uvType": "BOX",
     "uvOrientation": 300,
     "uvScale": 0.6
@@ -24605,7 +24605,7 @@
   {
     "description": "Stone bat wall decoration",
     "baseMaterial": "STONE_NORMALED",
-    "objectIds": [ 577 ],
+    "objectIds": [ "GARGOYLE1" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
@@ -24613,7 +24613,7 @@
     "description": "Deaths office - Entrances - Lumbridge",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      38426
+      "DEATH_OFFICE_ACCESS_GRAVE"
     ],
     "uvType": "BOX"
   },
@@ -24621,7 +24621,7 @@
     "description": "Deaths office - Entrances - Seers",
     "baseMaterial": "GRAY_90",
     "objectIds": [
-      39546
+      "DEATH_OFFICE_ACCESS_BROWNGRAVE"
     ],
     "uvType": "BOX"
   },
@@ -24629,7 +24629,7 @@
     "description": "Deaths office - Entrances - Ferox",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      39637
+      "WILDHUB_DEATH_ENTRANCE"
     ],
     "uvType": "BOX"
   },
@@ -24638,7 +24638,7 @@
     "baseMaterial": "GRUNGE_3",
     "flatNormals": true,
     "objectIds": [
-      39617
+      "FAI_DEATH_CRYPT_ENTRANCE"
     ],
     "uvType": "BOX"
   },
@@ -24646,21 +24646,21 @@
     "description": "Deaths office - Walls - Stone",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      39551,
-      39552,
-      39553,
-      39554,
-      39555,
-      39556,
-      39557,
-      39558,
-      39559,
-      39560,
-      39561,
-      39562,
-      39563,
-      39564,
-      39565
+      "DEATH_OFFICE_WALL_FIRE",
+      "DEATH_OFFICE_WALL_ALCOVE",
+      "DEATH_OFFICE_WALL_ALCOVE_SKULL",
+      "DEATH_OFFICE_WALL_ALCOVE_02",
+      "DEATH_OFFICE_WALL_GRATE",
+      "DEATH_OFFICE_WALL_VAR_01",
+      "DEATH_OFFICE_WALL_VAR_02",
+      "DEATH_OFFICE_WALL_VAR_03",
+      "DEATH_OFFICE_WALL_VAR_04",
+      "DEATH_OFFICE_WALL_INSIDE_CORNER_BASIC",
+      "DEATH_OFFICE_WALL_OUTSIDE_CORNER_BASIC",
+      "DEATH_OFFICE_WALL_FIRE_LEFT_1",
+      "DEATH_OFFICE_WALL_FIRE_LEFT_2",
+      "DEATH_OFFICE_WALL_FIRE_RIGHT_1",
+      "DEATH_OFFICE_WALL_FIRE_RIGHT_2"
     ],
     "uvType": "BOX"
   },
@@ -24668,10 +24668,10 @@
     "description": "Deaths office - Walls - Outer Layer",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      39566,
-      39567,
-      39568,
-      39569
+      "DEATH_OFFICE_CAVEWALL_TOP",
+      "DEATH_OFFICE_CAVEWALL_TOP_STRAIGHT",
+      "DEATH_OFFICE_CAVEWALL_TOP_CORNER",
+      "DEATH_OFFICE_CAVEWALL_TOP_CORNER_INSIDE"
     ],
     "uvType": "BOX"
   },
@@ -24679,20 +24679,20 @@
     "description": "Deaths office - Objects - Generic",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      39550,
-      39570,
-      39571,
-      39572,
-      39573,
-      39574,
-      39575,
-      39576,
-      39578,
-      39579,
-      39580,
-      39581,
-      39582,
-      39583
+      "DEATH_COFFER_ACCESS",
+      "DEATH_OFFICE_DESK_01",
+      "DEATH_OFFICE_MUNCHER",
+      "DEATH_OFFICE_CHAIR",
+      "DEATH_OFFICE_CHAIR_SKULLS",
+      "DEATH_OFFICE_SCYTHE",
+      "DEATH_OFFICE_CHEST_CLOSED",
+      "DEATH_OFFICE_CHEST_OPEN_GOLD",
+      "DEATH_OFFICE_CHEST_OPEN_RUNES_01",
+      "DEATH_OFFICE_TOB_WEAPONS",
+      "DEATH_OFFICE_BOOKS_02",
+      "DEATH_OFFICE_BOOKS_03",
+      "DEATH_OFFICE_TORCH",
+      "DEATH_OFFICE_BONES"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -24701,26 +24701,26 @@
     "description": "Deaths office - Objects - Rug",
     "baseMaterial": "CARPET",
     "objectIds": [
-      39585,
-      39586,
-      39587,
-      39588,
-      39589,
-      39590,
-      39591,
-      39592,
-      39593,
-      39594,
-      39595,
-      39596,
-      39597,
-      39598,
-      39599,
-      39600,
-      39601,
-      39602,
-      39603,
-      39604
+      "DEATH_OFFICE_RUG_01",
+      "DEATH_OFFICE_RUG_02",
+      "DEATH_OFFICE_RUG_03",
+      "DEATH_OFFICE_RUG_04",
+      "DEATH_OFFICE_RUG_05",
+      "DEATH_OFFICE_RUG_06",
+      "DEATH_OFFICE_RUG_07",
+      "DEATH_OFFICE_RUG_08",
+      "DEATH_OFFICE_RUG_09",
+      "DEATH_OFFICE_RUG_10",
+      "DEATH_OFFICE_RUG_11",
+      "DEATH_OFFICE_RUG_12",
+      "DEATH_OFFICE_RUG_13",
+      "DEATH_OFFICE_RUG_14",
+      "DEATH_OFFICE_RUG_15",
+      "DEATH_OFFICE_RUG_16",
+      "DEATH_OFFICE_RUG_17",
+      "DEATH_OFFICE_RUG_18",
+      "DEATH_OFFICE_RUG_19",
+      "DEATH_OFFICE_RUG_20"
     ],
     "uvType": "BOX"
   },
@@ -24729,8 +24729,8 @@
     "hide": true,
     "areas": [ "DEATHS_OFFICE" ],
     "objectIds": [
-      12930,
-      12931
+      "BURGH_ROCK_DUGUPSOIL_1",
+      "BURGH_ROCK_DUGUPSOIL_2"
     ],
     "uvType": "BOX"
   },
@@ -24738,11 +24738,11 @@
     "description": "Zombie Event Gravestones",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      9359,
-      9360,
-      9361,
-      9362,
-      9363
+      "MACRO_DIGGER_GRAVESTONE_1",
+      "MACRO_DIGGER_GRAVESTONE_2",
+      "MACRO_DIGGER_GRAVESTONE_3",
+      "MACRO_DIGGER_GRAVESTONE_4",
+      "MACRO_DIGGER_GRAVESTONE_5"
     ],
     "uvType": "BOX",
     "uvOrientation": 80
@@ -24751,11 +24751,11 @@
     "description": "Zombie Event Graves with coffins",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      9364,
-      9365,
-      9366,
-      9367,
-      10049
+      "MACRO_DIGGER_OPEN_GRAVE_COFFIN_1",
+      "MACRO_DIGGER_OPEN_GRAVE_COFFIN_2",
+      "MACRO_DIGGER_OPEN_GRAVE_COFFIN_3",
+      "MACRO_DIGGER_OPEN_GRAVE_COFFIN_4",
+      "MACRO_DIGGER_OPEN_GRAVE_COFFIN_5"
     ],
     "uvType": "BOX",
     "uvOrientation": 80
@@ -24764,11 +24764,11 @@
     "description": "Zombie Event Graves - empty",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      10050,
-      10051,
-      10052,
-      10053,
-      10054
+      "MACRO_DIGGER_OPEN_GRAVE_EMPTY_1",
+      "MACRO_DIGGER_OPEN_GRAVE_EMPTY_2",
+      "MACRO_DIGGER_OPEN_GRAVE_EMPTY_3",
+      "MACRO_DIGGER_OPEN_GRAVE_EMPTY_4",
+      "MACRO_DIGGER_OPEN_GRAVE_EMPTY_5"
     ],
     "uvType": "BOX",
     "uvOrientation": 80
@@ -24787,15 +24787,15 @@
       }
     ],
     "objectIds": [
-      10055
+      "GRAVEDIGGER_MAUSOLEUM"
     ]
   },
   {
     "description": "Wooden posts - textured",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      1774,
-      17123
+      "WATCHTOWER_LEG2",
+      "WATCHTOWER_LEG1_TALLER"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -24806,7 +24806,7 @@
     "description": "Compost pile with bricks - textured",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      303
+      "COMPOST"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -24816,9 +24816,9 @@
     "description": "Gnome stronghold door - textured",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      190,
-      191,
-      192
+      "GNOME_AREAGATE",
+      "GNOME_AREAGATE_OPEN_LEFT",
+      "GNOME_AREAGATE_OPEN_RIGHT"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -24829,10 +24829,10 @@
     "description": "Gnome statues",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "objectIds": [
-      569,
-      13104,
-      17140,
-      17141
+      "GNOMESTATUE1",
+      "EYEGLO_HAZLEMERE_STATUE",
+      "EYEGLO_OAKNOCK_STATUE",
+      "EYEGLO_HEALTHORG_STATUE"
     ],
     "retainVanillaUvs": false,
     "uvType": "BOX",
@@ -24843,15 +24843,15 @@
     "description": "Asgarnia Ice Dungeon - Snow Walls and Entrances",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      10588,
-      10589,
-      10595,
-      10596,
-      10597,
-      10599,
-      10600,
-      42507,
-      53251
+      "WYVERN_CAVE_WALL",
+      "WYVERN_CAVE_WALL_SHORTER",
+      "WYVERN_SNOW_CAVE_EXIT",
+      "WYVERN_SNOW_CAVE_ENTRANCE",
+      "WYVERN_UNDERGROUND_TOP",
+      "WYVERN_UNDERGROUND_TOP5_HIGHER",
+      "WYVERN_UNDERGROUND_TOP_SHORTER",
+      "CAVEWALL_SHORTCUT_WYVERN_SOUTH",
+      "CAVEWALL_SHORTCUT_WYVERN_EAST"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -24865,7 +24865,7 @@
     "description": "Asgarnia Ice Dungeon - Royal Titans Boss Entrance",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      55986
+      "ROYAL_TITANS_ENTRANCE"
     ],
     "uvType": "BOX",
     "castShadows": false
@@ -24874,7 +24874,7 @@
     "description": "Asgarnia Ice Dungeon - Ice Stairs",
     "baseMaterial": "ICE_2",
     "objectIds": [
-      8728
+      "WYVERN_STEPS_MODEL"
     ],
     "uvType": "BOX",
     "uvScale": 0.75
@@ -24883,7 +24883,7 @@
     "description": "Asgarnia Ice Dungeon - Entrance Trapdoor",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      1738
+      "FAI_TRAPDOOR"
     ],
     "uvType": "BOX",
     "uvScale": 0.55
@@ -24892,17 +24892,17 @@
     "description": "Asgarnia Ice Dungeon - Muddy Walls",
     "baseMaterial": "MUD_1",
     "objectIds": [
-      37568,
-      37569,
-      37572,
-      37580,
-      41413,
-      41414,
-      41415,
-      50707,
-      50709,
-      53228,
-      55901
+      "WYVERN_CAVE_WALL_COLDMUD",
+      "WYVERN_CAVE_WALLTOP_COLDMUD",
+      "WYVERN_CAVE_WALLTOP_COLDMUD_CONCAVE",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_LARGE2",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_MEDIUM",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_MEDIUM2",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_SMALL",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_SMALL2",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_FALLOFF2",
+      "WYVERN_CAVE_COLDMUD_STALAGMITE_FALLOFF3",
+      "WYVERN_CAVE_COLDMUD_PILLAR_DARK01"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -24916,9 +24916,9 @@
     "description": "Asgarnia Ice Dungeon - Muddy Walls Blending to Ice",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      37566,
-      37567,
-      37571
+      "WYVERN_CAVE_WALL_COLDMUD_TRANSITION",
+      "WYVERN_CAVE_WALL_COLDMUD_TRANSITION_M",
+      "WYVERN_CAVE_WALLTOP_COLDMUD_TRANSITION"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -24938,9 +24938,9 @@
     "description": "Asgarnia Ice Dungeon - Muddy Walls Blending to Rock",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      55908,
-      55974,
-      55975
+      "WYVERN_CAVE_WALLTOP_BROWNMUD_TRANSITION",
+      "WYVERN_CAVE_WALL_BROWNMUD_TRANSITION",
+      "WYVERN_CAVE_WALL_BROWNMUD_TRANSITION_M"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -24960,9 +24960,9 @@
     "description": "Asgarnia Ice Dungeon - Muddly Wall - Darken so it blends in with adjacent walls",
     "baseMaterial": "MUD_1_DARK",
     "objectIds": [
-      37573,
-      42506,
-      55987
+      "WYVERN_CAVE_WALL_COLDMUD_LAMP_SINGLE",
+      "CAVEWALL_SHORTCUT_WYVERN_NORTH",
+      "ROYAL_TITANS_EXIT"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -24982,14 +24982,14 @@
     "description": "Asgarnia Ice Dungeon - Ice Spikes",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      55982,
-      55983,
-      55984,
-      55985,
-      27889,
-      27890,
-      55980,
-      55981
+      "THRONE_ICE01_SPIKES03",
+      "THRONE_ICE01_SPIKES04",
+      "THRONE_ICE01_SPIKES05",
+      "THRONE_ICE01_SPIKES06",
+      "ARCHEUS_CRYSTAL_SMALLEST",
+      "ARCHEUS_CRYSTAL_SMALLEST_01",
+      "THRONE_ICE01_SPIKES01",
+      "THRONE_ICE01_SPIKES02"
     ],
     "shadowOpacityThreshold": 0.9
   },
@@ -24997,7 +24997,7 @@
     "description": "Asgarnia Ice Dungeon - Scoreboard",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      56004
+      "ROYAL_TITANS_SCOREBOARD"
     ],
     "shadowOpacityThreshold": 0.9,
     "colorOverrides": [
@@ -25018,7 +25018,7 @@
     "description": "Asgarnia Ice Dungeon - Frozen Throne",
     "baseMaterial": "ICE_1_HIGHGLOSS",
     "objectIds": [
-      55979
+      "THRONE_ICE01_ELDRIC01"
     ],
     "shadowOpacityThreshold": 0.9,
     "colorOverrides": [
@@ -25033,11 +25033,11 @@
     "description": "Asgarnia Ice Dungeon - Ice Floes",
     "baseMaterial": "SNOW_3",
     "objectIds": [
-      56021,
-      56022,
-      56023,
-      56024,
-      56025
+      "FLOORKIT_OBSIDIAN02_FILL02",
+      "DECOKIT_ICE_DEFAULT01",
+      "DECOKIT_ICE_DEFAULT02",
+      "DECOKIT_ICE_DEFAULT03",
+      "DECOKIT_ICE_DEFAULT04"
     ],
     "uvType": "BOX",
     "uvScale": 0.3
@@ -25046,13 +25046,13 @@
     "description": "Asgarnia Ice Dungeon - Ice Trim",
     "baseMaterial": "ICE_4",
     "objectIds": [
-      56014,
-      56015,
-      56016,
-      56017,
-      56018,
-      56019,
-      56020
+      "FLOORKIT_OBSIDIAN02_CORNER01",
+      "FLOORKIT_OBSIDIAN02_CORNER02",
+      "FLOORKIT_OBSIDIAN02_INNER01",
+      "FLOORKIT_OBSIDIAN02_INNER02",
+      "FLOORKIT_OBSIDIAN02_EDGE01",
+      "FLOORKIT_OBSIDIAN02_FILL01",
+      "FLOORKIT_OBSIDIAN02_EDGE02"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -25061,14 +25061,14 @@
     "description": "Asgarnia Ice Dungeon - Lava Trim",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      56005,
-      56006,
-      56007,
-      56008,
-      56009,
-      56010,
-      56011,
-      56012
+      "FLOORKIT_OBSIDIAN01_CORNER01",
+      "FLOORKIT_OBSIDIAN01_CORNER02",
+      "FLOORKIT_OBSIDIAN01_INNER01",
+      "FLOORKIT_OBSIDIAN01_INNER02",
+      "FLOORKIT_OBSIDIAN01_EDGE01",
+      "FLOORKIT_OBSIDIAN01_FILL01",
+      "FLOORKIT_OBSIDIAN01_EDGE02",
+      "FLOORKIT_OBSIDIAN01_FILL02"
     ],
     "uvType": "BOX"
   },
@@ -25076,7 +25076,7 @@
     "description": "Campfire",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      46421
+      "FAVOUR_CAMPFIRE_BASE_EMPTY"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -25085,33 +25085,33 @@
     "description": "Kraken Cove, Royal Trouble and Lizardman Caves  - Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      537,
-      538,
-      15122,
-      15123,
-      15124,
-      15160,
-      15168,
-      15169,
-      15177,
-      15179,
-      15194,
-      15195,
-      15196,
-      15197,
-      15188,
-      15189,
-      15170,
-      15171,
-      15173,
-      15175,
-      15186,
-      15187,
-      15178,
-      15216,
-      15218,
-      15219,
-      30178
+      "SLAYER_CAVE_KRAKEN_BOSS_ENTRANCE",
+      "SLAYER_CAVE_KRAKEN_BOSS_EXIT",
+      "ROYAL_ROCKY_CAVEWALL",
+      "ROYAL_ROCKY_CAVEWALL_FILLER",
+      "ROYAL_ROCKY_CAVEWALL_FILLER_MIRROR",
+      "ROYAL_CAVEWALL_TORCH_FACE1",
+      "ROYAL_CAVEWALL_FACE",
+      "ROYAL_CAVEWALL_CONCAVE_FACE",
+      "ROYAL_CAVEWALL_FACE_SHORTER",
+      "ROYAL_CAVEWALL_TOP_SHORTER",
+      "ROYAL_CAVEWALL_CRACK_FREMENNIKS_IN",
+      "ROYAL_CAVEWALL_CRACK_FREMENNIKS_OUT",
+      "ROYAL_CAVEWALL_CRACK_SEASNAKE_IN",
+      "ROYAL_CAVEWALL_CRACK_SEASNAKE_OUT",
+      "ROYAL_SMALL_CAVE",
+      "ROYAL_SMALL_CAVE_EXIT",
+      "ROYAL_CAVEWALL_FACE_GLOW",
+      "ROYAL_CAVEWALL_FACE_GLOW_HALF",
+      "ROYAL_CAVEWALL_TOP",
+      "ROYAL_CAVEWALL_TOP_HIGHER",
+      "ROYAL_CAVEWALL_CRACK",
+      "ROYAL_CAVEWALL_CRACK_EXIT",
+      "ROYAL_CAVEWALL_FACE_PLAIN",
+      "ROYAL_ROPESWING_MID",
+      "ROYAL_OBSTICAL_ROCKSWING_MIDDLE",
+      "ROYAL_OBSTICAL_ROCKSWING_ENDL",
+      "SLAYER_CAVE_KRAKEN_MAINCAVE_EXIT"
     ],
     "uvType": "BOX",
     "uvScale": 1.25
@@ -25120,9 +25120,9 @@
     "description": "Kraken Cove - Stalagmites",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      30181,
-      30182,
-      30183
+      "SLAYER_KRAKENCAVE_STALAGMITE1",
+      "SLAYER_KRAKENCAVE_STALAGMITE2",
+      "SLAYER_KRAKENCAVE_STALAGMITE6"
     ],
     "uvType": "BOX",
     "uvScale": 0.64
@@ -25131,7 +25131,7 @@
     "description": "Kraken Cove - Stalagmite - Boat",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      30184
+      "SLAYER_KRAKENCAVE_SHIPWRECK"
     ],
     "uvType": "BOX",
     "uvScale": 0.44
@@ -25140,25 +25140,25 @@
     "description": "Kraken Cove - Floating Body and Hole",
     "baseMaterial": "GRUNGE_2",
     "objectIds": [
-      26552,
-      30179
+      "GODWARS_UWATER_DEADGUY02",
+      "SLAYER_CAVE_KRAKEN_HOLE"
     ]
   },
   {
     "description": "Kraken Cove - Darken Whirlpools",
     "baseMaterial": "GRAY_65",
     "npcIds": [
-      493,
-      496,
-      5534
+      "SLAYER_KRAKEN_SUB",
+      "SLAYER_KRAKEN_BOSS_WHIRLPOOL",
+      "SLAYER_KRAKEN_BOSS_TENTACLE_WHIRLPOOL"
     ]
   },
   {
     "description": "Royal Trouble Dungeon - Entrance Rock and Hole",
     "baseMaterial": "STONE",
     "objectIds": [
-      15199,
-      15202
+      "ROYAL_ROCK_WITH_ROPE",
+      "ROYAL_CAVE_EXIT_HOLE_WITH_ROPE"
     ],
     "uvType": "BOX"
   },
@@ -25166,18 +25166,18 @@
     "description": "Royal Trouble Dungeon - Eggs",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      15182,
-      15183,
-      15184,
-      15185
+      "ROYAL_SNAKE_EGGS_1",
+      "ROYAL_SNAKE_EGGS_2",
+      "ROYAL_SNAKE_EGGS_3",
+      "ROYAL_SNAKE_EGGS_4"
     ]
   },
   {
     "description": "Royal Trouble Dungeon - Steam Vents",
     "baseMaterial": "STONE",
     "objectIds": [
-      15214,
-      15215
+      "ROYAL_STEAM_VENT",
+      "ROYAL_STEAM_VENT_2"
     ],
     "uvType": "BOX"
   },
@@ -25185,10 +25185,10 @@
     "description": "Royal Trouble Dungeon - House Walls and Doors",
     "baseMaterial": "WOOD_GRAIN_2",
     "objectIds": [
-      15089,
-      15090,
-      15204,
-      15205
+      "ROYAL_UNDERGROUND_TOWN_WALLS",
+      "ROYAL_UNDERGROUND_TOWN_WINDOW",
+      "ROYAL_VILLAGE_DOOR",
+      "ROYAL_VILLAGE_DOOR_OPEN"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -25197,13 +25197,13 @@
     "description": "Royal Trouble Dungeon - Crates, Barrels",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      15106,
-      15105,
-      15108,
-      15107,
-      15243,
-      15244,
-      15245
+      "ROYAL_CRATES",
+      "ROYAL_BARREL_TAP",
+      "ROYAL_BARREL",
+      "ROYAL_CRATE",
+      "ROYAL_CRATE_PLANKS",
+      "ROYAL_CRATE_PLANKS_PULLEYS",
+      "ROYAL_CRATE_ROPE"
     ],
     "uvType": "BOX",
     "uvOrientation": 512
@@ -25212,7 +25212,7 @@
     "description": "Royal Trouble Dungeon - Crates - Small",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      15109
+      "ROYAL_CRATES2"
     ],
     "uvType": "BOX",
     "uvOrientation": 680
@@ -25221,37 +25221,37 @@
     "description": "Royal Trouble Dungeon - Shelves, Hatstand, Beds, Bar and Fabrics",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      15094,
-      15095,
-      15096,
-      15100,
-      15110,
-      15111,
-      15112,
-      15113,
-      15163,
-      14165,
-      14166,
-      14167,
-      15102,
-      15117,
-      15097,
-      15098,
-      15104,
-      15103,
-      15118,
-      15119,
-      15143,
-      15141,
-      15142,
-      15140,
-      15134,
-      15135,
-      15136,
-      15139,
-      15144,
-      15138,
-      15145
+      "ROYAL_BUNKBED",
+      "ROYAL_BUNKBED2",
+      "ROYAL_BUNKBED3",
+      "ROYAL_SHELF_COOKING",
+      "ROYAL_SHELVES",
+      "ROYAL_SHELVES2",
+      "ROYAL_SHELVES3",
+      "ROYAL_SHELVES4",
+      "ROYAL_DWARF_CLOTHES",
+      "ROYAL_DWARF_SHELF_TANKARDS",
+      "ROYAL_DWARF_DOUBLE_SHELF",
+      "ROYAL_DWARF_DOUBLE_SHELF2",
+      "ROYAL_SHELF_BOOKS",
+      "ROYAL_BOOKCASE",
+      "ROYAL_BED",
+      "ROYAL_SHELF_EMPTY",
+      "ROYAL_BAR_NO_PUMPS",
+      "ROYAL_BAR",
+      "ROYAL_BOOKCASE2",
+      "ROYAL_BOOKCASE3",
+      "ROYAL_CLOTHESMODEL_MAN2",
+      "ROYAL_CLOTHESMODEL_WOMAN2",
+      "ROYAL_CLOTHESMODEL_MAN1",
+      "ROYAL_CLOTHESMODEL_WOMAN1",
+      "ROYAL_DYEDFABRIC_WASHING_LINE_ENDL",
+      "ROYAL_DYEDFABRIC_WASHING_LINE_ENDR",
+      "ROYAL_DYEDFABRIC_WASHING_LINE",
+      "ROYAL_FLOOR_CLOTH",
+      "ROYAL_CLOTHESEQUIPMENT",
+      "ROYAL_DYE_POTS",
+      "ROYAL_CLOTHES_SHELVES"
     ],
     "uvType": "BOX"
   },
@@ -25259,10 +25259,10 @@
     "description": "Royal Trouble Dungeon - Wooden Supports",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      15130,
-      15131,
-      15132,
-      15133
+      "ROYAL_DWARF_PITPROP",
+      "ROYAL_DWARF_PITPROP2",
+      "ROYAL_DWARF_PITPROP_L",
+      "ROYAL_DWARF_PITPROP_R"
     ],
     "uvType": "BOX",
     "uvOrientation": -50
@@ -25271,10 +25271,10 @@
     "description": "Royal Trouble Dungeon - Crane",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      15225,
-      15232,
-      15234,
-      15237
+      "ROYAL_COAL_LIFT_PLATFORM_USEABLE",
+      "ROYAL_SIDE_SCAFFOLD_REPAIRED",
+      "ROYAL_TOP_SCAFFOLD_REPAIRED",
+      "ROYAL_LIFT_PLATFORM_AT_TOP"
     ],
     "uvType": "BOX"
   },
@@ -25282,16 +25282,16 @@
     "description": "Royal Trouble Dungeon - Engine",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      7967,
-      15228,
-      15229
+      "PINEAPPLE_TREE_1",
+      "ROYAL_COAL_LIFT_ENGINE_PLATFORM_ENGINE_OFF",
+      "ROYAL_COAL_LIFT_ENGINE_PLATFORM_ENGINE_ON"
     ],
     "uvType": "BOX"
   },
   {
     "description": "Wooden -  Tables - Sturdy",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 27514 ],
+    "objectIds": [ "HOS_TABLE_01" ],
     "uvOrientationY": 512,
     "uvType": "BOX",
     "flatNormals": true,
@@ -25301,11 +25301,11 @@
     "description": "Wooden -  Tables - Sturdy",
     "baseMaterial": "MARBLE_2_SEMIGLOSS",
     "objectIds": [
-      41841,
-      41843,
-      41845,
-      41847,
-      41849
+      "KOUREND_ENTRANCE_STATUE_ARCEUUS_NOOP",
+      "KOUREND_ENTRANCE_STATUE_HOSIDIUS_NOOP",
+      "KOUREND_ENTRANCE_STATUE_LOVAKENGJ_NOOP",
+      "KOUREND_ENTRANCE_STATUE_PISCARILIUS_NOOP",
+      "KOUREND_ENTRANCE_STATUE_SHAYZIEN_NOOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -25315,9 +25315,9 @@
     "description": "Prison Pete Castle Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      24287,
-      24288,
-      24295
+      "FAI_FALADOR_PARTY_NEG_ROOM_WALL_BIG",
+      "FAI_FALADOR_PARTY_NEG_ROOM_WALL",
+      "FAI_FALADOR_PARTY_NEG_ROOM_PILLAR"
     ],
     "uvType": "BOX",
     "uvOrientation": 300,
@@ -25327,8 +25327,8 @@
     "description": "Prison Pete Castle Walls with Metal Bars",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      24289,
-      24290
+      "FAI_FALADOR_PARTY_NEG_ROOM_WALL_BARS_BIG",
+      "FAI_FALADOR_PARTY_NEG_ROOM_WALL_BARS"
     ],
     "uvType": "BOX",
     "uvOrientation": 300,
@@ -25337,14 +25337,14 @@
   {
     "description": "Canoe Station - Uncut",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 12144, 12145 ],
+    "objectIds": [ "CANOESTATION_TREE", "CANOESTATION_TREE_FALLING" ],
     "uvType": "BOX",
     "uvScale": 0.8
   },
   {
     "description": "Canoe Station - with Canoes",
     "baseMaterial": "WOOD_GRAIN_3",
-    "objectIds": [ 12146, 12147, 12148, 12149, 12150, 12151, 12152, 12153, 12154, 12155, 12156, 12157, 12158, 12159, 12160, 12161, 12162 ],
+    "objectIds": [ "CANOESTATION_FALLEN_TREE", "CANOESTATION_LOG", "CANOESTATION_DUGOUT", "CANOESTATION_STABLEDUGOUT", "CANOESTATION_WAKA", "CANOESTATION_LOG_INWATER", "CANOESTATION_DUGOUT_INWATER", "CANOESTATION_STABLEDUGOUT_INWATER", "CANOESTATION_WAKA_INWATER", "CANOEING_LOG_CANOEING_STATION_IN_WATER", "CANOEING_DUGOUT_CANOEING_STATION_IN_WATER", "CANOEING_CATAMARAN_CANOEING_STATION_IN_WATER", "CANOEING_WAKA_CANOEING_STATION_IN_WATER", "CANOEING_LOG_SINKING", "CANOEING_DUGOUT_SINKING", "CANOEING_CATAMARAN_SINKING", "CANOEING_WAKA_SINKING" ],
     "uvType": "BOX",
     "uvOrientation": 512,
     "uvScale": 0.8
@@ -25352,7 +25352,7 @@
   {
     "description": "Bankbooth with Glass Window - Lumbridge",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 18491 ],
+    "objectIds": [ "AIDE_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25367,7 +25367,7 @@
   {
     "description": "Bankbooth with Shutters - Lumbridge",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 18492 ],
+    "objectIds": [ "AIDE_BANKBOOTH_CLOSED" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512
@@ -25375,7 +25375,7 @@
   {
     "description": "Bankbooth with Glass Window - Varrock",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 10583 ],
+    "objectIds": [ "FAI_VARROCK_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25390,7 +25390,7 @@
   {
     "description": "Bankbooth with Shutters - Corsair Cove",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 10585 ],
+    "objectIds": [ "FAI_VARROCK_BANKBOOTH_CLOSED" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512
@@ -25398,7 +25398,7 @@
   {
     "description": "Bankbooth with Glass Window - Falador",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 24101 ],
+    "objectIds": [ "FAI_FALADOR_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25413,7 +25413,7 @@
   {
     "description": "Bankbooth with Glass Window - Seers",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 25808 ],
+    "objectIds": [ "KR_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25428,7 +25428,7 @@
   {
     "description": "Bankbooth with Shutters - Seers",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 25809 ],
+    "objectIds": [ "KR_BANKBOOTH_CLOSED" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512
@@ -25436,7 +25436,7 @@
   {
     "description": "Bankbooth with Glass Window - Lunar Island",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 16700 ],
+    "objectIds": [ "LUNAR_MOONCLAN_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25451,7 +25451,7 @@
   {
     "description": "Bankbooth with Glass Window - Canifis",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 24347 ],
+    "objectIds": [ "CANAFIS_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25466,7 +25466,7 @@
   {
     "description": "Bankbooth with Glass Window - Phasmatys",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 16642 ],
+    "objectIds": [ "AHOY_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25481,7 +25481,7 @@
   {
     "description": "Bankbooth with Shutters - Phasmatys",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 16643 ],
+    "objectIds": [ "AHOY_BANKBOOTHCLOSED" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512
@@ -25489,7 +25489,7 @@
   {
     "description": "Bankbooth with Glass Window - Nardah",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 10517 ],
+    "objectIds": [ "ELID_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25504,7 +25504,7 @@
   {
     "description": "Bankbooth with Shutters - Nardah",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 10518 ],
+    "objectIds": [ "ELID_BANKBOOTHCLOSED" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512
@@ -25512,7 +25512,7 @@
   {
     "description": "Bankbooth with Glass Window - Sophanem",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 20325 ],
+    "objectIds": [ "CONTACT_BANK_BOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25527,7 +25527,7 @@
   {
     "description": "Bankbooth with Glass Window - The Node",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
-    "objectIds": [ 42837 ],
+    "objectIds": [ "GIM_ISLAND_BANKBOOTH" ],
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientationZ": 512,
@@ -25565,450 +25565,450 @@
       }
     ],
     "objectIds": [
-      3830,
-      3835,
-      3836,
-      3837,
-      3838,
-      3839,
-      3840,
-      3841,
-      3842,
-      3843,
-      3844,
-      3845,
-      3846,
-      3847,
-      3848,
-      3849,
-      3850,
-      3851,
-      3852,
-      3853,
-      3854,
-      7808,
-      7813,
-      19054,
-      19055,
-      19056,
-      19057,
-      19058,
-      19059,
-      19060,
-      19061,
-      19062,
-      19063,
-      19064,
-      19066,
-      19067,
-      19068,
-      19069,
-      19070,
-      19071,
-      19072,
-      19073,
-      19074,
-      19075,
-      19076,
-      19077,
-      19078,
-      19079,
-      19080,
-      19081,
-      19082,
-      19083,
-      19084,
-      19085,
-      19086,
-      19087,
-      19088,
-      19089,
-      19090,
-      19091,
-      19092,
-      19093,
-      19094,
-      19095,
-      19096,
-      19097,
-      19098,
-      19099,
-      19100,
-      19101,
-      19102,
-      19103,
-      19104,
-      19105,
-      19106,
-      19107,
-      19108,
-      19109,
-      19110,
-      19111,
-      20099,
-      20100,
-      20101,
-      20102,
-      20103,
-      20104,
-      20105,
-      20106,
-      20107,
-      20108,
-      20109,
-      20110,
-      20111,
-      20112,
-      20113,
-      20114,
-      20115,
-      20116,
-      20117,
-      20119,
-      20120,
-      20121,
-      20122,
-      20123,
-      20124,
-      20125,
-      20126,
-      20228,
-      20870,
-      20871,
-      20872,
-      20886,
-      20887,
-      20888,
-      20889,
-      20890,
-      20891,
-      20892,
-      20893,
-      20894,
-      20895,
-      20896,
-      20897,
-      20898,
-      20899,
-      20900,
-      20901,
-      20902,
-      20903,
-      20904,
-      20905,
-      20906,
-      20907,
-      20908,
-      20909,
-      20910,
-      20911,
-      20912,
-      20913,
-      20914,
-      20915,
-      20916,
-      20917,
-      20918,
-      20919,
-      20920,
-      20921,
-      20922,
-      20923,
-      20924,
-      21281,
-      21282,
-      21283,
-      21284,
-      21285,
-      21286,
-      21287,
-      21288,
-      21289,
-      21290,
-      21291,
-      21292,
-      21293,
-      21294,
-      21295,
-      21296,
-      21297,
-      21298,
-      21668,
-      21669,
-      21670,
-      21671,
-      21672,
-      21673,
-      21674,
-      21675,
-      21676,
-      21677,
-      21678,
-      21679,
-      21680,
-      21681,
-      21682,
-      21683,
-      21684,
-      21685,
-      21686,
-      21687,
-      21688,
-      21689,
-      21690,
-      21691,
-      21692,
-      21693,
-      21694,
-      21695,
-      30502,
-      30503,
-      30504,
-      30505,
-      30506,
-      30507,
-      30508,
-      30509,
-      30510,
-      30511,
-      30512,
-      30513,
-      30514,
-      30515,
-      30516,
-      31863,
-      31864,
-      31865,
-      31866,
-      31867,
-      31868,
-      31869,
-      31870,
-      31871,
-      31872,
-      31873,
-      31874,
-      31875,
-      31876,
-      31877,
-      33762,
-      33763,
-      33764,
-      33765,
-      33766,
-      33767,
-      33768,
-      33769,
-      33770,
-      33771,
-      33772,
-      33773,
-      33774,
-      33775,
-      33776,
-      33777,
-      33778,
-      33779,
-      33780,
-      33781,
-      33782,
-      33783,
-      33784,
-      33785,
-      33786,
-      33787,
-      33788,
-      33789,
-      33790,
-      33791,
-      33792,
-      33793,
-      33794,
-      33795,
-      33796,
-      33797,
-      33798,
-      33799,
-      33800,
-      33801,
-      33802,
-      33803,
-      33804,
-      33805,
-      33806,
-      33807,
-      33808,
-      33809,
-      33810,
-      33811,
-      33812,
-      33813,
-      33814,
-      33815,
-      33816,
-      33817,
-      33818,
-      33819,
-      33820,
-      33821,
-      33822,
-      33823,
-      33824,
-      33825,
-      33826,
-      33827,
-      33828,
-      33829,
-      33830,
-      33831,
-      33832,
-      33833,
-      33834,
-      33835,
-      33836,
-      33837,
-      33838,
-      33839,
-      33840,
-      33841,
-      33842,
-      33843,
-      33844,
-      33845,
-      33846,
-      33847,
-      33848,
-      33849,
-      33850,
-      33851,
-      33852,
-      33853,
-      33854,
-      33855,
-      33856,
-      33857,
-      33858,
-      33859,
-      33860,
-      33861,
-      33862,
-      33863,
-      33864,
-      33865,
-      33866,
-      33867,
-      33868,
-      33869,
-      33870,
-      33871,
-      33872,
-      33873,
-      33874,
-      33875,
-      33876,
-      33877,
-      33878,
-      33879,
-      33880,
-      33881,
-      33882,
-      33883,
-      33884,
-      33885,
-      33886,
-      33887,
-      33888,
-      33889,
-      33890,
-      33891,
-      33892,
-      33893,
-      33894,
-      33895,
-      33896,
-      33897,
-      33898,
-      33899,
-      33900,
-      33901,
-      33902,
-      33903,
-      33904,
-      33905,
-      33906,
-      33907,
-      33908,
-      33909,
-      33910,
-      33911,
-      33912,
-      33913,
-      33914,
-      33915,
-      33916,
-      33917,
-      33918,
-      33919,
-      33920,
-      33921,
-      33922,
-      33923,
-      33924,
-      33925,
-      33926,
-      33927,
-      33928,
-      33929,
-      33930,
-      33931,
-      33932,
-      33933,
-      33934,
-      33935,
-      33936,
-      33937,
-      33938,
-      33939,
-      33940,
-      33941,
-      33942,
-      33943,
-      33944,
-      33945,
-      33946,
-      33947,
-      33948,
-      33949,
-      33950,
-      33951,
-      33952,
-      33953,
-      33954,
-      33955,
-      33956,
-      33957,
-      33958,
-      33959,
-      33960,
-      33961,
-      33962,
-      33963,
-      33964,
-      33965,
-      33966,
-      33967,
-      33968,
-      33969,
-      33970,
-      33971,
-      33972,
-      33973,
-      33974,
-      33975,
-      33976,
-      33977,
-      33978,
-      41426
+      "COMPOST_BIN_COMPOSTABLE_01",
+      "COMPOST_BIN_COMPOSTABLE_02",
+      "COMPOST_BIN_COMPOSTABLE_03",
+      "COMPOST_BIN_COMPOSTABLE_04",
+      "COMPOST_BIN_COMPOSTABLE_05",
+      "COMPOST_BIN_COMPOSTABLE_06",
+      "COMPOST_BIN_COMPOSTABLE_07",
+      "COMPOST_BIN_COMPOSTABLE_08",
+      "COMPOST_BIN_COMPOSTABLE_09",
+      "COMPOST_BIN_COMPOSTABLE_10",
+      "COMPOST_BIN_COMPOSTABLE_11",
+      "COMPOST_BIN_COMPOSTABLE_12",
+      "COMPOST_BIN_COMPOSTABLE_13",
+      "COMPOST_BIN_COMPOSTABLE_14",
+      "COMPOST_BIN_COMPOSTABLE_15",
+      "COMPOST_BIN_COMPOST_ROTTING",
+      "COMPOST_BIN_COMPOST_READY",
+      "COMPOST_BIN_COMPOST_01",
+      "COMPOST_BIN_COMPOST_02",
+      "COMPOST_BIN_COMPOST_03",
+      "COMPOST_BIN_COMPOST_04",
+      "COMPOST_BIN_EMPTY",
+      "COMPOST_BIN_CLOSED",
+      "COMPOST_BIN_COMPOST_05",
+      "COMPOST_BIN_COMPOST_06",
+      "COMPOST_BIN_COMPOST_07",
+      "COMPOST_BIN_COMPOST_08",
+      "COMPOST_BIN_COMPOST_09",
+      "COMPOST_BIN_COMPOST_10",
+      "COMPOST_BIN_COMPOST_11",
+      "COMPOST_BIN_COMPOST_12",
+      "COMPOST_BIN_COMPOST_13",
+      "COMPOST_BIN_COMPOST_14",
+      "COMPOST_BIN_COMPOST_15",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_01",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_02",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_03",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_04",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_05",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_06",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_07",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_08",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_09",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_10",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_11",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_12",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_13",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_14",
+      "COMPOST_BIN_SUPERCOMPOSTABLE_15",
+      "COMPOST_BIN_SUPERCOMPOST_ROTTING",
+      "COMPOST_BIN_SUPERCOMPOST_READY",
+      "COMPOST_BIN_SUPERCOMPOST_01",
+      "COMPOST_BIN_SUPERCOMPOST_02",
+      "COMPOST_BIN_SUPERCOMPOST_03",
+      "COMPOST_BIN_SUPERCOMPOST_04",
+      "COMPOST_BIN_SUPERCOMPOST_05",
+      "COMPOST_BIN_SUPERCOMPOST_06",
+      "COMPOST_BIN_SUPERCOMPOST_07",
+      "COMPOST_BIN_SUPERCOMPOST_08",
+      "COMPOST_BIN_SUPERCOMPOST_09",
+      "COMPOST_BIN_SUPERCOMPOST_10",
+      "COMPOST_BIN_SUPERCOMPOST_11",
+      "COMPOST_BIN_SUPERCOMPOST_12",
+      "COMPOST_BIN_SUPERCOMPOST_13",
+      "COMPOST_BIN_SUPERCOMPOST_14",
+      "COMPOST_BIN_SUPERCOMPOST_15",
+      "COMPOST_BIN_TOMATOES_01",
+      "COMPOST_BIN_TOMATOES_02",
+      "COMPOST_BIN_TOMATOES_03",
+      "COMPOST_BIN_TOMATOES_04",
+      "COMPOST_BIN_TOMATOES_05",
+      "COMPOST_BIN_TOMATOES_06",
+      "COMPOST_BIN_TOMATOES_07",
+      "COMPOST_BIN_TOMATOES_08",
+      "COMPOST_BIN_TOMATOES_09",
+      "COMPOST_BIN_TOMATOES_10",
+      "COMPOST_BIN_TOMATOES_11",
+      "COMPOST_BIN_TOMATOES_12",
+      "COMPOST_BIN_TOMATOES_13",
+      "COMPOST_BIN_TOMATOES_14",
+      "COMPOST_BIN_TOMATOES_15",
+      "COMPOST_BIN_ROTTENTOMATOES_ROTTING",
+      "COMPOST_BIN_ROTTENTOMATOES_READY",
+      "COMPOST_BIN_ROTTENTOMATOES_01",
+      "COMPOST_BIN_ROTTENTOMATOES_02",
+      "COMPOST_BIN_ROTTENTOMATOES_03",
+      "COMPOST_BIN_ROTTENTOMATOES_04",
+      "COMPOST_BIN_ROTTENTOMATOES_05",
+      "COMPOST_BIN_ROTTENTOMATOES_06",
+      "COMPOST_BIN_ROTTENTOMATOES_07",
+      "COMPOST_BIN_ROTTENTOMATOES_08",
+      "COMPOST_BIN_ROTTENTOMATOES_09",
+      "COMPOST_BIN_ROTTENTOMATOES_10",
+      "COMPOST_BIN_ROTTENTOMATOES_11",
+      "COMPOST_BIN_ROTTENTOMATOES_12",
+      "COMPOST_BIN_ROTTENTOMATOES_13",
+      "COMPOST_BIN_ROTTENTOMATOES_14",
+      "COMPOST_BIN_ROTTENTOMATOES_15",
+      "COMPOST_BIN_DARK_EMPTY",
+      "COMPOST_BIN_DARK_CLOSED",
+      "COMPOST_BIN_DARK_COMPOSTABLE_01",
+      "COMPOST_BIN_DARK_COMPOSTABLE_02",
+      "COMPOST_BIN_DARK_COMPOSTABLE_03",
+      "COMPOST_BIN_DARK_COMPOSTABLE_04",
+      "COMPOST_BIN_DARK_COMPOSTABLE_05",
+      "COMPOST_BIN_DARK_COMPOSTABLE_06",
+      "COMPOST_BIN_DARK_COMPOSTABLE_07",
+      "COMPOST_BIN_DARK_COMPOSTABLE_08",
+      "COMPOST_BIN_DARK_COMPOSTABLE_09",
+      "COMPOST_BIN_DARK_COMPOSTABLE_10",
+      "COMPOST_BIN_DARK_COMPOSTABLE_11",
+      "COMPOST_BIN_DARK_COMPOSTABLE_12",
+      "COMPOST_BIN_DARK_COMPOSTABLE_13",
+      "COMPOST_BIN_DARK_COMPOSTABLE_14",
+      "COMPOST_BIN_DARK_COMPOSTABLE_15",
+      "COMPOST_BIN_DARK_COMPOST_ROTTING",
+      "COMPOST_BIN_DARK_COMPOST_READY",
+      "COMPOST_BIN_DARK_COMPOST_01",
+      "COMPOST_BIN_DARK_COMPOST_02",
+      "COMPOST_BIN_DARK_COMPOST_03",
+      "COMPOST_BIN_DARK_COMPOST_04",
+      "COMPOST_BIN_DARK_COMPOST_05",
+      "COMPOST_BIN_DARK_COMPOST_06",
+      "COMPOST_BIN_DARK_COMPOST_07",
+      "COMPOST_BIN_DARK_COMPOST_08",
+      "COMPOST_BIN_DARK_COMPOST_09",
+      "COMPOST_BIN_DARK_COMPOST_10",
+      "COMPOST_BIN_DARK_COMPOST_11",
+      "COMPOST_BIN_DARK_COMPOST_12",
+      "COMPOST_BIN_DARK_COMPOST_13",
+      "COMPOST_BIN_DARK_COMPOST_14",
+      "COMPOST_BIN_DARK_COMPOST_15",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_01",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_02",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_03",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_04",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_05",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_06",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_07",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_08",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_09",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_10",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_11",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_12",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_13",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_14",
+      "COMPOST_BIN_DARK_SUPERCOMPOSTABLE_15",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_ROTTING",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_READY",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_01",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_02",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_03",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_04",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_05",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_06",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_07",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_08",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_09",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_10",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_11",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_12",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_13",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_14",
+      "COMPOST_BIN_DARK_SUPERCOMPOST_15",
+      "COMPOST_BIN_DARK_TOMATOES_01",
+      "COMPOST_BIN_DARK_TOMATOES_02",
+      "COMPOST_BIN_DARK_TOMATOES_03",
+      "COMPOST_BIN_DARK_TOMATOES_04",
+      "COMPOST_BIN_DARK_TOMATOES_05",
+      "COMPOST_BIN_DARK_TOMATOES_06",
+      "COMPOST_BIN_DARK_TOMATOES_07",
+      "COMPOST_BIN_DARK_TOMATOES_08",
+      "COMPOST_BIN_DARK_TOMATOES_09",
+      "COMPOST_BIN_DARK_TOMATOES_10",
+      "COMPOST_BIN_DARK_TOMATOES_11",
+      "COMPOST_BIN_DARK_TOMATOES_12",
+      "COMPOST_BIN_DARK_TOMATOES_13",
+      "COMPOST_BIN_DARK_TOMATOES_14",
+      "COMPOST_BIN_DARK_TOMATOES_15",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_ROTTING",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_READY",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_01",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_02",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_03",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_04",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_05",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_06",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_07",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_08",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_09",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_10",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_11",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_12",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_13",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_14",
+      "COMPOST_BIN_DARK_ROTTENTOMATOES_15",
+      "COMPOST_BIN_ULTRACOMPOST_01",
+      "COMPOST_BIN_ULTRACOMPOST_02",
+      "COMPOST_BIN_ULTRACOMPOST_03",
+      "COMPOST_BIN_ULTRACOMPOST_04",
+      "COMPOST_BIN_ULTRACOMPOST_05",
+      "COMPOST_BIN_ULTRACOMPOST_06",
+      "COMPOST_BIN_ULTRACOMPOST_07",
+      "COMPOST_BIN_ULTRACOMPOST_08",
+      "COMPOST_BIN_ULTRACOMPOST_09",
+      "COMPOST_BIN_ULTRACOMPOST_10",
+      "COMPOST_BIN_ULTRACOMPOST_11",
+      "COMPOST_BIN_ULTRACOMPOST_12",
+      "COMPOST_BIN_ULTRACOMPOST_13",
+      "COMPOST_BIN_ULTRACOMPOST_14",
+      "COMPOST_BIN_ULTRACOMPOST_15",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_01",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_02",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_03",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_04",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_05",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_06",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_07",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_08",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_09",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_10",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_11",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_12",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_13",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_14",
+      "COMPOST_BIN_DARK_ULTRACOMPOST_15",
+      "COMPOST_BIGBIN_EMPTY",
+      "COMPOST_BIGBIN_COMPOSTABLE_01",
+      "COMPOST_BIGBIN_COMPOSTABLE_02",
+      "COMPOST_BIGBIN_COMPOSTABLE_03",
+      "COMPOST_BIGBIN_COMPOSTABLE_04",
+      "COMPOST_BIGBIN_COMPOSTABLE_05",
+      "COMPOST_BIGBIN_COMPOSTABLE_06",
+      "COMPOST_BIGBIN_COMPOSTABLE_07",
+      "COMPOST_BIGBIN_COMPOSTABLE_08",
+      "COMPOST_BIGBIN_COMPOSTABLE_09",
+      "COMPOST_BIGBIN_COMPOSTABLE_10",
+      "COMPOST_BIGBIN_COMPOSTABLE_11",
+      "COMPOST_BIGBIN_COMPOSTABLE_12",
+      "COMPOST_BIGBIN_COMPOSTABLE_13",
+      "COMPOST_BIGBIN_COMPOSTABLE_14",
+      "COMPOST_BIGBIN_COMPOSTABLE_15",
+      "COMPOST_BIGBIN_COMPOSTABLE_16",
+      "COMPOST_BIGBIN_COMPOSTABLE_17",
+      "COMPOST_BIGBIN_COMPOSTABLE_18",
+      "COMPOST_BIGBIN_COMPOSTABLE_19",
+      "COMPOST_BIGBIN_COMPOSTABLE_20",
+      "COMPOST_BIGBIN_COMPOSTABLE_21",
+      "COMPOST_BIGBIN_COMPOSTABLE_22",
+      "COMPOST_BIGBIN_COMPOSTABLE_23",
+      "COMPOST_BIGBIN_COMPOSTABLE_24",
+      "COMPOST_BIGBIN_COMPOSTABLE_25",
+      "COMPOST_BIGBIN_COMPOSTABLE_26",
+      "COMPOST_BIGBIN_COMPOSTABLE_27",
+      "COMPOST_BIGBIN_COMPOSTABLE_28",
+      "COMPOST_BIGBIN_COMPOSTABLE_29",
+      "COMPOST_BIGBIN_COMPOSTABLE_30",
+      "COMPOST_BIGBIN_COMPOST_ROTTING",
+      "COMPOST_BIGBIN_COMPOST_READY",
+      "COMPOST_BIGBIN_COMPOST_01",
+      "COMPOST_BIGBIN_COMPOST_02",
+      "COMPOST_BIGBIN_COMPOST_03",
+      "COMPOST_BIGBIN_COMPOST_04",
+      "COMPOST_BIGBIN_COMPOST_05",
+      "COMPOST_BIGBIN_COMPOST_06",
+      "COMPOST_BIGBIN_COMPOST_07",
+      "COMPOST_BIGBIN_COMPOST_08",
+      "COMPOST_BIGBIN_COMPOST_09",
+      "COMPOST_BIGBIN_COMPOST_10",
+      "COMPOST_BIGBIN_COMPOST_11",
+      "COMPOST_BIGBIN_COMPOST_12",
+      "COMPOST_BIGBIN_COMPOST_13",
+      "COMPOST_BIGBIN_COMPOST_14",
+      "COMPOST_BIGBIN_COMPOST_15",
+      "COMPOST_BIGBIN_COMPOST_16",
+      "COMPOST_BIGBIN_COMPOST_17",
+      "COMPOST_BIGBIN_COMPOST_18",
+      "COMPOST_BIGBIN_COMPOST_19",
+      "COMPOST_BIGBIN_COMPOST_20",
+      "COMPOST_BIGBIN_COMPOST_21",
+      "COMPOST_BIGBIN_COMPOST_22",
+      "COMPOST_BIGBIN_COMPOST_23",
+      "COMPOST_BIGBIN_COMPOST_24",
+      "COMPOST_BIGBIN_COMPOST_25",
+      "COMPOST_BIGBIN_COMPOST_26",
+      "COMPOST_BIGBIN_COMPOST_27",
+      "COMPOST_BIGBIN_COMPOST_28",
+      "COMPOST_BIGBIN_COMPOST_29",
+      "COMPOST_BIGBIN_COMPOST_30",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_01",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_02",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_03",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_04",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_05",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_06",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_07",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_08",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_09",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_10",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_11",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_12",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_13",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_14",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_15",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_16",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_17",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_18",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_19",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_20",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_21",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_22",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_23",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_24",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_25",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_26",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_27",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_28",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_29",
+      "COMPOST_BIGBIN_SUPERCOMPOSTABLE_30",
+      "COMPOST_BIGBIN_SUPERCOMPOST_ROTTING",
+      "COMPOST_BIGBIN_SUPERCOMPOST_READY",
+      "COMPOST_BIGBIN_SUPERCOMPOST_01",
+      "COMPOST_BIGBIN_SUPERCOMPOST_02",
+      "COMPOST_BIGBIN_SUPERCOMPOST_03",
+      "COMPOST_BIGBIN_SUPERCOMPOST_04",
+      "COMPOST_BIGBIN_SUPERCOMPOST_05",
+      "COMPOST_BIGBIN_SUPERCOMPOST_06",
+      "COMPOST_BIGBIN_SUPERCOMPOST_07",
+      "COMPOST_BIGBIN_SUPERCOMPOST_08",
+      "COMPOST_BIGBIN_SUPERCOMPOST_09",
+      "COMPOST_BIGBIN_SUPERCOMPOST_10",
+      "COMPOST_BIGBIN_SUPERCOMPOST_11",
+      "COMPOST_BIGBIN_SUPERCOMPOST_12",
+      "COMPOST_BIGBIN_SUPERCOMPOST_13",
+      "COMPOST_BIGBIN_SUPERCOMPOST_14",
+      "COMPOST_BIGBIN_SUPERCOMPOST_15",
+      "COMPOST_BIGBIN_SUPERCOMPOST_16",
+      "COMPOST_BIGBIN_SUPERCOMPOST_17",
+      "COMPOST_BIGBIN_SUPERCOMPOST_18",
+      "COMPOST_BIGBIN_SUPERCOMPOST_19",
+      "COMPOST_BIGBIN_SUPERCOMPOST_20",
+      "COMPOST_BIGBIN_SUPERCOMPOST_21",
+      "COMPOST_BIGBIN_SUPERCOMPOST_22",
+      "COMPOST_BIGBIN_SUPERCOMPOST_23",
+      "COMPOST_BIGBIN_SUPERCOMPOST_24",
+      "COMPOST_BIGBIN_SUPERCOMPOST_25",
+      "COMPOST_BIGBIN_SUPERCOMPOST_26",
+      "COMPOST_BIGBIN_SUPERCOMPOST_27",
+      "COMPOST_BIGBIN_SUPERCOMPOST_28",
+      "COMPOST_BIGBIN_SUPERCOMPOST_29",
+      "COMPOST_BIGBIN_SUPERCOMPOST_30",
+      "COMPOST_BIGBIN_TOMATOES_01",
+      "COMPOST_BIGBIN_TOMATOES_02",
+      "COMPOST_BIGBIN_TOMATOES_03",
+      "COMPOST_BIGBIN_TOMATOES_04",
+      "COMPOST_BIGBIN_TOMATOES_05",
+      "COMPOST_BIGBIN_TOMATOES_06",
+      "COMPOST_BIGBIN_TOMATOES_07",
+      "COMPOST_BIGBIN_TOMATOES_08",
+      "COMPOST_BIGBIN_TOMATOES_09",
+      "COMPOST_BIGBIN_TOMATOES_10",
+      "COMPOST_BIGBIN_TOMATOES_11",
+      "COMPOST_BIGBIN_TOMATOES_12",
+      "COMPOST_BIGBIN_TOMATOES_13",
+      "COMPOST_BIGBIN_TOMATOES_14",
+      "COMPOST_BIGBIN_TOMATOES_15",
+      "COMPOST_BIGBIN_TOMATOES_16",
+      "COMPOST_BIGBIN_TOMATOES_17",
+      "COMPOST_BIGBIN_TOMATOES_18",
+      "COMPOST_BIGBIN_TOMATOES_19",
+      "COMPOST_BIGBIN_TOMATOES_20",
+      "COMPOST_BIGBIN_TOMATOES_21",
+      "COMPOST_BIGBIN_TOMATOES_22",
+      "COMPOST_BIGBIN_TOMATOES_23",
+      "COMPOST_BIGBIN_TOMATOES_24",
+      "COMPOST_BIGBIN_TOMATOES_25",
+      "COMPOST_BIGBIN_TOMATOES_26",
+      "COMPOST_BIGBIN_TOMATOES_27",
+      "COMPOST_BIGBIN_TOMATOES_28",
+      "COMPOST_BIGBIN_TOMATOES_29",
+      "COMPOST_BIGBIN_TOMATOES_30",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_ROTTING",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_READY",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_01",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_02",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_03",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_04",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_05",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_06",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_07",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_08",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_09",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_10",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_11",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_12",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_13",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_14",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_15",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_16",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_17",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_18",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_19",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_20",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_21",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_22",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_23",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_24",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_25",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_26",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_27",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_28",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_29",
+      "COMPOST_BIGBIN_ROTTENTOMATOES_30",
+      "COMPOST_BIGBIN_ULTRACOMPOST_01",
+      "COMPOST_BIGBIN_ULTRACOMPOST_02",
+      "COMPOST_BIGBIN_ULTRACOMPOST_03",
+      "COMPOST_BIGBIN_ULTRACOMPOST_04",
+      "COMPOST_BIGBIN_ULTRACOMPOST_05",
+      "COMPOST_BIGBIN_ULTRACOMPOST_06",
+      "COMPOST_BIGBIN_ULTRACOMPOST_07",
+      "COMPOST_BIGBIN_ULTRACOMPOST_08",
+      "COMPOST_BIGBIN_ULTRACOMPOST_09",
+      "COMPOST_BIGBIN_ULTRACOMPOST_10",
+      "COMPOST_BIGBIN_ULTRACOMPOST_11",
+      "COMPOST_BIGBIN_ULTRACOMPOST_12",
+      "COMPOST_BIGBIN_ULTRACOMPOST_13",
+      "COMPOST_BIGBIN_ULTRACOMPOST_14",
+      "COMPOST_BIGBIN_ULTRACOMPOST_15",
+      "COMPOST_BIGBIN_ULTRACOMPOST_16",
+      "COMPOST_BIGBIN_ULTRACOMPOST_17",
+      "COMPOST_BIGBIN_ULTRACOMPOST_18",
+      "COMPOST_BIGBIN_ULTRACOMPOST_19",
+      "COMPOST_BIGBIN_ULTRACOMPOST_20",
+      "COMPOST_BIGBIN_ULTRACOMPOST_21",
+      "COMPOST_BIGBIN_ULTRACOMPOST_22",
+      "COMPOST_BIGBIN_ULTRACOMPOST_23",
+      "COMPOST_BIGBIN_ULTRACOMPOST_24",
+      "COMPOST_BIGBIN_ULTRACOMPOST_25",
+      "COMPOST_BIGBIN_ULTRACOMPOST_26",
+      "COMPOST_BIGBIN_ULTRACOMPOST_27",
+      "COMPOST_BIGBIN_ULTRACOMPOST_28",
+      "COMPOST_BIGBIN_ULTRACOMPOST_29",
+      "COMPOST_BIGBIN_ULTRACOMPOST_30",
+      "HOS_COMPOST_BIN"
     ]
   },
   {
@@ -26025,8 +26025,8 @@
       }
     ],
     "objectIds": [
-      24046,
-      24047
+      "FAI_FALADOR_GARDEN_PAVING_STRAIGHT",
+      "FAI_FALADOR_GARDEN_PAVING_CURVED"
     ]
   },
   {
@@ -26034,7 +26034,7 @@
     "baseMaterial": "DIRT_1",
     "uvType": "MODEL_XZ",
     "objectIds": [
-      24048
+      "FAI_FALADOR_GARDEN_DIRTPATCH"
     ]
   },
   {
@@ -26044,9 +26044,9 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "objectIds": [
-      28484,
-      28485,
-      28486
+      "LOVA_WALL_HIGHER",
+      "LOVA_WALL_HIGHER_02",
+      "LOVA_WALL_CORNER_HIGHER"
     ]
   },
   {
@@ -26056,10 +26056,10 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "objectIds": [
-      28479,
-      28480,
-      28481,
-      28482
+      "LOVA_WALL_DOOR_LOWER",
+      "LOVA_WALL_DOOR_LOWER_M",
+      "LOVA_WALL_DOOR_OPEN_LOWER",
+      "LOVA_WALL_DOOR_OPEN_LOWER_M"
     ]
   },
   {
@@ -26077,11 +26077,11 @@
       }
     ],
     "objectIds": [
-      28474,
-      28475,
-      28476,
-      28477,
-      28478
+      "LOVA_WALL_LOWER",
+      "LOVA_WALL_LOWER_02",
+      "LOVA_WALL_CORNER_LOWER",
+      "LOVA_WALL_FOR_DOOR_LOWER",
+      "LOVA_WALL_FOR_DOOR_LOWER_M"
     ]
   },
   {
@@ -26103,7 +26103,7 @@
       }
     ],
     "objectIds": [
-      28483
+      "LOVA_WALL_WINDOW_LOWER"
     ]
   },
   {
@@ -26113,15 +26113,15 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "objectIds": [
-      28487,
-      28488,
-      28489,
-      28490,
-      28491,
-      28492,
-      28493,
-      28494,
-      28495
+      "LOVA_ROOF",
+      "LOVA_ROOF_02",
+      "LOVA_ROOF_PLAIN",
+      "LOVA_ROOF_CROSS_PIPE",
+      "LOVA_ROOF_START_PIPE",
+      "LOVA_ROOF_STRAIGHT_PIPE",
+      "LOVA_ROOF_TURN_PIPE",
+      "LOVA_ROOF_END_PIPE",
+      "LOVA_ROOF_ON_GRID"
     ]
   },
   {
@@ -26129,13 +26129,13 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "objectIds": [
-      1821,
-      1823,
-      1826,
-      1828,
-      1839,
-      1840,
-      8687
+      "WINDOW",
+      "POSHWINDOW",
+      "BIGWINDOW",
+      "POSHBIGWINDOW",
+      "SHUTTERWINDOW2",
+      "SHUTTERWINDOW3",
+      "FARM_PLANT_BOX"
     ],
     "colorOverrides": [
       {
@@ -26165,16 +26165,16 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "objectIds": [
-      1822,
-      1824,
-      1827,
-      1830,
-      1832,
-      1835,
-      1838,
-      1843,
-      1844,
-      1845
+      "CURTAINEDWINDOW",
+      "CURTAINEDPOSHWINDOW",
+      "CURTAINEDBIGWINDOW",
+      "REDCURTAINEDPOSHBIGWINDOW",
+      "GREENCURTAINEDPOSHBIGWINDOW",
+      "BLACKCURTAINEDPOSHBIGWINDOW",
+      "SHUTTERWINDOW",
+      "BROKENWINDOW",
+      "BROKENSHUTTERWINDOW1",
+      "BROKENSHUTTERWINDOW2"
     ],
     "colorOverrides": [
       {
@@ -26213,8 +26213,8 @@
     "description": "Cupboard with glass panels and silver dishes",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      346,
-      347
+      "CABINET",
+      "CABINET2"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26236,11 +26236,11 @@
     "description": "Weapons case mounted on wall",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      834,
-      836,
-      837,
-      3039,
-      3481
+      "CABINET_SWORDS",
+      "CABINET_BOWS",
+      "CABINET_AXES",
+      "FAI_VARROCK_BOWCASE_CROSSBOW",
+      "FAI_VARROCK_ARROW_DISPLAY"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26268,8 +26268,8 @@
     "description": "Weapons case With bows and arrows",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      3040,
-      3044
+      "FAI_VARROCK_BOWCASE_LONGBOW",
+      "FAI_VARROCK_WEAPONCASE_BOWS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26297,14 +26297,14 @@
     "description": "Thin cupboard with golden handles and hinges",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      2056,
-      2057,
-      2062,
-      2063,
-      2434,
-      2435,
-      2612,
-      2613
+      "JERICOSCUPBOARDSHUT",
+      "JERICOSCUPBOARDOPEN",
+      "BIONURSESCUPBOARDSHUT",
+      "BIONURSESCUPBOARDOPEN",
+      "GRANDTREE_CUPBOARDCLOSED",
+      "GRANDTREE_CUPBOARDOPEN",
+      "GARLICCUPBOARDSHUT",
+      "GARLICCUPBOARDOPEN"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26322,7 +26322,7 @@
     "description": "Farming Shelves with baskets boots and a rake head",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7507
+      "FARMING_SHELVES_PROPS_1"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26350,7 +26350,7 @@
     "description": "Farming Shelves with Watering can and books",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7508
+      "FARMING_SHELVES_PROPS_2"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26377,7 +26377,7 @@
     "description": "Light wooden shelves with boxs on them",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      8693
+      "FARM_SHELF_WITHBOOKS"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26404,9 +26404,9 @@
     "description": "Wine rack with bottles",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      2453,
-      2712,
-      2713
+      "FAI_VARROCK_WINE_RACK",
+      "FAI_VARROCK_CHEMISTY_SHELVES1",
+      "FAI_VARROCK_CHEMISTY_SHELVES2"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26425,11 +26425,11 @@
     "description": "Wooden bookcase with brown and taupe colored books",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      7176,
-      9523,
-      12539,
-      12540,
-      15461
+      "FAI_VARROCK_BOOKCASE",
+      "SARIM_BOOKCASE2",
+      "FAI_WIZTOWER_BOOKCASE",
+      "FAI_WIZTOWER_BOOKCASE_WALL",
+      "BOOKCASE_MAHOGANY"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -26471,11 +26471,11 @@
     "description": "General Store Shelves with metal and glass",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      3022,
-      3023,
-      3034,
-      3035,
-      30146
+      "FAI_VARROCK_GENERAL_SHELF",
+      "FAI_VARROCK_GENERAL_SHELF2",
+      "FAI_VARROCK_GENERAL_STORE_SHELF3",
+      "FAI_VARROCK_GENERAL_STORE_SHELF4",
+      "MISTMYST_SHELVES_TINDERBOX"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26514,7 +26514,7 @@
     "description": "Shelf with helmets",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      850
+      "HELMETRACK"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26533,7 +26533,7 @@
     "description": "Shelf with helmets",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      24001
+      "FAI_FALADOR_MACE_SHELVES"
     ],
     "uvType": "BOX",
     "uvScale": 0.8,
@@ -26568,7 +26568,7 @@
       }
     ],
     "objectIds": [
-      296
+      "PLOUGH"
     ]
   },
   {
@@ -26585,9 +26585,9 @@
       }
     ],
     "objectIds": [
-      11443,
-      11444,
-      34773
+      "GREATRUNESTONE_MID",
+      "GREATRUNESTONE_UPPERMID",
+      "BLANKRUNESTONE"
     ]
   },
   {
@@ -26595,9 +26595,9 @@
     "baseMaterial": "ROCK_3",
     "uvType": "BOX",
     "objectIds": [
-      11432,
-      11433,
-      11434
+      "ROCKSLIDE_LIGHTGREY1",
+      "ROCKSLIDE_LIGHTGREY2",
+      "ROCKSLIDE_LIGHTGREY3"
     ]
   },
   {
@@ -26606,8 +26606,8 @@
     "uvType": "BOX",
     "uvScale": 0.80,
     "objectIds": [
-      741,
-      742
+      "LADDER_OLD_BASE",
+      "LADDER_OLD_TOP"
     ]
   },
   {
@@ -26617,7 +26617,7 @@
     "uvType": "BOX",
     "uvScale": 0.80,
     "objectIds": [
-      743
+      "LADDER_ON_GROUND"
     ]
   },
   {
@@ -26628,7 +26628,7 @@
     "uvOrientationZ": 512,
     "uvOrientationX": 512,
     "objectIds": [
-      744
+      "SCAFFOLD"
     ]
   },
   {
@@ -26644,7 +26644,7 @@
       }
     ],
     "objectIds": [
-      11927
+      "MINING_BUCKET"
     ]
   },
   {
@@ -26661,7 +26661,7 @@
       }
     ],
     "objectIds": [
-      11924
+      "MINING_STONE"
     ]
   },
   {
@@ -26678,7 +26678,7 @@
       }
     ],
     "objectIds": [
-      11928
+      "MINING_SPADE"
     ]
   },
   {
@@ -26695,7 +26695,7 @@
       }
     ],
     "objectIds": [
-      1291
+      "DEADTREE2_SNOWY"
     ]
   },
   {
@@ -26710,7 +26710,7 @@
       }
     ],
     "objectIds": [
-      11474
+      "DRAYNOR_CANDLE_WALL"
     ]
   },
   {
@@ -26736,11 +26736,11 @@
       }
     ],
     "objectIds": [
-      2311,
-      2312,
-      24322,
-      24323,
-      39138
+      "FAI_VARROCK_BLUE_INN_BARSTOOL",
+      "FAI_VARROCK_BLUE_INN_BARSTOOL_TALL",
+      "CANAFIS_INN_BARSTOOL",
+      "CANAFIS_INN_BARSTOOL_TALL",
+      "GZ_BOARDGAMES_BARSTOOL_BLUE"
     ]
   },
   {
@@ -26773,9 +26773,9 @@
       }
     ],
     "objectIds": [
-      1100,
-      1101,
-      39137
+      "BARSTOOL",
+      "BARSTOOL_WHITE",
+      "GZ_BOARDGAMES_BARSTOOL"
     ]
   },
   {
@@ -26795,23 +26795,23 @@
       }
     ],
     "objectIds": [
-      2314,
-      2315,
-      2316,
-      2317,
-      2318,
-      2319,
-      2320,
-      2321,
-      2322,
-      2323,
-      2324,
-      2325,
-      2326,
-      2328,
-      2329,
-      2330,
-      2331
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_MIDDLE",
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_MIDDLE2",
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_LEFT",
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_RIGHT",
+      "FAI_VARROCK_BLUE_INN_BAR_MIDDLE",
+      "FAI_VARROCK_BLUE_INN_BAR_MIDDLE2",
+      "FAI_VARROCK_BLUE_INN_BAR_MIDDLE3",
+      "FAI_VARROCK_BLUE_INN_BAR_LEFT",
+      "FAI_VARROCK_BLUE_INN_BAR_RIGHT",
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_MIDDLE_BRIGHT",
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_MIDDLE2_BRIGHT",
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_LEFT_BRIGHT",
+      "FAI_VARROCK_BLUE_INN_DRINKS_BAR_RIGHT_BRIGHT",
+      "FAI_VARROCK_BLUE_INN_BAR_MIDDLE2_BRIGHT",
+      "FAI_VARROCK_BLUE_INN_BAR_MIDDLE3_BRIGHT",
+      "FAI_VARROCK_BLUE_INN_BAR_LEFT_BRIGHT",
+      "FAI_VARROCK_BLUE_INN_BAR_RIGHT_BRIGHT"
     ]
   },
   {
@@ -26843,7 +26843,7 @@
       }
     ],
     "objectIds": [
-      11877
+      "FAI_DWARF_POOR_BED"
     ]
   },
   {
@@ -26851,9 +26851,9 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvOrientation": 512,
     "objectIds": [
-      11858,
-      11859,
-      11860
+      "FAI_TARPAULAN_ROOF_PEAK",
+      "FAI_TARPAULAN_SLOPE1",
+      "FAI_TARPAULAN_SLOPE2"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -26870,7 +26870,7 @@
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "uvOrientation": 512,
     "objectIds": [
-      11863
+      "FAI_DWARF_WINCH"
     ],
     "uvType": "BOX",
     "uvScale": 0.3,
@@ -26887,7 +26887,7 @@
     "description": "Post at Dwarven Mine",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      11854
+      "FAI_TARPAULAN_SUPPORT"
     ],
     "uvType": "BOX",
     "uvScale": 0.35
@@ -26896,8 +26896,8 @@
     "description": "Post at Dwarven Mine",
     "baseMaterial": "ROPE",
     "objectIds": [
-      11856,
-      11857
+      "FAI_TARPAULAN_PEGS",
+      "FAI_TARPAULAN_PEGS_MIRROR"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -26916,7 +26916,7 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvOrientationX": 512,
     "objectIds": [
-      11864
+      "FAI_DWARF_TRAPDOOR"
     ],
     "uvType": "BOX",
     "uvScale": 0.6
@@ -26926,7 +26926,7 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvOrientationX": 512,
     "objectIds": [
-      11867
+      "FAI_DWARF_TRAPDOOR_DOWN"
     ],
     "colorOverrides": [
       {
@@ -26943,9 +26943,9 @@
     "description": "Light wooden ladder in an stone ground hole",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4965,
-      4967,
-      4969
+      "HAUNTEDMINE_LADDERTOP",
+      "HAUNTEDMINE_LADDERTOP_1E",
+      "HAUNTEDMINE_LADDERTOP_1SW"
     ],
     "colorOverrides": [
       {
@@ -26963,32 +26963,32 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvOrientationX": 512,
     "objectIds": [
-      638,
-      639,
-      640,
-      641,
-      642,
-      643,
-      644,
-      645,
-      646,
-      15818,
-      15819,
-      15820,
-      15821,
-      15822,
-      15823,
-      15824,
-      15826,
-      15827,
-      15828,
-      15829,
-      20403,
-      20404,
-      20405,
-      20406,
-      20434,
-      20438
+      "TRACKSTRAIGHT_GDECOR",
+      "TRACK_CURVE_A",
+      "TRACK_CURVE_B",
+      "TRACK_CURVE_C",
+      "TRACK_CURVE_D",
+      "TRACK_POINTS_A",
+      "TRACK_POINTS_B",
+      "TRACK_POINTS_C",
+      "TRACK_POINTS_D",
+      "LOTR_TRACKSTRAIGHT",
+      "LOTR_TRACKSTRAIGHT_BROKEN",
+      "LOTR_TRACKSTRAIGHT_BROKEN2",
+      "LOTR_TRACKCURVE_A",
+      "LOTR_TRACKCURVE_B",
+      "LOTR_TRACKCURVE_C",
+      "LOTR_TRACKCURVE_D",
+      "LOTR_TRACK_POINTS_A",
+      "LOTR_TRACK_POINTS_B",
+      "LOTR_TRACK_POINTS_C",
+      "LOTR_TRACK_POINTS_D",
+      "LOTR_TRACK_POINTS_A_MIRRORED",
+      "LOTR_TRACK_POINTS_B_MIRRORED",
+      "LOTR_TRACK_POINTS_C_MIRRORED",
+      "LOTR_TRACK_POINTS_D_MIRRORED",
+      "LOTR_TRACK_UP",
+      "LOTR_TRACKCROSS"
     ],
     "colorOverrides": [
       {
@@ -27022,8 +27022,8 @@
       }
     ],
     "objectIds": [
-      4914,
-      4915
+      "HAUNTEDMINE_BACK_ENTRANCE1",
+      "HAUNTEDMINE_BACK_ENTRANCE2"
     ]
   },
   {
@@ -27033,8 +27033,8 @@
     "uvScale": 0.6,
     "uvOrientationX": 512,
     "objectIds": [
-      20396,
-      20397
+      "LOTR_HAUNTED_MINE_ENTRANCE_LEFT",
+      "LOTR_HAUNTED_MINE_ENTRANCE_RIGHT"
     ]
   },
   {
@@ -27042,8 +27042,8 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvOrientationX": 512,
     "objectIds": [
-      636,
-      15825
+      "TRACKBUFFER",
+      "LOTR_TRACKBUFFER"
     ],
     "colorOverrides": [
       {
@@ -27060,8 +27060,8 @@
     "description": "Spiral Staircase - Concrete textured",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16671,
-      16672
+      "SPIRALSTAIRS",
+      "SPIRALSTAIRSMIDDLE"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -27071,7 +27071,7 @@
     "description": "Spiral Staircase top with rails - Concrete textured",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      16673
+      "SPIRALSTAIRSTOP"
     ],
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -27093,7 +27093,7 @@
       }
     ],
     "objectIds": [
-      11876
+      "FAI_DWARF_BLACKSMITHTOOLS"
     ]
   },
   {
@@ -27112,7 +27112,7 @@
       }
     ],
     "objectIds": [
-      2096
+      "DORICS_WALL_DECO"
     ]
   },
   {
@@ -27132,17 +27132,17 @@
       }
     ],
     "objectIds": [
-      2783
+      "FAI_VARROCK_SWORD_TABLE"
     ]
   },
   {
     "description": "Farming Guild - Small Tree",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      34486,
-      34487,
-      34488,
-      34489
+      "KEBOS_FARMING_GUILD_TREE_FANCY",
+      "KEBOS_FARMING_GUILD_TREE_FANCY2",
+      "KEBOS_FARMING_GUILD_TREE_FANCY3",
+      "KEBOS_FARMING_GUILD_TREE_NORMAL_01"
     ],
     "uvType": "BOX",
     "uvScale": 0.2,
@@ -27159,7 +27159,7 @@
     "description": "Farming Guild - Small Bush",
     "baseMaterial": "PLANT_GRUNGE_2",
     "objectIds": [
-      33638
+      "PLANTS_UPDATE_SMALL_BUSH_GRASSLAND"
     ],
     "uvType": "BOX",
     "uvScale": 0.2
@@ -27168,7 +27168,7 @@
     "description": "Farming Guild - Water Barrel",
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "objectIds": [
-      8702
+      "FARM_WATER_BARREL1"
     ],
     "uvType": "BOX",
     "uvScale": 0.55,
@@ -27189,7 +27189,7 @@
     "description": "Farming Guild - Gazebo with cat",
     "baseMaterial": "WOOD_GRAIN",
     "objectIds": [
-      34480
+      "KEBOS_FARMING_GUILD_GAZEBO"
     ],
     "colorOverrides": [
       {
@@ -27205,7 +27205,7 @@
     "uvScale": 0.5,
     "uvOrientationY": 512,
     "objectIds": [
-      34479
+      "KEBOS_FARMING_GUILD_T3_FENCE"
     ]
   },
   {
@@ -27215,10 +27215,10 @@
     "uvScale": 0.7,
     "uvOrientationY": 512,
     "objectIds": [
-      29685,
-      29686,
-      29687,
-      29688
+      "REDWOODTREE_PLATFORM_STRAIGHT1",
+      "REDWOODTREE_PLATFORM_STRAIGHT2",
+      "REDWOODTREE_PLATFORM_STRAIGHT3",
+      "REDWOODTREE_PLATFORM_STRAIGHT4"
     ],
     "colorOverrides": [
       {
@@ -27234,15 +27234,15 @@
     "uvScale": 0.7,
     "uvOrientation": -256,
     "objectIds": [
-      29689
+      "REDWOODTREE_PLATFORM_CORNER2"
     ]
   },
   {
     "description": "Farming Guild - Redwood Tree Walkway - Walls and Supports",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      29690,
-      29691
+      "REDWOODTREE_FENCE",
+      "REDWOODTREE_FENCE_MIRROR"
     ],
     "colorOverrides": [
       {
@@ -27257,8 +27257,8 @@
     "description": "Farming Guild - Redwood Tree Walkway - Rope Ladder",
     "baseMaterial": "ROPE",
     "objectIds": [
-      34477,
-      34478
+      "KEBOS_FARMING_GUILD_REDWOOD_LADDER_BOTTOM",
+      "KEBOS_FARMING_GUILD_REDWOOD_LADDER_TOP"
     ],
     "uvType": "MODEL_XY",
     "uvScale": 0.3,
@@ -27275,7 +27275,7 @@
     "uvType": "BOX",
     "uvScale": 0.33,
     "objectIds": [
-      309
+      "LOGPILE"
     ],
     "colorOverrides": [
       {
@@ -27290,10 +27290,10 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "objectIds": [
-      7509,
-      34505,
-      34506,
-      34507
+      "FARMING_SHELVES_PROPS_3",
+      "FGUILD_BOOK_BUSHES_LOC",
+      "FGUILD_BOOK_HOPS_LOC",
+      "FGUILD_BOOK_ALLOTMENTS_LOC"
     ],
     "colorOverrides": [
       {
@@ -27312,7 +27312,7 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      26206
+      "KEBOS_FARMING_GUILD_SEED_VAULT"
     ],
     "colorOverrides": [
       {
@@ -27326,7 +27326,7 @@
     "baseMaterial": "ROCK_3",
     "uvType": "BOX",
     "objectIds": [
-      34499
+      "KEBOS_FARMING_GUILD_HESPORI_ENTRANCE"
     ],
     "colorOverrides": [
       {
@@ -27341,7 +27341,7 @@
     "uvType": "BOX",
     "uvScale": 0.74,
     "objectIds": [
-      34498
+      "KEBOS_FARMING_GUILD_GRAND_STATUE"
     ],
     "colorOverrides": [
       {
@@ -27356,26 +27356,26 @@
     "uvType": "BOX",
     "flatNormals": true,
     "objectIds": [
-      34445,
-      34448,
-      34449,
-      34450,
-      34451,
-      34461,
-      34462,
-      34463,
-      34464,
-      34465,
-      34466,
-      34467,
-      34468,
-      34454,
-      34455,
-      34456,
-      34457,
-      34458,
-      34459,
-      34460
+      "KEBOS_FARMING_GUILD_WATERTAP",
+      "KEBOS_FARMING_GUILD_WALL_STRAIGHT",
+      "KEBOS_FARMING_GUILD_WALL_CORNER_OUTSIDE",
+      "KEBOS_FARMING_GUILD_WALL_DIAG_OUTSIDE",
+      "KEBOS_FARMING_GUILD_WALL_DIAG_OUTSIDE_FILLER",
+      "KEBOS_FARMING_GUILD_WALL_DOOR_SIDE_RIGHT",
+      "KEBOS_FARMING_GUILD_WALL_DOOR_SIDE_LEFT",
+      "KEBOS_FARMING_GUILD_DOOR_LEFT_CLOSED",
+      "KEBOS_FARMING_GUILD_DOOR_RIGHT_CLOSED",
+      "KEBOS_FARMING_GUILD_DOOR_LEFT_OPEN",
+      "KEBOS_FARMING_GUILD_DOOR_RIGHT_OPEN",
+      "KEBOS_FARMING_GUILD_WALL_STRAIGHT_GATE_SIDE_LEFT",
+      "KEBOS_FARMING_GUILD_WALL_STRAIGHT_GATE_SIDE_RIGHT",
+      "KEBOS_FARMING_GUILD_ROOF_LVL1",
+      "KEBOS_FARMING_GUILD_ROOF_LVL1_UPPER",
+      "KEBOS_FARMING_GUILD_ROOF_LVL1_UPPER_FILLER",
+      "KEBOS_FARMING_GUILD_ROOF_LVL1_CORNER_INSIDE",
+      "KEBOS_FARMING_GUILD_ROOF_LVL1_DIAG",
+      "KEBOS_FARMING_GUILD_ROOF_LVL1_SQ_CORNER",
+      "KEBOS_FARMING_GUILD_ROOF_LVL1_SQ_CORNER_UPPER"
     ],
     "colorOverrides": [
       {
@@ -27394,8 +27394,8 @@
     "baseMaterial": "METALLIC_1_LIGHT",
     "uvType": "BOX",
     "objectIds": [
-      34475,
-      34476
+      "KEBOS_FARMING_GUILD_GATE_T3_LEFT_OPEN",
+      "KEBOS_FARMING_GUILD_GATE_T3_RIGHT_OPEN"
     ]
   },
   {
@@ -27405,13 +27405,13 @@
     "uvOrientation": 256,
     "uvScale": 0.75,
     "objectIds": [
-      34435,
-      34438,
-      34439,
-      34440,
-      34441,
-      34442,
-      34443
+      "HESPORI_CAVE_EXIT",
+      "HESPORI_CAVE_WALL_VINES",
+      "HESPORI_CAVE_WALL_VINES_A",
+      "HESPORI_CAVE_WALL_TOP",
+      "HESPORI_CAVE_WALL_TOP_STRAIGHT",
+      "HESPORI_CAVE_WALL_TOP_INSIDE_CORNER",
+      "HESPORI_CAVE_WALL_TOP_OUTSIDE_CORNER"
     ],
     "colorOverrides": [
       {
@@ -27425,28 +27425,28 @@
     "baseMaterial": "GRUNGE_3",
     "uvType": "GEOMETRY",
     "objectIds": [
-      33726,
-      33727,
-      33728,
-      33729,
-      33730
+      "HESPORI_PATCH_SEED",
+      "HESPORI_PLANT_1",
+      "HESPORI_PLANT_2",
+      "HESPORI_PLANT_FULLYGROWN",
+      "HESPORI_PLANT_DEAD"
     ],
-    "npcIds": [ 8583 ]
+    "npcIds": [ "HESPORI" ]
   },
   {
     "description": "Farming Guild - Hespori Flower",
     "baseMaterial": "GRUNGE_3",
     "uvType": "GEOMETRY",
     "npcIds": [
-      8584,
-      8585
+      "HESPORI_HEALER_ACTIVE",
+      "HESPORI_HEALER_INACTIVE"
     ],
-    "objectIds": [ 34705, 34706 ]
+    "objectIds": [ "KEBOS_FARMING_GUILD_HESPORI_GROWN", "KEBOS_FARMING_GUILD_HESPORI_NOTGROWN" ]
   },
   {
     "description": "Farming Guild - Hide Ripples",
     "hide": true,
-    "objectIds": [ 5607 ]
+    "objectIds": [ "RIPPLE" ]
   },
   {
     "description": "Cushioned church pew with foot rest",
@@ -27471,10 +27471,10 @@
       }
     ],
     "objectIds": [
-      5788,
-      14862,
-      14863,
-      14864
+      "PEW_LUMBRIDGE",
+      "FAI_VARROCK_PEW_LEFT",
+      "FAI_VARROCK_PEW_RIGHT",
+      "FAI_VARROCK_PEW_MIDDLE"
     ]
   },
   {
@@ -27500,7 +27500,7 @@
       }
     ],
     "objectIds": [
-      12136
+      "ROMEO_JULIET_LECTURN_VARROCK"
     ]
   },
   {
@@ -27525,7 +27525,7 @@
       }
     ],
     "objectIds": [
-      2714
+      "FAI_VARROCK_CHEMISTY_DESK"
     ]
   },
   {
@@ -27551,7 +27551,7 @@
       }
     ],
     "objectIds": [
-      2722
+      "FAI_VARROCK_APOTHECARY_CABINET_TWO"
     ]
   },
   {
@@ -27569,7 +27569,7 @@
       }
     ],
     "objectIds": [
-      2716
+      "FAI_VARROCK_CHEMISTY_TABLE"
     ]
   },
   {
@@ -27579,16 +27579,16 @@
     "uvScale": 0.5,
     "uvOrientation": 42,
     "objectIds": [
-      34965
+      "STONEPILLAR_SMALL_WATERFALL_QUEST_NOOP"
     ]
   },
   {
     "description": "Baxtorian Falls - Statues",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      2006,
-      34967,
-      34968
+      "STATUE_QUEEN_WATERFALL_QUEST",
+      "STATUE_KING_WATERFALL_QUEST_STATUE",
+      "STATUE_KING_WATERFALL_QUEST_PLINTH"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -27597,15 +27597,15 @@
     "description": "Baxtorian Falls - Chalice",
     "baseMaterial": "METALLIC_1_LIGHT",
     "objectIds": [
-      2015
+      "BAXTORIAN_CHALICE_WATERFALL_QUEST_ASH"
     ]
   },
   {
     "description": "Underground Pass - Well of Voyage",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      4004,
-      4005
+      "REGICIDE_VOYAGE_TEMPLE_WELL1",
+      "REGICIDE_VOYAGE_TEMPLE_WELL2"
     ],
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -27629,7 +27629,7 @@
     "description": "Underground Pass - Exit to Tirannwn",
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
-      4007
+      "REGICIDE_VOYAGE_TEMPLE_EXIT"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -27646,16 +27646,16 @@
   {
     "description": "Grand Library - Bookcase Wall",
     "objectIds": [
-      2485, 4140, 4976, 34993, 34994, 34995, 34996, 35001, 35002,
-      35003, 35004, 35005, 35006, 35007, 35008, 35009, 35010, 35011,
-      35012, 35013, 35014, 35015, 35016, 35017, 35018, 35019, 35020,
-      35021, 35022, 35023, 35024, 35024, 35025, 35026, 35027, 35028,
-      35029, 35030, 35031, 35032, 35039, 35040, 35041, 35042, 35043,
-      35044, 35045, 35046, 35047, 35048, 35049, 35050, 35051, 35052,
-      35053, 35055, 35338, 35339, 35341, 35343, 35344, 35346, 35348,
-      35349, 35354, 35355, 35358, 35359, 35361, 35363, 35364, 35365,
-      35368, 35372, 35373, 35449, 35450, 37369, 37370, 37371, 37372,
-      37373, 37374, 37375, 37376, 37377, 37378, 37379
+      "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_2X1_01", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_3X1_01", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_4X1_01", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_03", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_04", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_AMLODD_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_AMLODD_UPPER_LVL2",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_CADARN_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_CADARN_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_CRWYS_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_CRWYS_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_HEFIN_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_HEFIN_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_IORWERTH_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_IORWERTH_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_ITHELL_LOWER_LVL2",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_ITHELL_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_MEILYR_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_MEILYR_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_TRAHAEARN_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_01_TRAHAEARN_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_AMLODD_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_AMLODD_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_CADARN_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_CADARN_UPPER_LVL2",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_CRWYS_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_CRWYS_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_HEFIN_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_HEFIN_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_HEFIN_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_IORWERTH_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_IORWERTH_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_ITHELL_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_ITHELL_UPPER_LVL2",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_MEILYR_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_MEILYR_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_TRAHAEARN_LOWER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_02_TRAHAEARN_UPPER_LVL2", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_01", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_01_AMLODD_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_01_AMLODD_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_02", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_02_AMLODD_LOWER",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_02_AMLODD_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_03", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_03_AMLODD_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_03_AMLODD_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_04", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_04_AMLODD_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_04_AMLODD_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_05", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_05_AMLODD_LOWER",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_05_AMLODD_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL3_06_AMLODD_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_01", "SOTE_WARPED_LIBRARY_BOOKCASE_01_AMLODD_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_01_CADARN_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_01_CRWYS_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_01_CRWYS_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_01_HEFIN_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_01_IORWERTH_UPPER",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_01_ITHELL_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_01_TRAHAEARN_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_02", "SOTE_WARPED_LIBRARY_BOOKCASE_02_CADARN_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_02_CADARN_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_02_CRWYS_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_02_HEFIN_UPPER", "SOTE_WARPED_LIBRARY_BOOKCASE_02_IORWERTH_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_02_IORWERTH_UPPER",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_02_MEILYR_LOWER", "SOTE_WARPED_LIBRARY_BOOKCASE_03", "SOTE_WARPED_LIBRARY_BOOKCASE_04", "SOTE_WARPED_LIBRARY_BOOKCASE_WARPED_01", "SOTE_WARPED_LIBRARY_BOOKCASE_WARPED_02", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_4X1_02", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_4X1_03", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_4X1_04", "SOTE_WARPED_LIBRARY_BOOKCASE_LVL2_4X1_05",
+      "SOTE_WARPED_LIBRARY_BOOKCASE_2X1_01", "SOTE_WARPED_LIBRARY_BOOKCASE_3X1_01", "SOTE_WARPED_LIBRARY_BOOKCASE_4X1_01", "SOTE_WARPED_LIBRARY_BOOKCASE_4X1_02", "SOTE_WARPED_LIBRARY_BOOKCASE_4X1_03", "SOTE_WARPED_LIBRARY_BOOKCASE_4X1_04", "SOTE_WARPED_LIBRARY_BOOKCASE_4X1_05"
     ],
     "colorOverrides": [
       {
@@ -27674,7 +27674,7 @@
   },
   {
     "description": "Grand Library - Wall Pillar",
-    "objectIds": [ 34997, 34999, 35000, 35057, 35058, 35060, 35062, 35063, 35380, 35381, 35382, 35383, 35385 ],
+    "objectIds": [ "SOTE_WARPED_LIBRARY_PILLAR_LVL2_01", "SOTE_WARPED_LIBRARY_PILLAR_LVL2_03", "SOTE_WARPED_LIBRARY_PILLAR_LVL2_04", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_01", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_02", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_04", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_06", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_07", "SOTE_WARPED_LIBRARY_FILLER_BLUE", "SOTE_WARPED_LIBRARY_PILLAR_01", "SOTE_WARPED_LIBRARY_PILLAR_01_X2", "SOTE_WARPED_LIBRARY_PILLAR_01_X3", "SOTE_WARPED_LIBRARY_PILLAR_03" ],
     "baseMaterial": "MARBLE_1",
     "uvType": "BOX",
     "uvScale": 0.75
@@ -27682,8 +27682,8 @@
   {
     "description": "Grand Library - Wall Pillar with Crystal",
     "objectIds": [
-      34998, 35059, 35061, 35064, 35384, 35451, 35451, 35452, 35453, 35453, 35454, 35455, 35455, 35456, 35457,
-      35457, 35458, 35459, 35459, 35460, 35461, 35461, 35462, 35463, 35463, 35464, 35465, 35465, 35466, 35467
+      "SOTE_WARPED_LIBRARY_PILLAR_LVL2_02", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_03", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_05", "SOTE_WARPED_LIBRARY_PILLAR_LVL3_08", "SOTE_WARPED_LIBRARY_PILLAR_02", "SOTE_CADARN_SEAL_FIXED", "SOTE_CADARN_SEAL_FIXED", "SOTE_CADARN_SEAL_BROKEN", "SOTE_CRWYS_SEAL_FIXED", "SOTE_CRWYS_SEAL_FIXED", "SOTE_CRWYS_SEAL_BROKEN", "SOTE_AMLODD_SEAL_FIXED", "SOTE_AMLODD_SEAL_FIXED", "SOTE_AMLODD_SEAL_BROKEN", "SOTE_HEFIN_SEAL_FIXED",
+      "SOTE_HEFIN_SEAL_FIXED", "SOTE_HEFIN_SEAL_BROKEN", "SOTE_IORWERTH_SEAL_FIXED", "SOTE_IORWERTH_SEAL_FIXED", "SOTE_IORWERTH_SEAL_BROKEN", "SOTE_ITHELL_SEAL_FIXED", "SOTE_ITHELL_SEAL_FIXED", "SOTE_ITHELL_SEAL_BROKEN", "SOTE_MEILYR_SEAL_FIXED", "SOTE_MEILYR_SEAL_FIXED", "SOTE_MEILYR_SEAL_BROKEN", "SOTE_TRAHAEARN_SEAL_FIXED", "SOTE_TRAHAEARN_SEAL_FIXED", "SOTE_TRAHAEARN_SEAL_BROKEN", "SOTE_FORGOTTEN_SEAL"
     ],
     "colorOverrides": [
       {
@@ -27701,13 +27701,13 @@
   {
     "description": "Grand Library - Inner Wall",
     "baseMaterial": "BLACK",
-    "objectIds": [ 35374, 35375, 35376, 35377, 35378, 35379 ]
+    "objectIds": [ "SOTE_WARPED_LIBRARY_FILLER_BLACK", "SOTE_WARPED_LIBRARY_FILLER_BLACK_2X2", "SOTE_WARPED_LIBRARY_FILLER_BLACK_3X3", "SOTE_WARPED_LIBRARY_FILLER_BLACK_4X4", "SOTE_WARPED_LIBRARY_FILLER_BLACK_5X5", "SOTE_WARPED_LIBRARY_FILLER_BLACK_6X6" ]
   },
   {
     "description": "Grand Library - Floor - Wooden with Marble",
     "baseMaterial": "WOOD_GRAIN",
-    "objectIds": [ 34978, 34979, 34980, 34981, 34982, 34983, 34984,
-      34985, 34986, 34987, 34988, 34989, 34990, 34991, 34992 ],
+    "objectIds": [ "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CENTRE_01", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CENTRE_02", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CENTRE_02_ICON", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CENTRE_03", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CENTRE_04", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CENTRE_05", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CENTRE_06",
+      "SOTE_WARPED_LIBRARY_FLOOR_LVL2_EDGE_01", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_EDGE_02", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_EDGE_03", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_EDGE_04", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_END_01", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_END_02", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_END_03", "SOTE_WARPED_LIBRARY_FLOOR_LVL2_CORNER_01" ],
     "colorOverrides": [
       {
         "colors": [ "h == 32" ],
@@ -27720,24 +27720,24 @@
   {
     "description": "Grand Library - Floor - Hole and Railing",
     "baseMaterial": "WOOD_GRAIN",
-    "objectIds": [ 35067, 35068, 35069, 35070, 35072, 35073, 35074 ]
+    "objectIds": [ "SOTE_WARPED_LIBRARY_BANISTER_CORNER_01", "SOTE_WARPED_LIBRARY_BANISTER_EDGE_01", "SOTE_WARPED_LIBRARY_BANISTER_END_01", "SOTE_WARPED_LIBRARY_BANISTER_END_02", "SOTE_WARPED_LIBRARY_FLOOR_LVL3_EDGE_01", "SOTE_WARPED_LIBRARY_FLOOR_LVL3_CORNER_01", "SOTE_WARPED_LIBRARY_FLOOR_LVL3_CORNER_02" ]
   },
   {
     "description": "Grand Library - Floor - Bust",
     "baseMaterial": "MARBLE_1",
     "uvType": "BOX",
     "uvScale": 0.6,
-    "objectIds": [ 35033, 35034, 35035, 35036, 35037, 35038, 35441, 35442, 35443, 35444, 35445, 35446 ]
+    "objectIds": [ "SOTE_BUSTS_AMLODD_LVL2", "SOTE_BUSTS_BAXTORIAN_LVL2", "SOTE_BUSTS_HEFIN_LVL2", "SOTE_BUSTS_IORWERTH_LVL2", "SOTE_BUSTS_MEILYR_LVL2", "SOTE_BUSTS_TRAHAEARN_LVL2", "SOTE_BUSTS_AMLODD", "SOTE_BUSTS_BAXTORIAN", "SOTE_BUSTS_HEFIN", "SOTE_BUSTS_IORWERTH", "SOTE_BUSTS_MEILYR", "SOTE_BUSTS_TRAHAEARN" ]
   },
   {
     "description": "Grand Library - Floor - Carpet",
     "baseMaterial": "CARPET",
-    "objectIds": [ 35430, 35431, 35432, 35433 ],
+    "objectIds": [ "SOTE_WARPED_LIBRARY_RUG_CENTRE_01", "SOTE_WARPED_LIBRARY_RUG_EDGE_01", "SOTE_WARPED_LIBRARY_RUG_CORNER_01", "SOTE_WARPED_LIBRARY_RUG_CORNER_02" ],
     "uvType": "MODEL_XZ"
   },
   {
     "description": "Grand Library - Large Cabinet",
-    "objectIds": [ 35423, 35424, 35425, 35426, 35427, 35428, 35429, 34970, 34971, 34973, 34974, 34975, 34976, 34977 ],
+    "objectIds": [ "SOTE_WARPED_LIBRARY_DESK_OFF_4X4", "SOTE_WARPED_LIBRARY_DESK_OFF_4X3", "SOTE_WARPED_LIBRARY_DESK_OFF_4X3_OPEN", "SOTE_WARPED_LIBRARY_DESK_OFF_4X3_OPEN_02", "SOTE_WARPED_LIBRARY_DESK_OFF_4X2", "SOTE_WARPED_LIBRARY_DESK_OFF_4X2_OPEN", "SOTE_WARPED_LIBRARY_DESK_OFF_4X2_OPEN_02", "SOTE_WARPED_LIBRARY_DESK_LVL2_02", "SOTE_WARPED_LIBRARY_DESK_LVL2_02_BOTH_OUT", "SOTE_WARPED_LIBRARY_DESK_LVL2_02_LEFT_OUT", "SOTE_WARPED_LIBRARY_DESK_END_LVL2_03", "SOTE_WARPED_LIBRARY_DESK_END_LVL2_03_OUT", "SOTE_WARPED_LIBRARY_DESK_END_LVL2_04", "SOTE_WARPED_LIBRARY_DESK_END_LVL2_04_OUT" ],
     "colorOverrides": [
       {
         "colors": [ "h == 3" ],
@@ -27752,7 +27752,7 @@
   },
   {
     "description": "Grand Library - Floating Bookcase",
-    "objectIds": [ 37380, 35447 ],
+    "objectIds": [ "SOTE_WARPED_LIBRARY_BOOK_TOWER_LVL2", "SOTE_WARPED_LIBRARY_TORNADO_2X2" ],
     "colorOverrides": [
       {
         "colors": [ "h == 3" ],
@@ -27762,7 +27762,7 @@
   },
   {
     "description": "Grand Library - Furniture",
-    "objectIds": [ 35406, 35407, 35408, 35437, 35439, 35440 ],
+    "objectIds": [ "SOTE_WARPED_LIBRARY_CHAIR_01", "SOTE_WARPED_LIBRARY_CHAIR_02", "SOTE_WARPED_LIBRARY_CHAIR_03", "SOTE_WARPED_LIBRARY_LADDER_01", "SOTE_WARPED_LIBRARY_CART_02", "SOTE_WARPED_LIBRARY_CART_03" ],
     "colorOverrides": [
       {
         "colors": [ "h == 3" ],
@@ -27773,20 +27773,20 @@
   {
     "description": "Grand Library - Light Pillar",
     "objectIds": [
-      35076, 35082, 35083, 35084, 35085, 35086, 35087, 35088, 35089, 35090, 35091, 35092, 35093, 35094, 35095, 35096, 35097,
-      35098, 35099, 35100, 35101, 35102, 35103, 35104, 35105, 35106, 35107, 35108, 35109, 35110, 35111, 35112, 35113, 35114,
-      35115, 35116, 35117, 35118, 35119, 35120, 35121, 35122, 35123, 35124, 35125, 35126, 35127, 35128, 35129, 35130, 35131,
-      35132, 35133, 35134, 35135, 35136, 35137, 35138, 35139, 35140, 35141, 35142, 35143, 35144, 35145, 35146, 35147, 35148,
-      35149, 35150, 35151, 35152, 35153, 35154, 35155, 35156, 35157, 35158, 35159, 35160, 35161, 35162, 35163, 35164, 35165,
-      35166, 35167, 35168, 35169, 35170, 35171, 35172, 35173, 35174, 35175, 35176, 35177, 35178, 35179, 35180, 35181, 35182,
-      35183, 35184, 35185, 35186, 35187, 35188, 35189, 35190, 35191, 35192, 35193, 35194, 35195, 35196, 35197, 35198, 35199,
-      35200, 35201, 35202, 35203, 35204, 35205, 35206, 35208, 35209, 35210, 35211, 35212, 35213, 35214, 35215, 35216, 35217,
-      35218, 35219, 35220, 35221, 35222, 35223, 35224, 35225, 35226, 35227, 35228, 35229, 35230, 35231, 35232, 35233, 35234,
-      35253, 35254, 35255, 35256, 35257, 35258, 35259, 35260, 35261, 35262, 35263, 35264, 35265, 35266, 35267, 35268, 35269,
-      35270, 35271, 35272, 35273, 35274, 35275, 35276, 35277, 35278, 35279, 35280, 35281, 35282, 35283, 35284, 35285, 35286,
-      35287, 35288, 35289, 35290, 35291, 35292, 35293, 35294, 35295, 35296, 35297, 35298, 35299, 35300, 35301, 35302, 35303,
-      35304, 35305, 35306, 35307, 35308, 35309, 35310, 35311, 35312, 35313, 35314, 35315, 35316, 35317, 35318, 35319, 35320,
-      35321, 35322, 35323, 35324, 35325, 35326, 35327, 35328, 35329, 35330, 35331
+      "SOTE_LIBRARY_DISPENSER", "SOTE_PILLAR_2_A_2", "SOTE_PILLAR_2_A_3", "SOTE_PILLAR_2_A_4", "SOTE_PILLAR_2_A_7", "SOTE_PILLAR_2_A_8", "SOTE_PILLAR_2_B_2", "SOTE_PILLAR_2_B_3", "SOTE_PILLAR_2_B_4", "SOTE_PILLAR_2_B_5", "SOTE_PILLAR_2_B_7", "SOTE_PILLAR_2_B_8", "SOTE_PILLAR_2_C_4", "SOTE_PILLAR_2_C_5", "SOTE_PILLAR_2_C_6", "SOTE_PILLAR_2_C_7", "SOTE_PILLAR_2_C_8",
+      "SOTE_PILLAR_2_D_1", "SOTE_PILLAR_2_D_3", "SOTE_PILLAR_2_D_4", "SOTE_PILLAR_2_D_5", "SOTE_PILLAR_2_D_6", "SOTE_PILLAR_2_E_6", "SOTE_PILLAR_2_E_7", "SOTE_PILLAR_2_E_8", "SOTE_PILLAR_2_F_1", "SOTE_PILLAR_2_F_3", "SOTE_PILLAR_2_F_4", "SOTE_PILLAR_2_F_5", "SOTE_PILLAR_2_F_6", "SOTE_PILLAR_2_F_7", "SOTE_PILLAR_2_F_8", "SOTE_PILLAR_2_G_0", "SOTE_PILLAR_2_G_1",
+      "SOTE_PILLAR_2_G_2", "SOTE_PILLAR_2_G_3", "SOTE_PILLAR_2_G_4", "SOTE_PILLAR_2_G_5", "SOTE_PILLAR_2_G_6", "SOTE_PILLAR_2_G_7", "SOTE_PILLAR_2_G_8", "SOTE_PILLAR_2_H_0", "SOTE_PILLAR_2_H_2", "SOTE_PILLAR_2_H_3", "SOTE_PILLAR_2_H_4", "SOTE_PILLAR_2_H_6", "SOTE_PILLAR_2_H_7", "SOTE_PILLAR_2_H_8", "SOTE_PILLAR_2_I_3", "SOTE_PILLAR_2_I_4", "SOTE_PILLAR_2_I_5",
+      "SOTE_PILLAR_2_I_6", "SOTE_PILLAR_2_I_7", "SOTE_PILLAR_2_I_8", "SOTE_PILLAR_0_A_3", "SOTE_PILLAR_0_A_7", "SOTE_PILLAR_0_B_3", "SOTE_PILLAR_0_C_2", "SOTE_PILLAR_0_C_3", "SOTE_PILLAR_0_C_4", "SOTE_PILLAR_0_C_5", "SOTE_PILLAR_0_C_6", "SOTE_PILLAR_0_D_1", "SOTE_PILLAR_0_D_2", "SOTE_PILLAR_0_D_3", "SOTE_PILLAR_0_D_4", "SOTE_PILLAR_0_D_5", "SOTE_PILLAR_0_D_6",
+      "SOTE_PILLAR_0_E_1", "SOTE_PILLAR_0_E_2", "SOTE_PILLAR_0_E_3", "SOTE_PILLAR_0_E_4", "SOTE_PILLAR_0_F_1", "SOTE_PILLAR_0_F_2", "SOTE_PILLAR_0_F_3", "SOTE_PILLAR_0_F_6", "SOTE_PILLAR_0_F_7", "SOTE_PILLAR_0_G_6", "SOTE_PILLAR_0_G_7", "SOTE_PILLAR_0_H_6", "SOTE_PILLAR_0_H_7", "SOTE_PILLAR_QUAD", "SOTE_PILLAR_QUAD_WHITE", "SOTE_PILLAR_QUAD_RED", "SOTE_PILLAR_QUAD_YELLOW",
+      "SOTE_PILLAR_QUAD_GREEN", "SOTE_PILLAR_QUAD_CYAN", "SOTE_PILLAR_QUAD_BLUE", "SOTE_PILLAR_QUAD_MAGENTA", "SOTE_PILLAR_TRI", "SOTE_PILLAR_TRI_WHITE", "SOTE_PILLAR_TRI_RED", "SOTE_PILLAR_TRI_YELLOW", "SOTE_PILLAR_TRI_GREEN", "SOTE_PILLAR_TRI_CYAN", "SOTE_PILLAR_TRI_BLUE", "SOTE_PILLAR_TRI_MAGENTA", "SOTE_PILLAR_SIN", "SOTE_PILLAR_SIN_WHITE", "SOTE_PILLAR_SIN_RED", "SOTE_PILLAR_SIN_YELLOW", "SOTE_PILLAR_SIN_GREEN",
+      "SOTE_PILLAR_SIN_CYAN", "SOTE_PILLAR_SIN_BLUE", "SOTE_PILLAR_SIN_MAGENTA", "SOTE_PILLAR_DBL_OP", "SOTE_PILLAR_DBL_OP_WHITE", "SOTE_PILLAR_DBL_OP_RED", "SOTE_PILLAR_DBL_OP_YELLOW", "SOTE_PILLAR_DBL_OP_GREEN", "SOTE_PILLAR_DBL_OP_CYAN", "SOTE_PILLAR_DBL_OP_BLUE", "SOTE_PILLAR_DBL_OP_MAGENTA", "SOTE_PILLAR_DBL_ADJ", "SOTE_PILLAR_DBL_ADJ_WHITE", "SOTE_PILLAR_DBL_ADJ_RED", "SOTE_PILLAR_DBL_ADJ_YELLOW", "SOTE_PILLAR_DBL_ADJ_GREEN", "SOTE_PILLAR_DBL_ADJ_CYAN",
+      "SOTE_PILLAR_DBL_ADJ_BLUE", "SOTE_PILLAR_DBL_ADJ_MAGENTA", "SOTE_PILLAR_QUAD_NOOP", "SOTE_PILLAR_QUAD_NOOP_SEALED", "SOTE_PILLAR_TRI_NOOP", "SOTE_PILLAR_TRI_NOOP_SEALED", "SOTE_PILLAR_SIN_NOOP", "SOTE_PILLAR_DBL_OP_NOOP", "SOTE_PILLAR_DBL_OP_NOOP_SEALED", "SOTE_PILLAR_DBL_ADJ_NOOP", "SOTE_PILLAR_DBL_ADJ_NOOP_SEALED", "SOTE_PILLAR_BASE", "SOTE_PILLAR_BASE_WHITE", "SOTE_PILLAR_BASE_CYAN", "SOTE_PILLAR_BASE_BLUE", "SOTE_PILLAR_BASE_MAGENTA", "SOTE_PILLAR_BASE_RED",
+      "SOTE_PILLAR_BASE_YELLOW", "SOTE_PILLAR_BASE_GREEN", "SOTE_PILLAR_BASE_PLAIN", "SOTE_PILLAR_ITHELL_A_0", "SOTE_PILLAR_ITHELL_A_1", "SOTE_PILLAR_ITHELL_A_2", "SOTE_PILLAR_ITHELL_A_3", "SOTE_PILLAR_ITHELL_A_4", "SOTE_PILLAR_ITHELL_B_0", "SOTE_PILLAR_ITHELL_B_1", "SOTE_PILLAR_ITHELL_B_2", "SOTE_PILLAR_ITHELL_B_3", "SOTE_PILLAR_ITHELL_B_4", "SOTE_PILLAR_ITHELL_C_0", "SOTE_PILLAR_ITHELL_C_1", "SOTE_PILLAR_ITHELL_C_2", "SOTE_PILLAR_ITHELL_C_3",
+      "SOTE_PILLAR_1_A_2", "SOTE_PILLAR_2_A_2_BASE", "SOTE_PILLAR_1_A_4", "SOTE_PILLAR_2_A_4_BASE", "SOTE_PILLAR_1_A_5", "SOTE_PILLAR_1_A_6", "SOTE_PILLAR_1_A_8", "SOTE_PILLAR_2_A_8_BASE", "SOTE_PILLAR_1_B_1", "SOTE_PILLAR_1_B_2", "SOTE_PILLAR_2_B_2_BASE", "SOTE_PILLAR_1_B_4", "SOTE_PILLAR_2_B_4_BASE", "SOTE_PILLAR_1_B_5", "SOTE_PILLAR_1_B_6", "SOTE_PILLAR_1_B_7", "SOTE_PILLAR_2_B_7_BASE",
+      "SOTE_PILLAR_1_B_8", "SOTE_PILLAR_2_B_8_BASE", "SOTE_PILLAR_1_C_0", "SOTE_PILLAR_1_C_1", "SOTE_PILLAR_1_C_2", "SOTE_PILLAR_1_C_3", "SOTE_PILLAR_1_C_4", "SOTE_PILLAR_1_C_5", "SOTE_PILLAR_1_C_6", "SOTE_PILLAR_1_C_7", "SOTE_PILLAR_2_C_7_BASE", "SOTE_PILLAR_1_C_8", "SOTE_PILLAR_2_C_8_BASE", "SOTE_PILLAR_1_D_1", "SOTE_PILLAR_1_D_2", "SOTE_PILLAR_1_D_3", "SOTE_PILLAR_1_D_4",
+      "SOTE_PILLAR_1_D_5", "SOTE_PILLAR_1_D_6", "SOTE_PILLAR_1_D_7", "SOTE_PILLAR_1_E_1", "SOTE_PILLAR_1_E_2", "SOTE_PILLAR_1_E_3", "SOTE_PILLAR_1_E_5", "SOTE_PILLAR_1_E_6", "SOTE_PILLAR_2_E_6_BASE", "SOTE_PILLAR_1_E_7", "SOTE_PILLAR_2_E_7_BASE", "SOTE_PILLAR_1_E_8", "SOTE_PILLAR_2_E_8_BASE", "SOTE_PILLAR_1_F_1", "SOTE_PILLAR_1_F_2", "SOTE_PILLAR_1_F_3", "SOTE_PILLAR_1_F_4",
+      "SOTE_PILLAR_2_F_4_BASE", "SOTE_PILLAR_1_F_5", "SOTE_PILLAR_1_F_6", "SOTE_PILLAR_1_F_7", "SOTE_PILLAR_2_F_7_BASE", "SOTE_PILLAR_1_F_8", "SOTE_PILLAR_2_F_8_BASE", "SOTE_PILLAR_1_G_2", "SOTE_PILLAR_1_G_3", "SOTE_PILLAR_1_G_4", "SOTE_PILLAR_1_G_7", "SOTE_PILLAR_1_G_8", "SOTE_PILLAR_2_G_8_BASE", "SOTE_PILLAR_1_H_2", "SOTE_PILLAR_1_H_3", "SOTE_PILLAR_2_H_3_BASE", "SOTE_PILLAR_1_H_4",
+      "SOTE_PILLAR_2_H_4_BASE", "SOTE_PILLAR_1_H_5", "SOTE_PILLAR_1_H_6", "SOTE_PILLAR_1_H_7", "SOTE_PILLAR_2_H_7_BASE", "SOTE_PILLAR_1_H_8", "SOTE_PILLAR_2_H_8_BASE", "SOTE_PILLAR_1_I_3", "SOTE_PILLAR_2_I_3_BASE", "SOTE_PILLAR_1_I_4", "SOTE_PILLAR_1_I_5"
     ],
     "colorOverrides": [
       {
@@ -27803,7 +27803,7 @@
     "uvType": "MODEL_XZ",
     "uvOrientation": 256,
     "uvScale": 0.7,
-    "objectIds": [ 35387, 35388, 35389 ],
+    "objectIds": [ "SOTE_WARPED_LIBRARY_TELEPORTER_UP", "SOTE_WARPED_LIBRARY_TELEPORTER_DOWN", "SOTE_WARPED_LIBRARY_TELEPORTER_BOTH" ],
     "colorOverrides": [
       {
         "colors": [ "h == 34" ],
@@ -27818,12 +27818,12 @@
     "baseMaterial": "MARBLE_2_GLOSS",
     "uvType": "BOX",
     "uvScale": 0.7,
-    "objectIds": [ 35894, 35893 ]
+    "objectIds": [ "SOTE_TEMPLE_PILLAR_OF_LIGHT_3", "SOTE_TEMPLE_PILLAR_OF_LIGHT_2" ]
   },
   {
     "description": "Song of the Elves Cutscene - Fragment of Seren, Fix Shadow Flicker",
     "shadowOpacityThreshold": 0.1,
-    "npcIds": [ 8920 ]
+    "npcIds": [ "DARK_SEREN_CUTSCENE_TRAPPED" ]
   },
   {
     "description": "Gauntlet Lobby - Walls - Scoreboard",
@@ -27831,7 +27831,7 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      36060
+      "GAUNTLET_SCOREBOARD"
     ],
     "colorOverrides": [
       {
@@ -27848,7 +27848,7 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      36086
+      "GAUNTLET_DEPOSIT_BOX"
     ],
     "colorOverrides": [
       {
@@ -27864,8 +27864,8 @@
     "baseMaterial": "GRUNGE_3",
     "uvType": "BOX",
     "objectIds": [
-      36087,
-      36088
+      "GAUNTLET_CHEST_CLOSED",
+      "GAUNTLET_CHEST_OPEN"
     ],
     "colorOverrides": [
       {
@@ -27882,11 +27882,11 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      36098,
-      36099,
-      36102,
-      36101,
-      36105
+      "PRIF_GAUNTLET_WALL_TOP_ARCH_01",
+      "PRIF_GAUNTLET_WALL_TOP_ARCH_02",
+      "PRIF_GAUNTLET_DOOR_WALL_UNLIT_02",
+      "PRIF_GAUNTLET_DOOR_WALL_UNLIT_01",
+      "PRIF_GAUNTLET_WALL_EDGE"
     ]
   },
   {
@@ -27895,9 +27895,9 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      36095,
-      36096,
-      36097
+      "PRIF_GAUNTLET_WALL_ARCH_BLUE_LIT",
+      "PRIF_GAUNTLET_WALL_ARCH_BLUE_LIT_INACTIVE",
+      "PRIF_GAUNTLET_WALL_ARCH_BLUE_UNLIT"
     ],
     "colorOverrides": [
       {
@@ -27913,9 +27913,9 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      36100,
-      36103,
-      36104
+      "PRIF_GAUNTLET_WALL_TOP_TREE",
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_01",
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_02"
     ],
     "colorOverrides": [
       {
@@ -27930,12 +27930,12 @@
     "uvType": "BOX",
     "uvScale": 0.4,
     "objectIds": [
-      36106,
-      36109,
-      36108,
-      36107,
-      36110,
-      36111
+      "GAUNTLET_VINE_WALL_01",
+      "GAUNTLET_VINE_WALL_END_01",
+      "GAUNTLET_VINE_WALL_03",
+      "GAUNTLET_VINE_WALL_02",
+      "GAUNTLET_VINE_WALL_END_02",
+      "GAUNTLET_VINE_WALL_CORNER_01"
     ],
     "colorOverrides": [
       {
@@ -27951,8 +27951,8 @@
     "baseMaterial": "MARBLE_1",
     "uvType": "MODEL_XZ",
     "objectIds": [
-      36046,
-      36149
+      "PRIF_GAUNTLET_FLOOR_TILE_01_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_01"
     ]
   },
   {
@@ -27961,22 +27961,22 @@
     "uvType": "MODEL_XZ",
     "uvScale": 0.5,
     "objectIds": [
-      36052,
-      36053,
-      36054,
-      36055,
-      36056,
-      36057,
-      36058,
-      36059,
-      36155,
-      36156,
-      36157,
-      36158,
-      36159,
-      36160,
-      36161,
-      36162
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_01_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_02_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_03_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_04_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_05_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_06_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_07_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_08_HM",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_01",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_02",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_03",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_04",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_05",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_06",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_07",
+      "PRIF_GAUNTLET_FLOOR_TILE_BROKEN_08"
     ]
   },
   {
@@ -27985,8 +27985,8 @@
     "uvType": "BOX",
     "uvScale": 0.25,
     "objectIds": [
-      35981,
-      36078
+      "GAUNTLET_SINK_HM",
+      "GAUNTLET_SINK"
     ],
     "colorOverrides": [
       {
@@ -28000,8 +28000,8 @@
     "baseMaterial": "GRUNGE_3",
     "uvType": "BOX",
     "objectIds": [
-      35980,
-      36077
+      "GAUNTLET_RANGE_HM",
+      "GAUNTLET_RANGE"
     ]
   },
   {
@@ -28010,8 +28010,8 @@
     "uvType": "MODEL_XY",
     "uvScale": 0.5,
     "objectIds": [
-      36075,
-      36076
+      "GAUNTLET_BOOK",
+      "GAUNTLET_BOOK_2"
     ],
     "colorOverrides": [
       {
@@ -28026,7 +28026,7 @@
     "description": "Gauntlet - Singing Bowl",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      36063
+      "GAUNTLET_SINGING_BOWL"
     ],
     "colorOverrides": [
       {
@@ -28038,9 +28038,9 @@
   {
     "description": "Gauntlet - Teleport Platform & Entrance",
     "objectIds": [
-      36062,
-      36082,
-      36085
+      "GAUNTLET_EXIT",
+      "GAUNTLET_LOBBY_EXIT",
+      "GAUNTLET_ENTRANCE_DUMMY"
     ],
     "colorOverrides": [
       {
@@ -28053,8 +28053,8 @@
     "description": "Gauntlet - Tool Storage",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      35977,
-      36074
+      "GAUNTLET_TOOLS_HM",
+      "GAUNTLET_TOOLS"
     ],
     "colorOverrides": [
       {
@@ -28070,8 +28070,8 @@
     "uvType": "BOX",
     "uvScale": 0.4,
     "objectIds": [
-      36066,
-      36067
+      "GAUNTLET_TREE",
+      "GAUNTLET_TREE_DEPLETED"
     ],
     "colorOverrides": [
       {
@@ -28092,8 +28092,8 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      36064,
-      36065
+      "GAUNTLET_ROCK",
+      "GAUNTLET_ROCK_DEPLETED"
     ],
     "colorOverrides": [
       {
@@ -28108,8 +28108,8 @@
     "uvType": "BOX",
     "uvScale": 0.44,
     "objectIds": [
-      36072,
-      36073
+      "GAUNTLET_FIBRE",
+      "GAUNTLET_FIBRE_DEPLETED"
     ],
     "colorOverrides": [
       {
@@ -28130,8 +28130,8 @@
     "uvType": "BOX",
     "uvScale": 0.22,
     "objectIds": [
-      36070,
-      36071
+      "GAUNTLET_HERB",
+      "GAUNTLET_HERB_DEPLETED"
     ]
   },
   {
@@ -28140,8 +28140,8 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      36068,
-      36069
+      "GAUNTLET_POND",
+      "GAUNTLET_POND_DEPLETED"
     ],
     "colorOverrides": [
       {
@@ -28156,11 +28156,11 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      35995,
-      35996,
-      35998,
-      35999,
-      36002
+      "PRIF_GAUNTLET_WALL_TOP_ARCH_01_HM",
+      "PRIF_GAUNTLET_WALL_TOP_ARCH_02_HM",
+      "PRIF_GAUNTLET_DOOR_WALL_UNLIT_01_HM",
+      "PRIF_GAUNTLET_DOOR_WALL_UNLIT_02_HM",
+      "PRIF_GAUNTLET_WALL_EDGE_HM"
     ]
   },
   {
@@ -28169,8 +28169,8 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      35992,
-      35994
+      "PRIF_GAUNTLET_WALL_ARCH_RED_LIT_HM",
+      "PRIF_GAUNTLET_WALL_ARCH_RED_UNLIT_HM"
     ],
     "colorOverrides": [
       {
@@ -28186,9 +28186,9 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      35997,
-      36000,
-      36001
+      "PRIF_GAUNTLET_WALL_TOP_TREE_HM",
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_01_HM",
+      "PRIF_GAUNTLET_DOOR_WALL_LIT_02_HM"
     ],
     "colorOverrides": [
       {
@@ -28203,12 +28203,12 @@
     "uvType": "BOX",
     "uvScale": 0.4,
     "objectIds": [
-      36003,
-      36004,
-      36005,
-      36006,
-      36007,
-      36008
+      "GAUNTLET_VINE_WALL_01_HM",
+      "GAUNTLET_VINE_WALL_02_HM",
+      "GAUNTLET_VINE_WALL_03_HM",
+      "GAUNTLET_VINE_WALL_END_01_HM",
+      "GAUNTLET_VINE_WALL_END_02_HM",
+      "GAUNTLET_VINE_WALL_CORNER_01_HM"
     ],
     "colorOverrides": [
       {
@@ -28225,8 +28225,8 @@
     "uvType": "MODEL_XY",
     "uvScale": 0.5,
     "objectIds": [
-      35978,
-      35979
+      "GAUNTLET_BOOK_HM",
+      "GAUNTLET_BOOK_2_HM"
     ],
     "colorOverrides": [
       {
@@ -28241,7 +28241,7 @@
     "description": "Corrupted Gauntlet - Singing Bowl",
     "baseMaterial": "GRAY_75",
     "objectIds": [
-      35966
+      "GAUNTLET_SINGING_BOWL_HM"
     ],
     "colorOverrides": [
       {
@@ -28253,7 +28253,7 @@
   {
     "description": "Corrupted Gauntlet - Teleport Platform",
     "objectIds": [
-      35965
+      "GAUNTLET_EXIT_HM"
     ],
     "colorOverrides": [
       {
@@ -28268,8 +28268,8 @@
     "uvType": "BOX",
     "uvScale": 0.4,
     "objectIds": [
-      35969,
-      35970
+      "GAUNTLET_TREE_HM",
+      "GAUNTLET_TREE_DEPLETED_HM"
     ],
     "colorOverrides": [
       {
@@ -28290,8 +28290,8 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      35967,
-      35968
+      "GAUNTLET_ROCK_HM",
+      "GAUNTLET_ROCK_DEPLETED_HM"
     ],
     "colorOverrides": [
       {
@@ -28306,8 +28306,8 @@
     "uvType": "BOX",
     "uvScale": 0.44,
     "objectIds": [
-      35975,
-      35976
+      "GAUNTLET_FIBRE_HM",
+      "GAUNTLET_FIBRE_DEPLETED_HM"
     ],
     "colorOverrides": [
       {
@@ -28328,8 +28328,8 @@
     "uvType": "BOX",
     "uvScale": 0.22,
     "objectIds": [
-      35973,
-      35974
+      "GAUNTLET_HERB_HM",
+      "GAUNTLET_HERB_DEPLETED_HM"
     ]
   },
   {
@@ -28338,8 +28338,8 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      35971,
-      35972
+      "GAUNTLET_POND_HM",
+      "GAUNTLET_POND_DEPLETED_HM"
     ],
     "colorOverrides": [
       {
@@ -28351,14 +28351,14 @@
   {
     "description": "Gauntlet - Barrier - Remove Flickering Shadow",
     "castShadows": false,
-    "objectIds": [ 36079, 36080, 35982, 35983 ]
+    "objectIds": [ "GAUNTLET_BLOCKADE_ENTER", "GAUNTLET_BLOCKADE_ESCAPE", "GAUNTLET_BLOCKADE_ENTER_HM", "GAUNTLET_BLOCKADE_ESCAPE_HM" ]
   },
   {
     "description": "Baba Yaga's House - Door",
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "objectIds": [
-      16774
+      "LUNAR_MOONCLAN_DOOR_BABA_YAGA"
     ]
   },
   {
@@ -28367,9 +28367,9 @@
     "uvType": "MODEL_XZ",
     "uvScale": 0.7,
     "objectIds": [
-      16725,
-      16814,
-      16815
+      "LUNAR_MOONCLAN_SHELF_EMPTY",
+      "LUNAR_MOONCLAN_ANIM_LOC_STOOL",
+      "LUNAR_MOONCLAN_ANIM_LOC_TABLE_ROUND"
     ]
   },
   {
@@ -28378,7 +28378,7 @@
     "uvType": "MODEL_XZ",
     "uvScale": 0.7,
     "objectIds": [
-      16816
+      "LUNAR_MOONCLAN_ANIM_LOC_SHELF_SPOONS"
     ],
     "colorOverrides": [
       {
@@ -28393,7 +28393,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "objectIds": [
-      16812
+      "LUNAR_MOONCLAN_ANIM_LOC_KETTLE"
     ],
     "colorOverrides": [
       {
@@ -28406,7 +28406,7 @@
     "description": "Baba Yaga's House - Bed",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      16721
+      "LUNAR_MOONCLAN_FUTON"
     ],
     "colorOverrides": [
       {
@@ -28434,7 +28434,7 @@
     "description": "Baba Yaga's House - Clothes Rack",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      16813
+      "LUNAR_MOONCLAN_ANIM_LOC_CLOTHES_RACK"
     ],
     "colorOverrides": [
       {
@@ -28450,7 +28450,7 @@
     "baseMaterial": "WOOD_GRAIN_2_SMOOTH",
     "areas": [ "Baba Yaga House Interior" ],
     "objectIds": [
-      16707
+      "LUNAR_MOONCLAN_BOOKCASE"
     ],
     "uvType": "BOX",
     "uvScale": 0.4
@@ -28460,7 +28460,7 @@
     "baseMaterial": "NONE",
     "areas": [ "Baba Yaga House Interior" ],
     "objectIds": [
-      16704
+      "LUNAR_MOONCLAN_SINK_SMALL"
     ],
     "colorOverrides": [
       {
@@ -28474,8 +28474,8 @@
   {
     "description": "Hellrats - Hide Fake Lighting",
     "npcIds": [
-      4809,
-      6793
+      "HUNDRED_DAVE_HELLRAT",
+      "HUNDRED_DAVE_BIGRAT"
     ],
     "colorOverrides": [
       {
@@ -28490,7 +28490,7 @@
     "description": "Object - Wooden - Barrel - with coal",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      41455
+      "BIM_SUPPLY_BARREL"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -28510,7 +28510,7 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      52377
+      "FLOORKIT_WOODEN01_DEFAULT01"
     ]
   },
   {
@@ -28520,7 +28520,7 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      52375
+      "WALLKIT_WOODEN01_DEFAULT01"
     ]
   },
   {
@@ -28530,7 +28530,7 @@
     "uvScale": 0.9,
     "flatNormals": true,
     "objectIds": [
-      52635
+      "CIVITAS_STAIRS_1X3"
     ]
   },
   {
@@ -28541,7 +28541,7 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      52012
+      "VARLAMORE_THIEVING_HOUSE_STAIRS"
     ]
   },
   {
@@ -28559,7 +28559,7 @@
       }
     ],
     "objectIds": [
-      52053
+      "WALLKIT_CIVITAS03_MIDDLE01"
     ]
   },
   {
@@ -28577,7 +28577,7 @@
       }
     ],
     "objectIds": [
-      52055
+      "WALLKIT_CIVITAS03_MIDDLE02"
     ]
   },
   {
@@ -28604,10 +28604,10 @@
       }
     ],
     "objectIds": [
-      52060,
-      52061,
-      52062,
-      52063
+      "WALLKIT_CIVITAS03_WINDOW01",
+      "WALLKIT_CIVITAS03_WINDOW02",
+      "WALLKIT_CIVITAS03_WINDOW03",
+      "WALLKIT_CIVITAS03_WINDOW04"
     ]
   },
   {
@@ -28634,8 +28634,8 @@
       }
     ],
     "objectIds": [
-      52000,
-      52001
+      "VARLAMORE_THIEVING_HOUSE_WINDOW_OPEN",
+      "VARLAMORE_THIEVING_HOUSE_WINDOW_CLOSED"
     ]
   },
   {
@@ -28645,21 +28645,21 @@
     "uvScale": 0.8,
     "uvType": "BOX",
     "objectIds": [
-      52049,
-      52050,
-      52066,
-      52067,
-      52068,
-      52072,
-      52073,
-      52074,
-      52075,
-      52077,
-      52078,
-      52079,
-      52080,
-      52081,
-      52083
+      "WALLKIT_CIVITAS01_INNER01",
+      "WALLKIT_CIVITAS01_INNER02",
+      "WALLKIT_CIVITAS03_END01_LEFT",
+      "WALLKIT_CIVITAS03_END01_RIGHT",
+      "WALLKIT_CIVITAS03_JUNCTION01",
+      "WALLKIT_CIVITAS03_JUNCTION03",
+      "WALLKIT_CIVITAS03_JUNCTION03_M",
+      "WALLKIT_CIVITAS03_JUNCTION04",
+      "WALLKIT_CIVITAS03_JUNCTION04_M",
+      "WALLKIT_CIVITAS07_MIDDLE01",
+      "WALLKIT_CIVITAS07_MIDDLE02",
+      "WALLKIT_CIVITAS07_END01",
+      "WALLKIT_CIVITAS07_END02",
+      "WALLKIT_CIVITAS04_MIDDLE01",
+      "WALLKIT_CIVITAS04_END01_LEFT"
     ]
   },
   {
@@ -28669,12 +28669,12 @@
     "uvScale": 0.8,
     "uvType": "BOX",
     "objectIds": [
-      52104,
-      52105,
-      52106,
-      52107,
-      52108,
-      52109
+      "WALLKIT_CIVITAS06_ARCH01",
+      "WALLKIT_CIVITAS06_ARCH02",
+      "WALLKIT_CIVITAS06_ARCH03",
+      "WALLKIT_CIVITAS06_ARCH01_TALL",
+      "WALLKIT_CIVITAS06_ARCH01_TALL_MID",
+      "WALLKIT_CIVITAS06_ARCH02_TALL"
     ]
   },
   {
@@ -28684,7 +28684,7 @@
     "uvScale": 0.9,
     "flatNormals": true,
     "objectIds": [
-      52099
+      "WALLKIT_CIVITAS05_FENCE02"
     ]
   },
   {
@@ -28695,7 +28695,7 @@
     "uvScale": 0.9,
     "flatNormals": true,
     "objectIds": [
-      52098
+      "WALLKIT_CIVITAS05_FENCE01"
     ]
   },
   {
@@ -28705,18 +28705,18 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "objectIds": [
-      16537,
-      16538
+      "SLAYERTOWER_SC_CHAINBOTTOM",
+      "SLAYERTOWER_SC_CHAINTOP"
     ]
   },
   {
     "description": "Ground decoration blood",
     "baseMaterial": "METALLIC_NONE_GLOSS",
     "objectIds": [
-      654,
-      3666,
-      3667,
-      3668
+      "BLOODSPLATTER3",
+      "DEATH_TROLLBLOODSPLAT1",
+      "DEATH_TROLLBLOODSPLAT2",
+      "DEATH_TROLLBLOODSPLAT3"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -28735,7 +28735,7 @@
       }
     ],
     "objectIds": [
-      1901
+      "OLDLONGTABLE"
     ]
   },
   {
@@ -28753,8 +28753,8 @@
       }
     ],
     "objectIds": [
-      31672,
-      31673
+      "SLAYER_ROOF_ENTRANCE_LOCKED",
+      "SLAYER_ROOF_ENTRANCE_UNLOCKED"
     ]
   },
   {
@@ -28765,7 +28765,7 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      31674
+      "SLAYER_ROOF_EXIT"
     ]
   },
   {
@@ -28783,29 +28783,29 @@
       }
     ],
     "objectIds": [
-      31675
+      "GARGBOSS_GRAVESTONE_RETRIEVAL"
     ]
   },
   {
     "description": "Grotesque Guardians Tiled Floor",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      31653,
-      31654,
-      31655,
-      31656,
-      31657,
-      31658,
-      31659,
-      31660,
-      31661,
-      31662,
-      31663,
-      31664,
-      31665,
-      31666,
-      31667,
-      31668
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_1A",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_1B",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_1C",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_1D",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_2A",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_2B",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_2C",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_2D",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_3A",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_3B",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_3C",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_3D",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_4A",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_4B",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_4C",
+      "SLAYER_TOWER_ROOF_TOP_FLOOR_4D"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 156
@@ -28814,9 +28814,9 @@
     "description": "Grotesque Guardians Low Wall",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      31642,
-      31643,
-      31644
+      "SLAYER_ROOF_WALL_PONY_STRAIGHT_01",
+      "SLAYER_ROOF_WALL_PONY_STRAIGHT_02",
+      "SLAYER_ROOF_WALL_PONY_CORNER_01"
     ],
     "uvType": "BOX",
     "uvOrientation": 156
@@ -28825,19 +28825,19 @@
     "description": "Grotesque Guardians Roof",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      31635,
-      31637,
-      31638,
-      31639,
-      31640,
-      31641,
-      31645,
-      31646,
-      31647,
-      31648,
-      31649,
-      31651,
-      31652
+      "SLAYER_ROOF_WALL_STRAIGHT_01",
+      "SLAYER_ROOF_WALL_CORNER_01",
+      "SLAYER_ROOF_WALL_ARCH_STRAIGHT_01",
+      "SLAYER_ROOF_WALL_ARCH_STRAIGHT_02",
+      "SLAYER_ROOF_WALL_ARCH_STRAIGHT_03",
+      "SLAYER_ROOF_WALL_ARCH_CORNER_01",
+      "SLAYER_ROOF_STRAIGHT_01",
+      "SLAYER_ROOF_STRAIGHT_02",
+      "SLAYER_ROOF_CORNER_01",
+      "SLAYER_ROOF_CORNER_02",
+      "SLAYER_ROOF_TOP_01",
+      "SLAYER_ROOF_TOP_03",
+      "SLAYER_ROOF_TOP_04"
     ],
     "uvType": "BOX",
     "uvScale": 0.5
@@ -28846,8 +28846,8 @@
     "description": "Grotesque Guardians Dusk and Dawn Statues",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      31670,
-      31671
+      "SLAYER_ROOF_PLINTH_DUSK",
+      "SLAYER_ROOF_PLINTH_DAWN"
     ],
     "uvType": "BOX",
     "uvScale": 1.2
@@ -28858,25 +28858,25 @@
     "retainVanillaShadowsInPvm": true,
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      31676,
-      31677
+      "GUARDIAN_DUSK_STATUE_VISIBLE",
+      "GUARDIAN_DAWN_STATUE_VISIBLE"
     ],
     "npcIds": [
-      7849,
-      7850,
-      7851,
-      7852,
-      7853,
-      7854,
-      7855,
-      7882,
-      7883,
-      7884,
-      7885,
-      7886,
-      7887,
-      7888,
-      7889
+      "GARGBOSS_DUSK_SPAWN",
+      "GARGBOSS_DAWN_SPAWN",
+      "GARGBOSS_DUSK_PHASE1_DEFENSIVE",
+      "GARGBOSS_DAWN_PHASE1",
+      "GARGBOSS_DAWN_PHASE1_TRANSITION",
+      "GARGBOSS_DUSK_PHASE1_TRANSITION",
+      "GARGBOSS_DUSK_PHASE1_FLYTRANSITION",
+      "GARGBOSS_DUSK_PHASE2_ATTACKING",
+      "GARGBOSS_DUSK_PHASE3_DEFENSIVE",
+      "GARGBOSS_DAWN_PHASE3",
+      "GARGBOSS_DAWN_DEATH",
+      "GARGBOSS_DUSK_PHASE3_TRANSITION",
+      "GARGBOSS_DUSK_PHASE4_SPAWN",
+      "GARGBOSS_DUSK_PHASE4",
+      "GARGBOSS_DUSK_DEATH"
     ],
     "uvScale": 0.75
   },
@@ -28885,7 +28885,7 @@
     "baseMaterial": "GRUNGE_3",
     "uvType": "BOX",
     "objectIds": [
-      31685
+      "SLAYER_ROOF_BELL_QUICKSTART"
     ],
     "colorOverrides": [
       {
@@ -28900,7 +28900,7 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      6752
+      "POH_CHAIR1"
     ]
   },
   {
@@ -28909,7 +28909,7 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      6753
+      "POH_CHAIR2"
     ]
   },
   {
@@ -28919,8 +28919,8 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      13098,
-      13099
+      "VILLAGE_WALL",
+      "VILLAGE_WALL_WINDOW"
     ]
   },
   {
@@ -28930,7 +28930,7 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      13253
+      "POH_RIMMINGTON_WINDOW_SHUTTERS"
     ]
   },
   {
@@ -28940,22 +28940,22 @@
     "uvScale": 0.8,
     "flatNormals": true,
     "objectIds": [
-      17164,
-      17165,
-      17166,
-      17167,
-      17168,
-      17169,
-      17170,
-      17171,
-      17172,
-      17173,
-      17174,
-      17175,
-      17176,
-      17177,
-      17178,
-      17179
+      "POH_RIMMINGTON_REGION_ROOF01",
+      "POH_RIMMINGTON_REGION_ROOF02",
+      "POH_RIMMINGTON_REGION_ROOF03",
+      "POH_RIMMINGTON_REGION_ROOF04",
+      "POH_RIMMINGTON_REGION_ROOF05",
+      "POH_RIMMINGTON_REGION_ROOF06",
+      "POH_RIMMINGTON_REGION_ROOF07",
+      "POH_RIMMINGTON_REGION_ROOF08",
+      "POH_RIMMINGTON_REGION_ROOF09",
+      "POH_RIMMINGTON_REGION_ROOF10",
+      "POH_RIMMINGTON_REGION_ROOF11",
+      "POH_RIMMINGTON_REGION_ROOF12",
+      "POH_RIMMINGTON_REGION_ROOF13",
+      "POH_RIMMINGTON_REGION_ROOF14",
+      "POH_RIMMINGTON_REGION_ROOF15",
+      "POH_RIMMINGTON_REGION_ROOF16"
     ]
   },
   {
@@ -28975,10 +28975,10 @@
       }
     ],
     "objectIds": [
-      13100,
-      13101,
-      13102,
-      13103
+      "VILLAGE_DOOR_L",
+      "VILLAGE_DOOR_R",
+      "VILLAGE_DOOR_L_OPEN",
+      "VILLAGE_DOOR_R_OPEN"
     ]
   },
   {
@@ -28996,7 +28996,7 @@
       }
     ],
     "objectIds": [
-      13226
+      "POH_LUMBRIDGE_WINDOW_SHUTTERS"
     ]
   },
   {
@@ -29013,8 +29013,8 @@
       }
     ],
     "objectIds": [
-      13005,
-      13010
+      "DESERT_WALL_WINDOW",
+      "DESERTWALL_NOSHARELIGHT"
     ]
   },
   {
@@ -29036,7 +29036,7 @@
       }
     ],
     "objectIds": [
-      13235
+      "POH_POLLNIVNEACH_WINDOW_SHUTTERS"
     ]
   },
   {
@@ -29051,10 +29051,10 @@
       }
     ],
     "objectIds": [
-      13006,
-      13007,
-      13008,
-      13009
+      "DESERT_DOOR_L",
+      "DESERT_DOOR_R",
+      "DESERT_DOOR_L_OPEN",
+      "DESERT_DOOR_R_OPEN"
     ]
   },
   {
@@ -29063,8 +29063,8 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      13111,
-      13112
+      "VIKING_LONGHALL_WALL_INNER",
+      "VIKING_LONGHALL_WALL_WINDOW_INNER"
     ]
   },
   {
@@ -29073,22 +29073,22 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      17180,
-      17181,
-      17182,
-      17183,
-      17184,
-      17185,
-      17186,
-      17187,
-      17188,
-      17189,
-      17190,
-      17191,
-      17192,
-      17193,
-      17194,
-      17195
+      "POH_RELLEKKA_REGION_ROOF01",
+      "POH_RELLEKKA_REGION_ROOF02",
+      "POH_RELLEKKA_REGION_ROOF03",
+      "POH_RELLEKKA_REGION_ROOF04",
+      "POH_RELLEKKA_REGION_ROOF05",
+      "POH_RELLEKKA_REGION_ROOF06",
+      "POH_RELLEKKA_REGION_ROOF07",
+      "POH_RELLEKKA_REGION_ROOF08",
+      "POH_RELLEKKA_REGION_ROOF09",
+      "POH_RELLEKKA_REGION_ROOF10",
+      "POH_RELLEKKA_REGION_ROOF11",
+      "POH_RELLEKKA_REGION_ROOF12",
+      "POH_RELLEKKA_REGION_ROOF13",
+      "POH_RELLEKKA_REGION_ROOF14",
+      "POH_RELLEKKA_REGION_ROOF15",
+      "POH_RELLEKKA_REGION_ROOF16"
     ]
   },
   {
@@ -29097,10 +29097,10 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "objectIds": [
-      13107,
-      13108,
-      13109,
-      13110
+      "RELLEKKA_POH_DOUBLEDOOR",
+      "RELLEKKA_POH_DOUBLEDOOR_OPEN",
+      "RELLEKKA_POH_DOUBLEDOORL",
+      "RELLEKKA_POH_DOUBLEDOORL_OPEN"
     ]
   },
   {
@@ -29118,8 +29118,8 @@
       }
     ],
     "objectIds": [
-      27647,
-      27648
+      "PISCARILIUS_PIER_POST_01",
+      "PISCARILIUS_PIER_POST_02"
     ]
   },
   {
@@ -29135,8 +29135,8 @@
       }
     ],
     "objectIds": [
-      9473,
-      9474
+      "WHITE_BRICK_WALL",
+      "WHITE_BRICK_WALLPAINTED_INSIDE"
     ]
   },
   {
@@ -29165,7 +29165,7 @@
       }
     ],
     "objectIds": [
-      1021
+      "WITCHSHELF3"
     ]
   },
   {
@@ -29174,8 +29174,8 @@
     "uvType": "BOX",
     "uvOrientation": 512,
     "objectIds": [
-      16169,
-      16170
+      "QIP_IMP_CATCHER_MAGIC_TABLE_BEFORE",
+      "QIP_IMP_CATCHER_MAGIC_TABLE_AFTER"
     ]
   },
   {
@@ -29185,14 +29185,14 @@
     "uvType": "BOX",
     "retainVanillaUvs": false,
     "objectIds": [
-      603
+      "TABLE3"
     ]
   },
   {
     "description": "Double bed with red blanket and bed frame",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
-      427
+      "BIGBED3"
     ],
     "uvType": "BOX",
     "uvScale": 0.75,
@@ -29230,7 +29230,7 @@
     "description": "Single bed with gray blanket",
     "baseMaterial": "CARPET",
     "objectIds": [
-      417
+      "BED"
     ],
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -29259,7 +29259,7 @@
       }
     ],
     "objectIds": [
-      1027
+      "TANNINGLINE"
     ]
   },
   {
@@ -29277,8 +29277,8 @@
       }
     ],
     "objectIds": [
-      1987,
-      1988
+      "LOGRAFT_WATERFALL_QUEST",
+      "LOGRAFT_BROKEN"
     ]
   },
   {
@@ -29296,7 +29296,7 @@
       }
     ],
     "objectIds": [
-      10795
+      "OVERHANG3ROCK"
     ]
   },
   {
@@ -29314,7 +29314,7 @@
       }
     ],
     "objectIds": [
-      2010
+      "WATERFALL_LEDGE_DOOR"
     ]
   },
   {
@@ -29323,7 +29323,7 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      1107
+      "WALLBENCH"
     ]
   },
   {
@@ -29343,7 +29343,7 @@
       }
     ],
     "objectIds": [
-      2014
+      "BAXTORIAN_CHALICE_WATERFALL_QUEST"
     ]
   },
   {
@@ -29367,7 +29367,7 @@
       }
     ],
     "objectIds": [
-      1112
+      "PEW"
     ]
   },
   {
@@ -29383,7 +29383,7 @@
       }
     ],
     "objectIds": [
-      608
+      "STUDYDESK"
     ]
   },
   {
@@ -29391,10 +29391,10 @@
     "baseMaterial": "DIRT_1",
     "uvType": "MODEL_XZ_MIRROR_B",
     "objectIds": [
-      3442,
-      3450,
-      3451,
-      12765
+      "UNDERGROUND_WALL_SIDE",
+      "UNDERGROUND_WALL_OUTSIDECORNER",
+      "UNDERGROUND_WALL_INSIDECORNER",
+      "BURGH_LIBRARY_KEYHOLE"
     ]
   },
   {
@@ -29402,7 +29402,7 @@
     "baseMaterial": "DIRT_1",
     "uvType": "MODEL_XZ_MIRROR_B",
     "objectIds": [
-     3443
+      "PIP_UNDERGROUND_WALL_SIDE_WITHPORTAL"
     ]
   },
   {
@@ -29412,8 +29412,8 @@
     "uvScale": 1.15,
     "uvOrientation": 42,
     "objectIds": [
-      3447,
-      3448
+      "UNDERGROUND_WALL_TOPLVL2",
+      "UNDERGROUND_WALL_TOPLVL1"
     ]
   },
   {
@@ -29423,7 +29423,7 @@
     "uvOrientation": 343,
     "uvScale": 0.6,
     "objectIds": [
-      3486
+      "PRIESTPERIL_WELL_COLOUMN"
     ]
   },
   {
@@ -29433,7 +29433,7 @@
     "uvOrientation": 42,
     "uvScale": 0.6,
     "objectIds": [
-      3485
+      "PRIESTPERIL_WELL"
     ]
   },
   {
@@ -29443,13 +29443,13 @@
     "uvOrientation": 42,
     "uvScale": 0.6,
     "objectIds": [
-      3493,
-      3494,
-      3495,
-      3496,
-      3497,
-      3498,
-      3499
+      "PRIESTPERIL_GRAVE_BASE1",
+      "PRIESTPERIL_GRAVE_BASE2",
+      "PRIESTPERIL_GRAVE_BASE3",
+      "PRIESTPERIL_GRAVE_BASE4",
+      "PRIESTPERIL_GRAVE_BASE5",
+      "PRIESTPERIL_GRAVE_BASE6",
+      "PRIESTPERIL_GRAVE_BASE7"
     ]
   },
   {
@@ -29459,11 +29459,11 @@
     "uvOrientation": 75,
     "uvType": "BOX",
     "objectIds": [
-      12454,
-      12457,
-      12464,
-      12465,
-      12459
+      "SEABED_CAVEWALL_FACE1",
+      "SEABED2_CAVEWALL_TOP",
+      "SEABED3_CAVEWALL_ABOVE_CAVEENTRANCEL",
+      "SEABED3_CAVEWALL_ABOVE_CAVEENTRANCER",
+      "SEABED3_CAVEWALL_TOP"
     ]
   },
   {
@@ -29472,9 +29472,9 @@
     "uvType": "BOX",
     "uvOrientation": -50,
     "objectIds": [
-      12455,
-      12456,
-      12458
+      "SEABED_CAVEWALL_TOP",
+      "SEABED2_CAVEWALL_FACE1",
+      "SEABED3_CAVEWALL_FACE1"
     ]
   },
   {
@@ -29482,10 +29482,10 @@
     "baseMaterial": "ROCK_3",
     "uvType": "BOX",
     "objectIds": [
-      12460,
-      12461,
-      12462,
-      12463
+      "SEABED2_CAVEWALL_MUDSKIPPER_CAVEENTRANCEL",
+      "SEABED2_CAVEWALL_MUDSKIPPER_CAVEENTRANCER",
+      "SEABED2_CAVEWALL_MUDSKIPPER_CAVEEXITL",
+      "SEABED2_CAVEWALL_MUDSKIPPER_CAVEEXITR"
     ],
     "colorOverrides": [
       {
@@ -29500,14 +29500,14 @@
     "baseMaterial": "GRUNGE_2",
     "uvType": "BOX",
     "objectIds": [
-      12466,
-      12467,
-      12468,
-      12469,
-      12470,
-      12471,
-      12472,
-      12473
+      "PEN_WALL",
+      "PEN_WALL_DOORL",
+      "PEN_WALL_DOORR",
+      "PEN_WALL_DOORL_OPEN",
+      "PEN_WALL_DOORR_OPEN",
+      "PEN_WALLL",
+      "PEN_WALLR",
+      "PEN_WALL_BROKEN"
     ]
   },
   {
@@ -29516,57 +29516,57 @@
     "uvType": "BOX",
     "uvScale": 0.4,
     "objectIds": [
-      12479,
-      12480,
-      12481,
-      12482,
-      12483,
-      12484,
-      12485,
-      12486,
-      12487,
-      12488,
-      12489,
-      12490,
-      12491,
-      12492,
-      12493,
-      12494,
-      12495,
-      12496,
-      12497,
-      12498,
-      12499,
-      12500,
-      12501,
-      12502,
-      12503,
-      12504,
-      12505,
-      12506,
-      12507,
-      12508,
-      12509,
-      12510,
-      12511,
-      12512,
-      12513,
-      12514,
-      12515,
-      12516,
-      12517,
-      12518,
-      12519,
-      12520,
-      12521,
-      12522,
-      12523,
-      12524,
-      12525,
-      12526,
-      12527,
-      12528,
-      12529
+      "_100_CORAL_PLAIN_SIDE1",
+      "_100_CORAL_PLAIN_SIDE2",
+      "_100_CORAL_PLAIN_CORNER1",
+      "_100_CORAL_PLAIN_CORNER2",
+      "_100_CORAL_PLAIN_INVERSE",
+      "_100_CORAL_PLAIN_TOP1",
+      "_100_CORAL_PLAIN_TOP2",
+      "_100_CORAL_PLAIN_TOP3",
+      "_100_CORAL_PLAIN_ROCK1",
+      "_100_CORAL_PLAIN_ROCK2",
+      "_100_CORAL_ELK_SIDE1",
+      "_100_CORAL_ELK_SIDE2",
+      "_100_CORAL_ELK_CORNER1",
+      "_100_CORAL_ELK_CORNER2",
+      "_100_CORAL_ELK_INVERSE",
+      "_100_CORAL_ELK_TOP1",
+      "_100_CORAL_ELK_TOP2",
+      "_100_CORAL_ELK_TOP3",
+      "_100_CORAL_ELK_ROCK1",
+      "_100_CORAL_ELK_ROCK2",
+      "_100_CORAL_LACE_SIDE1",
+      "_100_CORAL_LACE_SIDE2",
+      "_100_CORAL_LACE_CORNER1",
+      "_100_CORAL_LACE_CORNER2",
+      "_100_CORAL_LACE_INVERSE",
+      "_100_CORAL_LACE_TOP1",
+      "_100_CORAL_LACE_TOP2",
+      "_100_CORAL_LACE_TOP3",
+      "_100_CORAL_LACE_ROCK1",
+      "_100_CORAL_LACE_ROCK2",
+      "_100_CORAL_DISC_SIDE1",
+      "_100_CORAL_DISC_SIDE2",
+      "_100_CORAL_DISC_CORNER1",
+      "_100_CORAL_DISC_CORNER2",
+      "_100_CORAL_DISC_INVERSE",
+      "_100_CORAL_DISC_TOP1",
+      "_100_CORAL_DISC_TOP2",
+      "_100_CORAL_DISC_TOP3",
+      "_100_CORAL_DISC_ROCK1",
+      "_100_CORAL_DISC_ROCK2",
+      "_100_CORAL_FLOWER_ROCK",
+      "_100_CORAL_TUBE_SIDE1",
+      "_100_CORAL_TUBE_SIDE2",
+      "_100_CORAL_TUBE_CORNER1",
+      "_100_CORAL_TUBE_CORNER2",
+      "_100_CORAL_TUBE_INVERSE",
+      "_100_CORAL_TUBE_TOP1",
+      "_100_CORAL_TUBE_TOP2",
+      "_100_CORAL_TUBE_TOP3",
+      "_100_CORAL_TUBE_ROCK1",
+      "_100_CORAL_TUBE_ROCK2"
     ],
     "colorOverrides": [
       {
@@ -29587,9 +29587,9 @@
     "description": "Mogre Camp Anchor",
     "baseMaterial": "METALLIC_1_SEMIGLOSS",
     "objectIds": [
-      12474,
-      12475,
-      12476
+      "ANCHOR_BOTTOM",
+      "ANCHOR_MIDDLE",
+      "ANCHOR_MIDDLE2"
     ]
   },
   {
@@ -29599,11 +29599,11 @@
     "uvOrientation": 75,
     "uvType": "BOX",
     "objectIds": [
-      30738,
-      30740,
-      30741,
-      30742,
-      30743
+      "FOSSIL_SEABED_MID_WALL_TOP",
+      "FOSSIL_SEABED_CAVE_WALL_TOP",
+      "FOSSIL_SEABED_CAVE_WALL_TOP_SIDE",
+      "FOSSIL_SEABED_CAVE_WALL_TOP_CORN",
+      "FOSSIL_SEABED_CAVE_WALL_TOP_CORN2"
     ]
   },
   {
@@ -29612,19 +29612,19 @@
     "uvType": "BOX",
     "uvOrientation": -50,
     "objectIds": [
-      30734,
-      30735,
-      30736,
-      30744,
-      30745,
-      30746,
-      30747,
-      30959,
-      30962,
-      30963,
-      30964,
-      30965,
-      31845
+      "FOSSIL_SEABED_LOW_WALL",
+      "FOSSIL_SEABED_MID_WALL",
+      "FOSSIL_SEABED_HIGH_WALL",
+      "FOSSIL_SEABED_1_CAVEWALL",
+      "FOSSIL_SEABED_1_CAVEJOIN",
+      "FOSSIL_SEABED_1_CAVEJOIN_M",
+      "FOSSIL_SEABED_1_CAVEWALL_B",
+      "FOSSIL_UNDERWATER_DEEPWATER_AGIHOLE",
+      "FOSSIL_UNDERWATER_CAVE_OBSTACLE1",
+      "FOSSIL_UNDERWATER_CAVE_OBSTACLE1_JOIN",
+      "FOSSIL_UNDERWATER_CAVE_OBSTACLE2",
+      "FOSSIL_UNDERWATER_CAVE_OBSTACLE2_JOIN",
+      "FOSSIL_DRIFTNET_ENTRANCE_2OPS"
     ]
   },
   {
@@ -29633,10 +29633,10 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "objectIds": [
-      2440,
-      2441,
-      2442,
-      2443
+      "GRANDTREE_PILLART",
+      "GRANDTREE_PILLARU",
+      "GRANDTREE_PILLARZ",
+      "GRANDTREE_PILLARO"
     ]
   },
   {
@@ -29653,7 +29653,7 @@
         "uvScale": 0.8
       }
     ],
-    "objectIds": [ 2451 ]
+    "objectIds": [ "GRANDTREE_ROOTDOOR" ]
   },
   {
     "description": "Porcine of Interest - Veg Cart",
@@ -29667,7 +29667,7 @@
       }
     ],
     "objectIds": [
-      40314
+      "PORCINE_TRACKING_CART_VISIBLE"
     ]
   },
   {
@@ -29694,8 +29694,8 @@
       }
     ],
     "objectIds": [
-      40308,
-      40309
+      "PORCINE_HOLE_NOROPE",
+      "PORCINE_HOLE_ROPE"
     ]
   },
   {
@@ -29711,9 +29711,9 @@
       }
     ],
     "objectIds": [
-      31793,
-      31794,
-      31795
+      "DS2_OGRE_CORSAIR_DUNGEON_WALL_VINE",
+      "DS2_OGRE_CORSAIR_DUNGEON_WALL_VINE_END_RIGHT",
+      "DS2_OGRE_CORSAIR_DUNGEON_WALL_VINE_END_LEFT"
     ]
   },
   {
@@ -29721,11 +29721,11 @@
     "baseMaterial": "DIRT_2",
     "uvType": "BOX",
     "objectIds": [
-      40332,
-      40333,
-      40334,
-      40335,
-      40336
+      "PORCINE_CAVE_CAVETOP",
+      "PORCINE_CAVE_CAVETOP_FALLOFF_STRAIGHT",
+      "PORCINE_CAVE_CAVETOP_FALLOFF_INSIDE_CORNER",
+      "PORCINE_CAVE_CAVETOP_FALLOFF_OUTSIDE_CORNER",
+      "PORCINE_CAVE_WALL_HOLE"
     ]
   },
   {
@@ -29734,7 +29734,7 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "objectIds": [
-      40331
+      "PORCINE_CAVE_BLOCKAGE"
     ]
   },
   {
@@ -29743,11 +29743,11 @@
     "uvType": "BOX",
     "uvScale": 0.2,
     "objectIds": [
-      40320,
-      40326,
-      40327,
-      40328,
-      40329
+      "PORCINE_SKELETON_VISIBLE_OP",
+      "PORCINE_CAVE_BONES1",
+      "PORCINE_CAVE_BONES2",
+      "PORCINE_CAVE_BONES3",
+      "PORCINE_CAVE_BONES4"
     ]
   },
   {
@@ -29757,9 +29757,9 @@
     "uvOrientation": 512,
     "uvScale": 0.25,
     "objectIds": [
-      1593,
-      1616,
-      1855
+      "BAMBOO_DOORWAY",
+      "BAMBOO_WALL",
+      "BAMBOO_WINDOW"
     ]
   },
   {
@@ -29769,8 +29769,8 @@
     "uvOrientation": 512,
     "uvScale": 0.25,
     "objectIds": [
-      9038,
-      9039
+      "TBWCU_BAMBOO_DOOR_L",
+      "TBWCU_BAMBOO_DOOR_R"
     ]
   },
   {
@@ -29780,7 +29780,7 @@
     "uvOrientation": 512,
     "uvScale": 0.25,
     "objectIds": [
-      779
+      "TBWT_BAMBOO_DOOR"
     ]
   },
   {
@@ -29801,7 +29801,7 @@
       }
     ],
     "objectIds": [
-      1721
+      "BAMBOO_BRIDGE1"
     ]
   },
   {
@@ -29821,7 +29821,7 @@
       }
     ],
     "objectIds": [
-      1160
+      "POTTEDPLANT_BAMBOO"
     ]
   },
   {
@@ -29831,8 +29831,8 @@
     "uvScale": 0.25,
     "uvOrientation": 512,
     "objectIds": [
-      395,
-      396
+      "POT_BAMBOO",
+      "POTS_BAMBOO"
     ]
   },
   {
@@ -29842,7 +29842,7 @@
     "uvScale": 0.25,
     "uvOrientation": 512,
     "objectIds": [
-      393
+      "BOOKCASE_BAMBOO"
     ]
   },
   {
@@ -29852,7 +29852,7 @@
     "uvScale": 0.25,
     "uvOrientation": 512,
     "objectIds": [
-      394
+      "SHELVES_BAMBOO"
     ]
   },
   {
@@ -29872,7 +29872,7 @@
       }
     ],
     "objectIds": [
-      620
+      "TABLE_BAMBOO"
     ]
   },
   {
@@ -29882,7 +29882,7 @@
     "uvScale": 0.25,
     "uvOrientation": 512,
     "objectIds": [
-      1113
+      "STOOL_BAMBOO"
     ]
   },
   {
@@ -29902,7 +29902,7 @@
       }
     ],
     "objectIds": [
-      433
+      "BIGBED_BAMBOO"
     ]
   },
   {
@@ -29921,7 +29921,7 @@
       }
     ],
     "objectIds": [
-      1617
+      "BAMBOO_RAMP"
     ]
   },
   {
@@ -29929,7 +29929,7 @@
     "baseMaterial": "STONE_NORMALED",
     "uvType": "BOX",
     "uvOrientation": 32,
-    "objectIds": [ 3863 ]
+    "objectIds": [ "TBWT_TRIBAL_STATUE" ]
   },
   {
     "description": "Tai Bwo Wannai Village Fence",
@@ -29937,7 +29937,7 @@
     "uvType": "BOX",
     "uvOrientation": 64,
     "uvScale": 0.66,
-    "objectIds": [ 9025, 9026, 9027, 9028, 9029, 9042, 9043 ]
+    "objectIds": [ "VILLAGE_FENCE_ROTTEN", "VILLAGE_FENCE_FIXED1", "VILLAGE_FENCE_FIXED2", "VILLAGE_FENCE_FIXED3", "VILLAGE_FENCE_FIXEDCOMPLETE", "TBW_SUPPORT_POLE", "TBW_VILLAGE_FENCE" ]
   },
   {
     "description": "Tai Bwo Wannai Cleanup Jungle - Dynamic",
@@ -29946,14 +29946,14 @@
     "uvScale": 0.25,
     "uvOrientation": 512,
     "objectIds": [
-      9013,
-      9014,
-      9017,
-      9018,
-      9019,
-      9022,
-      9023,
-      9024
+      "TAI_BWO_JUNGLE_VEGETATION_EASY_4",
+      "TAI_BWO_JUNGLE_VEGETATION_EASY_5",
+      "TAI_BWO_JUNGLE_VEGETATION_MED_3",
+      "TAI_BWO_JUNGLE_VEGETATION_MED_4",
+      "TAI_BWO_JUNGLE_VEGETATION_MED_5",
+      "TAI_BWO_JUNGLE_VEGETATION_HARD_3",
+      "TAI_BWO_JUNGLE_VEGETATION_HARD_4",
+      "TAI_BWO_JUNGLE_VEGETATION_HARD_5"
     ]
   },
   {
@@ -29973,12 +29973,12 @@
       }
     ],
     "objectIds": [
-      9010,
-      9011,
-      9015,
-      9016,
-      9020,
-      9021
+      "TAI_BWO_JUNGLE_VEGETATION_EASY_1",
+      "TAI_BWO_JUNGLE_VEGETATION_EASY_2",
+      "TAI_BWO_JUNGLE_VEGETATION_MED_1",
+      "TAI_BWO_JUNGLE_VEGETATION_MED_2",
+      "TAI_BWO_JUNGLE_VEGETATION_HARD_1",
+      "TAI_BWO_JUNGLE_VEGETATION_HARD_2"
     ]
   },
   {
@@ -29987,7 +29987,7 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      3415
+      "ELEMENTAL_WORKSHOP_SPIRALSTAIRSTOP"
     ]
   },
   {
@@ -29996,28 +29996,28 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      3416
+      "ELEMENTAL_WORKSHOP_SPIRALSTAIRS"
     ]
   },
   {
     "description": "Water wheel - DYNAMIC",
-    "objectIds": [ 18512 ],
+    "objectIds": [ "ELEMENTAL_WORKSHOP_WHEEL_NO_ANIM" ],
     "flatNormals": true
   },
   {
     "description": "Elemental workshop water controls - DYNAMIC",
-    "objectIds": [ 18509, 18510 ]
+    "objectIds": [ "ELEMENTAL_WORKSHOP_VALVE_1_RED", "ELEMENTAL_WORKSHOP_VALVE_1_GREEN" ]
   },
   {
     "description": "Elemental workshop moving machinery - DYNAMIC",
-    "objectIds": [ 18530 ]
+    "objectIds": [ "ELEMENTAL_PIPE_END_ANIM" ]
   },
   {
     "description": "Elemental workshop levers",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "uvType": "BOX",
     "uvScale": 0.4,
-    "objectIds": [ 3406, 3409, 3417 ]
+    "objectIds": [ "ELEMENTAL_WORKSHOP_WATER_LEVER", "ELEMENTAL_WORKSHOP_AIR_LEVER", "ELEMENTAL_WORKSHOP_LEVER_PULLED" ]
   },
   {
     "description": "metallic pipe with a beige stripe on the side",
@@ -30025,12 +30025,12 @@
     "uvType": "BOX",
     "uvOrientation": 256,
     "objectIds": [
-      18726,
-      18727,
-      18728,
-      18729,
-      18730,
-      18732
+      "ELEMENTAL_PIPING_BLUE_FLOAT",
+      "ELEMENTAL_PIPING_LIGHTBROWN",
+      "ELEMENTAL_PIPING_LIGHTBROWN_FLOAT",
+      "ELEMENTAL_PIPING_LIGHTBROWN_CORNER",
+      "ELEMENTAL_PIPING_LIGHTGREY",
+      "ELEMENTAL_PIPING_LIGHTGREY_FLOAT"
     ]
   },
   {
@@ -30039,12 +30039,12 @@
     "uvType": "BOX",
     "uvOrientation": 256,
     "objectIds": [
-      18528,
-      18529,
-      18532,
-      18533,
-      18534,
-      18535
+      "ELEM1_QIP_FLOORPIPE_TPIECE",
+      "ELEM1_QIP_FLOORPIPE_XPIECE",
+      "ELEM1_QIP_FLOORPIPE_OUTLET_STRIPE",
+      "ELEM1_QIP_PIPE_ORANGE",
+      "ELEM1_QIP_PIPE_ORANGE_FLOAT",
+      "ELEM1_QIP_PIPE_ORANGE_CORNER"
     ]
   },
   {
@@ -30053,11 +30053,11 @@
     "uvType": "BOX",
     "uvOrientation": 42,
     "objectIds": [
-      18519,
-      18520,
-      18521,
-      18522,
-      18523
+      "ELEMENTAL_WORKSHOP_TROUGH_1",
+      "ELEMENTAL_WORKSHOP_TROUGH_2",
+      "ELEMENTAL_WORKSHOP_TROUGH_3",
+      "ELEMENTAL_WORKSHOP_TROUGH_4",
+      "ELEMENTAL_WORKSHOP_TROUGH_5"
     ]
   },
   {
@@ -30066,8 +30066,8 @@
     "uvType": "BOX",
     "uvOrientation": 256,
     "objectIds": [
-      18588,
-      18589
+      "ELEM1_QIP_TROUGH_WALL1",
+      "ELEM1_QIP_TROUGH_WALL2"
     ]
   },
   {
@@ -30076,8 +30076,8 @@
     "uvType": "BOX",
     "uvOrientation": 256,
     "objectIds": [
-      3422,
-      3423
+      "ELEMENTAL_BOILER",
+      "ELEMENTAL_BOILER_LEFT"
     ]
   },
   {
@@ -30086,8 +30086,8 @@
     "uvType": "BOX",
     "uvOrientation": 343,
     "objectIds": [
-      18515,
-      18516
+      "ELEMENTAL_WORKSHOP_BELLOWS_ANIM",
+      "ELEMENTAL_WORKSHOP_BELLOWS_NOANIM"
     ]
   },
   {
@@ -30096,9 +30096,9 @@
     "uvType": "BOX",
     "uvOrientation": 343,
     "objectIds": [
-      18517,
-      18518,
-      18525
+      "ELEMENTAL_WORKSHOP_FURNACE_DOOR_LEFT",
+      "ELEMENTAL_WORKSHOP_FURNACE_DOOR_RIGHT_MIRROR",
+      "ELEMENTAL_WORKSHOP_FURNACE_OUT"
     ]
   },
   {
@@ -30107,36 +30107,36 @@
     "uvType": "BOX",
     "uvOrientation": 343,
     "objectIds": [
-      18538,
-      18539,
-      18540,
-      18541,
-      18543,
-      18544,
-      18545,
-      18547,
-      18548,
-      18550,
-      18552,
-      18553,
-      18554,
-      18555,
-      18556,
-      18557,
-      18558,
-      18565,
-      18567,
-      18568,
-      18570,
-      18571,
-      18573,
-      18574,
-      18575,
-      18576,
-      18577,
-      18579,
-      18583,
-      18585
+      "ELEM1_QIP_WALL1",
+      "ELEM1_QIP_WALL2",
+      "ELEM1_QIP_WALL2A",
+      "ELEM1_QIP_WALL2B",
+      "ELEM1_QIP_WALL3",
+      "ELEM1_QIP_WALL3A",
+      "ELEM1_QIP_WALL3B",
+      "ELEM1_QIP_WALL4",
+      "ELEM1_QIP_WALL4A",
+      "ELEM1_QIP_WALL4C",
+      "ELEM1_QIP_WALL5",
+      "ELEM1_QIP_WALL6",
+      "ELEM1_QIP_WALL6A",
+      "ELEM1_QIP_WALL6B",
+      "ELEM1_QIP_WALL6C",
+      "ELEM1_QIP_WALL_WATERWAY",
+      "ELEM1_QIP_WALL_SAND",
+      "ELEM1_QIP_WALL_SPCL",
+      "ELEM1_QIP_WALL2TO3",
+      "ELEM1_QIP_WALL2TO3MIRROR",
+      "ELEM1_QIP_WALL2TO3B",
+      "ELEM1_QIP_WALL2TO3BMIRROR",
+      "ELEM1_QIP_WALL2TO3CMIRROR",
+      "ELEM1_QIP_WALL2TO2",
+      "ELEM1_QIP_WALL3TO6",
+      "ELEM1_QIP_WALL3TO3",
+      "ELEM1_QIP_WALL3TO4A",
+      "ELEM1_QIP_WALL6TO3",
+      "ELEM1_QIP_GIRDER_WALL3",
+      "ELEM1_QIP_WALL_TOP"
     ]
   },
   {
@@ -30144,14 +30144,14 @@
     "baseMaterial": "ROCK_3",
     "uvType": "BOX",
     "uvScale": 0.8,
-    "objectIds": [ 4919 ]
+    "objectIds": [ "HAUNTEDMINE_MAIN_ENTRANCE" ]
   },
   {
     "description": "Abandoned Mine Secret Exit",
     "baseMaterial": "ROCK_3",
     "uvType": "BOX",
     "uvScale": 0.75,
-    "objectIds": [ 4923, 4973 ]
+    "objectIds": [ "HAUNTEDMINE_MAIN_ENTRANCE_INSIDE", "HAUNTEDMINE_LIGHT_STAIRS_BOTTOM" ]
   },
   {
     "description": "Abandoned Mine cart tunnel with tracks",
@@ -30174,10 +30174,10 @@
       }
     ],
     "objectIds": [
-      4920,
-      15830,
-      20432,
-      29333
+      "HAUNTEDMINE_SECONDARY_ENTRANCE_INSIDE",
+      "LOTR_BACK_ENTRANCE1_INSIDE",
+      "LOTR_MINE_TUNNEL_CART",
+      "HAUNTEDMINE_CRYSTALSHORTCUT_EXIT"
     ]
   },
   {
@@ -30194,9 +30194,9 @@
       }
     ],
     "objectIds": [
-      15792,
-      15793,
-      15794
+      "LOTR_MINE_WALL_SUPPORT_LEFT",
+      "LOTR_MINE_WALL_SUPPORT_RIGHT",
+      "LOTR_MINE_WALL_SUPPORT_MID"
     ]
   },
   {
@@ -30222,7 +30222,7 @@
       }
     ],
     "objectIds": [
-      15791
+      "LOTR_MINE_WALL_SUPPORT"
     ]
   },
   {
@@ -30245,7 +30245,7 @@
       }
     ],
     "objectIds": [
-      15796
+      "LOTR_MINE_WALL_LAMP"
     ]
   },
   {
@@ -30254,13 +30254,13 @@
     "uvType": "BOX",
     "uvScale": 0.75,
     "objectIds": [
-      15788,
-      15789,
-      15790,
-      20439,
-      20440,
-      20441,
-      20442
+      "LOTR_MINE_WALL_BLEND_05",
+      "LOTR_MINE_WALL",
+      "LOTR_MINE_WALL_ROCKY",
+      "LOTR_MINE_WALL_DEPLETED_R",
+      "LOTR_MINE_WALL_DEPLETED_MID",
+      "LOTR_MINE_WALL_DEPLETED_L",
+      "LOTR_MINE_WALL_DEPLETED_SINGLE"
     ]
   },
   {
@@ -30287,9 +30287,9 @@
       }
     ],
     "objectIds": [
-      4939,
-      4940,
-      4941
+      "LIFT_BACK_L",
+      "LIFT_BACK",
+      "LIFT_BACK_R"
     ]
   },
   {
@@ -30309,8 +30309,8 @@
       }
     ],
     "objectIds": [
-      4937,
-      4938
+      "LIFT_SIDE_L",
+      "LIFT_SIDE_R"
     ]
   },
   {
@@ -30327,7 +30327,7 @@
       }
     ],
     "objectIds": [
-      4949
+      "HAUNTEDMINE_POINTS_INFO"
     ]
   },
   {
@@ -30343,14 +30343,14 @@
       }
     ],
     "objectIds": [
-      15775,
-      15776,
-      15777,
-      15778,
-      15780,
-      15781,
-      15782,
-      15783
+      "LOTR_MINE_PIPE_WALL_01",
+      "LOTR_MINE_PIPE_WALL_02",
+      "LOTR_MINE_PIPE_WALL_03",
+      "LOTR_MINE_PIPE_WALL_04",
+      "LOTR_MINE_PIPE_WALL_06",
+      "LOTR_MINE_PIPE_WALL_07",
+      "LOTR_MINE_PIPE_WALL_08",
+      "LOTR_MINE_PIPE_WALL_09"
     ]
   },
   {
@@ -30366,8 +30366,8 @@
       }
     ],
     "objectIds": [
-      20427,
-      20428
+      "LOTR_MINE_WALL_WOOD_GATE_SUPPORT_L",
+      "LOTR_MINE_WALL_WOOD_GATE_SUPPORT_R"
     ]
   },
   {
@@ -30386,10 +30386,10 @@
       }
     ],
     "objectIds": [
-      20407,
-      20443,
-      20444,
-      20445
+      "LOTR_MINE_WALL_TIN_MID",
+      "LOTR_MINE_WALL_TIN_L",
+      "LOTR_MINE_WALL_TIN_R",
+      "LOTR_MINE_WALL_TIN_SINGLE"
     ]
   },
   {
@@ -30408,10 +30408,10 @@
       }
     ],
     "objectIds": [
-      20408,
-      20446,
-      20447,
-      20448
+      "LOTR_MINE_WALL_COPPER_MID",
+      "LOTR_MINE_WALL_COPPER_L",
+      "LOTR_MINE_WALL_COPPER_R",
+      "LOTR_MINE_WALL_COPPER_SINGLE"
     ]
   },
   {
@@ -30430,10 +30430,10 @@
       }
     ],
     "objectIds": [
-      20422,
-      20423,
-      20424,
-      20425
+      "LOTR_MINE_WALL_IRON_L",
+      "LOTR_MINE_WALL_IRON_R",
+      "LOTR_MINE_WALL_IRON_SINGLE",
+      "LOTR_MINE_WALL_IRON_MID"
     ]
   },
   {
@@ -30452,10 +30452,10 @@
       }
     ],
     "objectIds": [
-      20410,
-      20411,
-      20412,
-      20413
+      "LOTR_MINE_WALL_COAL_L",
+      "LOTR_MINE_WALL_COAL_R",
+      "LOTR_MINE_WALL_COAL_SINGLE",
+      "LOTR_MINE_WALL_COAL_MID"
     ]
   },
   {
@@ -30474,10 +30474,10 @@
       }
     ],
     "objectIds": [
-      20418,
-      20419,
-      20420,
-      20421
+      "LOTR_MINE_WALL_MITHRIL_L",
+      "LOTR_MINE_WALL_MITHRIL_R",
+      "LOTR_MINE_WALL_MITHRIL_SINGLE",
+      "LOTR_MINE_WALL_MITHRIL_MID"
     ]
   },
   {
@@ -30496,10 +30496,10 @@
       }
     ],
     "objectIds": [
-      20414,
-      20415,
-      20416,
-      20417
+      "LOTR_MINE_WALL_ADAMANT_L",
+      "LOTR_MINE_WALL_ADAMANT_R",
+      "LOTR_MINE_WALL_ADAMANT_SINGLE",
+      "LOTR_MINE_WALL_ADAMANT_MID"
     ]
   },
   {
@@ -30518,8 +30518,8 @@
       }
     ],
     "objectIds": [
-      20449,
-      20450
+      "LOTR_MINE_WALL_CLAY_L",
+      "LOTR_MINE_WALL_CLAY_R"
     ]
   },
   {
@@ -30528,7 +30528,7 @@
     "uvType": "WORLD_XZ",
     "uvScale": 1.2,
     "objectIds": [
-      15804
+      "LOTR_MINE_WALL_TOP"
     ]
   },
   {
@@ -30537,8 +30537,8 @@
     "uvType": "BOX",
     "uvScale": 1.1,
     "objectIds": [
-      4932,
-      4933
+      "GLOWING_MUSHROOM",
+      "GLOWING_MUSHROOM2"
     ]
   },
   {
@@ -30557,18 +30557,18 @@
       }
     ],
     "objectIds": [
-      4950,
-      4951,
-      4952,
-      4953,
-      4954,
-      4955,
-      4956,
-      4957,
-      4958,
-      4959,
-      4960,
-      4961
+      "HAUNTEDMINE_POINT_LEVER1",
+      "HAUNTEDMINE_POINT_LEVER2",
+      "HAUNTEDMINE_POINT_LEVER3",
+      "HAUNTEDMINE_POINT_LEVER4",
+      "HAUNTEDMINE_POINT_LEVER5",
+      "HAUNTEDMINE_POINT_LEVER6",
+      "HAUNTEDMINE_POINT_LEVER7",
+      "HAUNTEDMINE_POINT_LEVER8",
+      "HAUNTEDMINE_POINT_LEVER_INACTIVE",
+      "HAUNTEDMINE_POINT_LEVER_FLOODED9",
+      "HAUNTEDMINE_POINT_LEVER_FLOODED10",
+      "HAUNTEDMINE_POINT_LEVER_FLOODED11"
     ]
   },
   {
@@ -30577,8 +30577,8 @@
     "uvType": "BOX",
     "uvScale": 0.75,
     "objectIds": [
-      4946,
-      4948
+      "CAVEWALL_HOLE",
+      "CAVEWALL_HOLE_CORNER"
     ]
   },
   {
@@ -30588,7 +30588,7 @@
     "uvType": "BOX",
     "uvScale": 0.75,
     "objectIds": [
-      4947
+      "CAVEWALL_HOLE_BRIDGE"
     ]
   },
   {
@@ -30605,7 +30605,7 @@
       }
     ],
     "objectIds": [
-      4945
+      "MINE_CART_FLOODED"
     ]
   },
   {
@@ -30625,7 +30625,7 @@
       }
     ],
     "objectIds": [
-      4942
+      "LIFT_FLOODED"
     ]
   },
   {
@@ -30633,32 +30633,32 @@
     "baseMaterial": "STONE_NORMALED",
     "uvType": "BOX",
     "uvScale": 0.8,
-    "objectIds": [ 4971 ]
+    "objectIds": [ "HAUNTEDMINE_DARK_STAIRS_TOP" ]
   },
   {
     "description": "Crystal Outcrop - Haunted Mine crystals",
     "baseMaterial": "GRUNGE_3_LIGHT_SHINY",
     "uvType": "BOX",
     "objectIds": [
-      4927,
-      4928
+      "CRYSTALEDGING",
+      "LARGECRYSTALS"
     ]
   },
   {
     "description": "Hueycoatl Rocks",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      55205,
-      55234,
-      55249,
-      55250,
-      55251,
-      55252,
-      55253,
-      55254,
-      55256,
-      55259,
-      55260
+      "HUEY_HOLDING_ENTRANCE_INSTANCED",
+      "HUEY_FIGHT_EXIT_SHORTCUT",
+      "DF_CAVE_SNOW01_ROCKS01",
+      "DF_CAVE_SNOW01_ROCKS02",
+      "DF_CAVE_SNOW01_ROCKS02_M",
+      "DF_CAVE_SNOW01_ROCKS03",
+      "DF_CAVE_SNOW01_ROCKS04",
+      "DF_CAVE_ROCK01_ROCKS04",
+      "DF_CAVE_ROCK01_ROCKS06",
+      "DF_CAVE_SNOW01_FALLOFF01",
+      "DF_CAVE_ROCK01_FALLOFF01"
     ],
     "uvType": "BOX",
     "uvScale": 0.8
@@ -30666,10 +30666,10 @@
   {
     "description": "Hueycoatl Body Cave",
     "objectIds": [
-      55242,
-      55243,
-      55245,
-      55246
+      "DF_CAVE_SNOW01_ENTRANCE03",
+      "DF_CAVE_SNOW01_ENTRANCE03_HUEY",
+      "DF_CAVE_SNOW01_ENTRANCE03_DIAG",
+      "DF_CAVE_SNOW01_ENTRANCE03_DIAG_HUEY"
     ],
     "colorOverrides": [
       {
@@ -30685,8 +30685,8 @@
   {
     "description": "Hueycoatl Blockage Segment Caves",
     "objectIds": [
-      55206,
-      55207
+      "HUEY_P2_BARRIER",
+      "HUEY_P2_BARRIER_RETRACTED"
     ],
     "colorOverrides": [
       {
@@ -30697,8 +30697,8 @@
   },
   {
     "description": "Hueycoatl Tail Cave",
-    "objectIds": [ 55241 ],
-    "npcIds": [ 14014, 14015 ],
+    "objectIds": [ "DF_CAVE_SNOW01_ENTRANCE02" ],
+    "npcIds": [ "HUEY_TAIL", "HUEY_TAIL_BROKEN" ],
     "colorOverrides": [
       {
         "colors": [ 2 ],
@@ -30712,7 +30712,7 @@
   },
   {
     "description": "Hueycoatl",
-    "npcIds": [ 14009, 14010, 14011, 14012, 14013 ],
+    "npcIds": [ "HUEY_HEAD", "HUEY_HEAD_RESPAWN_PLACEHOLDER", "HUEY_HEAD_INVULNERABLE", "HUEY_HEAD_DEFEATED", "HUEY_HEAD_ENRAGED" ],
     "colorOverrides": [
       {
         "colors": [ "h == 0 && s == 0", "h == 63" ],
@@ -30725,38 +30725,38 @@
     "baseMaterial": "MARBLE_1",
     "uvType": "MODEL_XZ",
     "objectIds": [
-      55263,
-      55264,
-      55265,
-      55266,
-      55267,
-      55268,
-      55269,
-      55270,
-      55271,
-      55272,
-      55273,
-      55274,
-      55275,
-      55276,
-      55277,
-      55278,
-      55279,
-      55280,
-      55281,
-      55282,
-      55283,
-      55284,
-      55285,
-      55286,
-      55287,
-      55288,
-      55289,
-      55290,
-      55291,
-      55292,
-      55293,
-      55294
+      "DF_ALTAR_LOSANIUM01_DARKFROST01",
+      "DF_ALTAR_LOSANIUM01_DARKFROST02",
+      "DF_ALTAR_LOSANIUM01_DARKFROST03",
+      "DF_ALTAR_LOSANIUM01_DARKFROST04",
+      "DF_ALTAR_LOSANIUM01_DARKFROST04_M",
+      "DF_ALTAR_LOSANIUM01_DARKFROST05",
+      "DF_ALTAR_LOSANIUM01_DARKFROST05_M",
+      "DF_ALTAR_LOSANIUM01_DARKFROST06",
+      "DF_ALTAR_LOSANIUM01_DARKFROST06_M",
+      "DF_ALTAR_LOSANIUM01_DARKFROST07",
+      "FLOORKIT_LOSANIUM01_DARKFROST08",
+      "FLOORKIT_LOSANIUM01_DARKFROST09",
+      "FLOORKIT_LOSANIUM01_DARKFROST10",
+      "FLOORKIT_LOSANIUM01_DARKFROST11",
+      "FLOORKIT_LOSANIUM01_DARKFROST12",
+      "FLOORKIT_LOSANIUM01_DARKFROST13",
+      "FLOORKIT_LOSANIUM01_DARKFROST14",
+      "FLOORKIT_LOSANIUM01_DARKFROST15",
+      "FLOORKIT_LOSANIUM01_DARKFROST16",
+      "FLOORKIT_LOSANIUM01_DARKFROST17",
+      "FLOORKIT_LOSANIUM01_DARKFROST18",
+      "FLOORKIT_LOSANIUM01_DARKFROST19",
+      "FLOORKIT_LOSANIUM01_DARKFROST20",
+      "FLOORKIT_LOSANIUM01_DARKFROST21",
+      "FLOORKIT_LOSANIUM01_DARKFROST22",
+      "FLOORKIT_LOSANIUM01_DARKFROST22_M",
+      "FLOORKIT_LOSANIUM01_DARKFROST23",
+      "FLOORKIT_LOSANIUM01_DARKFROST24",
+      "FLOORKIT_LOSANIUM01_DARKFROST25",
+      "FLOORKIT_LOSANIUM01_DARKFROST26",
+      "FLOORKIT_LOSANIUM01_DARKFROST27",
+      "FLOORKIT_LOSANIUM01_DARKFROST28"
     ]
   },
   {
@@ -30765,8 +30765,8 @@
     "uvType": "BOX",
     "uvScale": 0.75,
     "objectIds": [
-      55201,
-      55202
+      "HUEY_FIGHT_ENTRANCE_INAREA",
+      "HUEY_FIGHT_ENTRANCE_OUTAREA"
     ],
     "colorOverrides": [
       {
@@ -30781,14 +30781,14 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      55198
+      "HUEY_SCOREBOARD"
     ]
   },
   {
     "description": "Hueycoatl Tent",
     "baseMaterial": "SNOW_1",
     "objectIds": [
-      55261
+      "DF_TENT_MOUNTAIN01_DWARF01"
     ],
     "colorOverrides": [
       {
@@ -30803,7 +30803,7 @@
     "description": "Hueycoatl Campfire Frame",
     "baseMaterial": "METALLIC_1_GLOSS",
     "objectIds": [
-      55200
+      "HUEY_LOBBY_COOKINGFIRE"
     ],
     "colorOverrides": [
       {
@@ -30818,7 +30818,7 @@
   {
     "description": "Hueycoatl Campfire Fire",
     "objectIds": [
-      19882
+      "EAGLEPEAK_CAMPFIRE_FIRE_TIDY"
     ],
     "colorOverrides": [
       {
@@ -30836,12 +30836,12 @@
     "uvScale": 0.5,
     "uvOrientation": 256,
     "objectIds": [
-      55210,
-      55211,
-      55218,
-      55219,
-      55226,
-      55227
+      "HUEY_PRAYER_PILLAR_MAGIC_BRAZIER_ON",
+      "HUEY_PRAYER_PILLAR_MAGIC_BRAZIER_OFF",
+      "HUEY_PRAYER_PILLAR_RANGED_BRAZIER_ON",
+      "HUEY_PRAYER_PILLAR_RANGED_BRAZIER_OFF",
+      "HUEY_PRAYER_PILLAR_MELEE_BRAZIER_ON",
+      "HUEY_PRAYER_PILLAR_MELEE_BRAZIER_OFF"
     ],
     "colorOverrides": [
       {
@@ -30871,9 +30871,9 @@
       }
     ],
     "objectIds": [
-      11638,
-      11639,
-      11640
+      "WEREWOLF_HURDLE_MID",
+      "WEREWOLF_HURDLE_END",
+      "WEREWOLF_HURDLE_END_MIRROR"
     ]
   },
   {
@@ -30898,12 +30898,12 @@
       }
     ],
     "objectIds": [
-      11644,
-      11645,
-      11646,
-      11647,
-      11648,
-      11649
+      "WEREWOLF_SLIDE_CENTER",
+      "WEREWOLF_SLIDE_SIDE",
+      "WEREWOLF_SLIDE_SIDE_MIRROR",
+      "WEREWOLF_SLIDE_CENTER_NONACTIVE",
+      "WEREWOLF_SLIDE_SIDE_NONACTIVE",
+      "WEREWOLF_SLIDE_SIDE_MIRROR_NONACTIVE"
     ]
   },
   {
@@ -30911,14 +30911,14 @@
     "baseMaterial": "ROPE",
     "uvType": "BOX",
     "uvOrientation": 128,
-    "objectIds": [ 11650 ]
+    "objectIds": [ "WEREWOLF_SLIDE_ROPE" ]
   },
   {
     "description": "Werewolf - Agility Course - Spikes",
     "baseMaterial": "METALLIC_1_LIGHT_HIGHGLOSS",
     "objectIds": [
-      11658,
-      11660
+      "WAA_SPIKES_1",
+      "WAA_SPIKES_3"
     ]
   },
   {
@@ -30934,7 +30934,7 @@
       }
     ],
     "objectIds": [
-      11659
+      "WAA_SPIKES_2"
     ]
   },
   {
@@ -30953,8 +30953,8 @@
       }
     ],
     "objectIds": [
-      11652,
-      11653
+      "WEREWOLF_GOAL_LEFT",
+      "WEREWOLF_GOAL_RIGHT"
     ]
   },
   {
@@ -30964,7 +30964,7 @@
     "uvOrientation": 343,
     "uvScale": 0.6,
     "objectIds": [
-      11651
+      "WEREWOLF_GOAL_MID"
     ]
   },
   {
@@ -30973,8 +30973,8 @@
     "uvType": "MODEL_XZ",
     "uvOrientation": 343,
     "objectIds": [
-      11654,
-      11655
+      "WEREWOLF_ARROW",
+      "WEREWOLF_SPOT"
     ]
   },
   {
@@ -30982,32 +30982,32 @@
     "baseMaterial": "CARPET",
     "uvType": "MODEL_XZ",
     "objectIds": [
-      37674,
-      37675,
-      37676,
-      37677,
-      37678,
-      37680,
-      37681,
-      37682,
-      37683,
-      37684,
-      37685,
-      37686,
-      37687,
-      37688,
-      37689,
-      37690,
-      37691,
-      37692,
-      37693,
-      37694,
-      37695,
-      37696,
-      37697,
-      37698,
-      37699,
-      37700
+      "NIGHTMARE_PLATFORM_LVL2_01",
+      "NIGHTMARE_PLATFORM_LVL2_02",
+      "NIGHTMARE_PLATFORM_LVL2_03",
+      "NIGHTMARE_PLATFORM_LVL2_04",
+      "NIGHTMARE_PLATFORM_LVL2_05",
+      "NIGHTMARE_PLATFORM_LVL2_08",
+      "NIGHTMARE_PLATFORM_LVL2_09",
+      "NIGHTMARE_PLATFORM_LVL2_10",
+      "NIGHTMARE_PLATFORM_LVL2_11",
+      "NIGHTMARE_PLATFORM_LVL2_12",
+      "NIGHTMARE_PLATFORM_LVL2_13",
+      "NIGHTMARE_PLATFORM_LVL2_14",
+      "NIGHTMARE_PLATFORM_LVL2_15",
+      "NIGHTMARE_PLATFORM_LVL2_16",
+      "NIGHTMARE_PLATFORM_LVL2_17",
+      "NIGHTMARE_PLATFORM_LVL2_18",
+      "NIGHTMARE_PLATFORM_LVL2_19",
+      "NIGHTMARE_PLATFORM_LVL2_20",
+      "NIGHTMARE_PLATFORM_LVL2_21",
+      "NIGHTMARE_PLATFORM_LVL2_22",
+      "NIGHTMARE_PLATFORM_LVL2_23",
+      "NIGHTMARE_PLATFORM_LVL2_24",
+      "NIGHTMARE_PLATFORM_LVL2_25",
+      "NIGHTMARE_PLATFORM_LVL2_26",
+      "NIGHTMARE_PLATFORM_LVL2_27",
+      "NIGHTMARE_PLATFORM_LVL2_28"
     ],
     "colorOverrides": [
       {
@@ -31029,11 +31029,11 @@
     "description": "Nightmare of Ashihama - Arena Fence",
     "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
     "objectIds": [
-      37701,
-      37702,
-      37703,
-      37704,
-      37705
+      "NIGHTMARE_PLATFORM_LVL3_01",
+      "NIGHTMARE_PLATFORM_LVL3_01_MIRROR",
+      "NIGHTMARE_PLATFORM_LVL3_02",
+      "NIGHTMARE_PLATFORM_LVL3_03",
+      "NIGHTMARE_PLATFORM_LVL3_04"
     ],
     "colorOverrides": [
       {
@@ -31051,13 +31051,13 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      37637,
-      37638,
-      37639,
-      37640,
-      37642,
-      37643,
-      37644
+      "NIGHTMARE_GARDEN_WALKWAY_FALLOFF_LEFT_SIDE",
+      "NIGHTMARE_GARDEN_WALKWAY_FALLOFF_LEFT_SIDE_REAR",
+      "NIGHTMARE_GARDEN_WALKWAY_FALLOFF_RIGHT_SIDE",
+      "NIGHTMARE_GARDEN_WALKWAY_FALLOFF_RIGHT_SIDE_REAR",
+      "NIGHTMARE_GARDEN_GATE_02",
+      "NIGHTMARE_GARDEN_GATE_03",
+      "NIGHTMARE_GARDEN_GATE_04"
     ],
     "colorOverrides": [
       {
@@ -31074,27 +31074,27 @@
     "uvType": "BOX",
     "uvScale": 0.75,
     "objectIds": [
-      37636,
-      37646,
-      37651,
-      37652,
-      37653,
-      37658,
-      37659,
-      37660,
-      37661,
-      37662,
-      37663,
-      37664,
-      37665,
-      37666,
-      37667,
-      37668,
-      37669,
-      37670,
-      37671,
-      37672,
-      37673
+      "NIGHTMARE_GARDEN_WALKWAY_FALLOFF",
+      "NIGHTMARE_PLATFORM_LVL0_01",
+      "NIGHTMARE_PLATFORM_LVL0_06",
+      "NIGHTMARE_PLATFORM_LVL0_07",
+      "NIGHTMARE_PLATFORM_LVL0_08",
+      "NIGHTMARE_PLATFORM_LVL1_01",
+      "NIGHTMARE_PLATFORM_LVL1_02",
+      "NIGHTMARE_PLATFORM_LVL1_03",
+      "NIGHTMARE_PLATFORM_LVL1_04",
+      "NIGHTMARE_PLATFORM_LVL1_05",
+      "NIGHTMARE_PLATFORM_LVL1_06",
+      "NIGHTMARE_PLATFORM_LVL1_07",
+      "NIGHTMARE_PLATFORM_LVL1_08",
+      "NIGHTMARE_PLATFORM_LVL1_09",
+      "NIGHTMARE_PLATFORM_LVL1_10",
+      "NIGHTMARE_PLATFORM_LVL1_11",
+      "NIGHTMARE_PLATFORM_LVL1_12",
+      "NIGHTMARE_PLATFORM_LVL1_13",
+      "NIGHTMARE_PLATFORM_LVL1_14",
+      "NIGHTMARE_PLATFORM_LVL1_15",
+      "NIGHTMARE_PLATFORM_LVL1_16"
     ],
     "colorOverrides": [
       {
@@ -31110,14 +31110,14 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "objectIds": [
-      37647,
-      37648,
-      37649,
-      37650,
-      37654,
-      37655,
-      37656,
-      37657
+      "NIGHTMARE_PLATFORM_LVL0_02",
+      "NIGHTMARE_PLATFORM_LVL0_03",
+      "NIGHTMARE_PLATFORM_LVL0_04",
+      "NIGHTMARE_PLATFORM_LVL0_05",
+      "NIGHTMARE_PLATFORM_LVL0_09",
+      "NIGHTMARE_PLATFORM_LVL0_10",
+      "NIGHTMARE_PLATFORM_LVL0_11",
+      "NIGHTMARE_PLATFORM_LVL0_12"
 
     ],
     "colorOverrides": [
@@ -31134,18 +31134,18 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "npcIds": [
-      9434,
-      9435,
-      9436,
-      9437,
-      9438,
-      9439,
-      9440,
-      9441,
-      9442,
-      9443,
-      9444,
-      9445
+      "NIGHTMARE_TOTEM_1_DORMANT",
+      "NIGHTMARE_TOTEM_1_READY",
+      "NIGHTMARE_TOTEM_1_CHARGED",
+      "NIGHTMARE_TOTEM_2_DORMANT",
+      "NIGHTMARE_TOTEM_2_READY",
+      "NIGHTMARE_TOTEM_2_CHARGED",
+      "NIGHTMARE_TOTEM_3_DORMANT",
+      "NIGHTMARE_TOTEM_3_READY",
+      "NIGHTMARE_TOTEM_3_CHARGED",
+      "NIGHTMARE_TOTEM_4_DORMANT",
+      "NIGHTMARE_TOTEM_4_READY",
+      "NIGHTMARE_TOTEM_4_CHARGED"
     ],
     "colorOverrides": [
       {
@@ -31172,9 +31172,9 @@
     "uvType": "MODEL_XZ",
     "uvScale": 0.75,
     "objectIds": [
-      37719,
-      37720,
-      37721
+      "NIGHTMARE_GARDEN_ISLAND_01",
+      "NIGHTMARE_GARDEN_ISLAND_02",
+      "NIGHTMARE_GARDEN_ISLAND_03"
 
     ],
     "colorOverrides": [
@@ -31214,7 +31214,7 @@
       }
     ],
     "objectIds": [
-      42594
+      "ARAXYTE_CAVE_ENTRY"
     ]
   },
   {
@@ -31231,7 +31231,7 @@
       }
     ],
     "objectIds": [
-      42649
+      "REGICIDE_TREE_DEAD1SWAMP_WEB"
     ]
   },
   {
@@ -31248,7 +31248,7 @@
       }
     ],
     "objectIds": [
-      4053
+      "REGICIDE_TREE_DEAD1SWAMP"
     ]
   },
   {
@@ -31258,9 +31258,9 @@
     "uvScale": 1.2,
     "uvType": "BOX",
     "objectIds": [
-      42596,
-      42597,
-      54186
+      "ARAXYTE_CAVE_WALL_TOP",
+      "ARAXYTE_CAVE_WALL_TOP02",
+      "CAVEKIT_ARAXXOR_CAVETOP"
     ]
   },
   {
@@ -31269,12 +31269,12 @@
     "uvOrientation": 256,
     "uvType": "BOX",
     "objectIds": [
-      42598,
-      42599,
-      42600,
-      54189,
-      54190,
-      54191
+      "ARAXYTE_CAVE_WALL_TOP03",
+      "ARAXYTE_CAVE_WALL_TOP04",
+      "ARAXYTE_CAVE_WALL_TOP05",
+      "CAVEKIT_ARAXXOR_CAVETOP_WALLTOP02",
+      "CAVEKIT_ARAXXOR_CAVETOP_WALLTOP03",
+      "CAVEKIT_ARAXXOR_CAVETOP_WALLTOP04"
     ]
   },
   {
@@ -31295,12 +31295,12 @@
       }
     ],
     "objectIds": [
-      42610,
-      42611,
-      42612,
-      42613,
-      54167,
-      54183
+      "CAVEKIT_WEB01_DEFAULT01",
+      "CAVEKIT_WEB01_BLOOD01",
+      "CAVEKIT_WEB01_STRAND01",
+      "CAVEKIT_WEB01_STRAND02",
+      "CAVEKIT_WEB04_BLOOD01",
+      "CAVEKIT_WEB03_STRAND01_BLOOD01"
     ]
   },
   {
@@ -31321,7 +31321,7 @@
       }
     ],
     "objectIds": [
-      42595
+      "ARAXYTE_CAVE_EXIT"
     ]
   },
   {
@@ -31342,9 +31342,9 @@
       }
     ],
     "objectIds": [
-      54152,
-      54154,
-      54159
+      "ARAXXOR_CAVE_OUTER_TUNNEL_OP",
+      "ARAXXOR_CAVE_OUTER_TUNNEL_NOOP",
+      "ARAXXOR_CAVE_OUTER_TUNNEL_OP_4"
     ]
   },
   {
@@ -31361,10 +31361,10 @@
       }
     ],
     "objectIds": [
-      42629,
-      54215,
-      54216,
-      54222
+      "DECOKIT_WEB01_HANGING01",
+      "ARAXXOR_STALAGMITE02_WEBBED01",
+      "ARAXXOR_STALAGMITE02_WEBBED02",
+      "ARAXXOR_WEBSACK02_STALAGMITE01"
     ]
   },
   {
@@ -31381,27 +31381,27 @@
       }
     ],
     "objectIds": [
-      54150
+      "ARAXXOR_SCOREBOARD_DISABLED"
     ]
   },
   {
     "description": "Theatre of Blood - Verzik Stone Floor",
     "baseMaterial": "BLANK_SEMIGLOSS",
     "objectIds": [
-      32719,
-      32721,
-      32722,
-      32723,
-      32724,
-      32725,
-      32726,
-      32727,
-      32728,
-      32729,
-      32730,
-      32731,
-      32732,
-      32733
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_A",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_B",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_C",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_D",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_E",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_F",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_G",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_H",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_MIDDLE_I",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_CARPET_EDGE",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_OUTSIDE_STRAIGHT_A",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_OUTSIDE_STRAIGHT_B",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_OUTSIDE_CORNER",
+      "TOB_DUNGEON_VERZIK_FLOOR_TILE_OUTSIDE_STRAIGHT_A_END"
     ],
     "uvType": "MODEL_XZ"
   },
@@ -31410,7 +31410,7 @@
     "baseMaterial": "ROCK_3",
     "uvScale": 1.2,
     "objectIds": [
-      32699
+      "TOB_DUNGEON_VERZIK_THRONE_WALL"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -31426,9 +31426,9 @@
     "baseMaterial": "ROCK_3",
     "uvScale": 1.2,
     "objectIds": [
-      32697,
-      32693,
-      32694
+      "TOB_DUNGEON_VERZIK_THRONE_WALL_WINDOW",
+      "TOB_DUNGEON_VERZIK_THRONE_RIGHT_SIDE",
+      "TOB_DUNGEON_VERZIK_THRONE_LEFT_SIDE"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -31442,7 +31442,7 @@
     "description": "Theatre of Blood - Verzik Walls - Big Window",
     "baseMaterial": "GRAY_90",
     "objectIds": [
-      32691
+      "TOB_DUNGEON_VERZIK_THRONE_WINDOW"
     ],
     "colorOverrides": [
       {
@@ -31455,19 +31455,19 @@
     "description": "Theatre of Blood - Verzik - Throne",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      32702,
-      32703,
-      32704,
-      32705,
-      32706,
-      32707,
-      32708,
-      32709,
-      32710,
-      32711,
-      32712,
-      32737,
-      32738
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_RIGHT_SIDE",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_LEFT_SIDE",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_RIGHT_SIDE_BOTTOM",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_LEFT_SIDE_BOTOM",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_BLANK",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_STEPS_TOP_LEFT",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_STEPS_TOP_MIDDLE",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_STEPS_TOP_RIGHT",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_STEPS_LEFT",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_STEPS_MIDDLE",
+      "TOB_DUNGEON_VERZIK_THRONE_FLOOR_STEPS_RIGHT",
+      "TOB_DUNGEON_VERZIK_THRONE_TRANSFORMING",
+      "TOB_DUNGEON_VERZIK_THRONE_DOOR_OPENED"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -31483,15 +31483,15 @@
     "baseMaterial": "ROCK_3",
     "uvScale": 1.2,
     "objectIds": [
-      32687,
-      32692,
-      32695,
-      32696,
-      32700,
-      32701,
-      32713,
-      32714,
-      32715
+      "TOB_DUNGEON_VERZIK_PILLAR",
+      "TOB_DUNGEON_VERZIK_THRONE_WINDOW_BACK",
+      "TOB_DUNGEON_VERZIK_THRONE_RIGHT_SIDE_BACK",
+      "TOB_DUNGEON_VERZIK_THRONE_LEFT_SIDE_BACK",
+      "TOB_DUNGEON_VERZIK_THRONE_WALL_CORNER",
+      "TOB_DUNGEON_VERZIK_ENTRANCE_DOOR",
+      "TOB_DUNGEON_VERZIK_THRONE_SIDE_BLOCKER",
+      "TOB_DUNGEON_VERZIK_THRONE_SIDE_BLOCKER_END_RIGHT",
+      "TOB_DUNGEON_VERZIK_THRONE_SIDE_BLOCKER_END_LEFT"
     ],
     "uvType": "BOX"
   },
@@ -31499,32 +31499,32 @@
     "description": "Theatre of Blood - Verzik Crumbling Pillar",
     "baseMaterial": "ROCK_3",
     "uvScale": 1.2,
-    "npcIds": [ 8377 ],
+    "npcIds": [ "VERZIK_COLLAPSING_PILLAR_NPC" ],
     "uvType": "BOX"
   },
   {
     "description": "Theatre of Blood - Treasure Room Walls",
     "baseMaterial": "MARBLE_2",
     "objectIds": [
-      32995,
-      32997,
-      32998,
-      32999,
-      33000,
-      33001,
-      33002,
-      33003,
-      33005,
-      33006,
-      33007,
-      33008,
-      33009,
-      33010,
-      33021,
-      33022,
-      33023,
-      33024,
-      33025
+      "TOB_TREASUREROOM_STAIRSUP",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_BLANK",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_INSIDE_CORNER",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_OUTSIDE_CORNER",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_BOOKCASE_A",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_BOOKCASE_B",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_BOOKCASE_C",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_BOOKCASE_D",
+      "TOB_DUNGEON_TREASURE_ROOM_STAIRS_RIGHT",
+      "TOB_DUNGEON_TREASURE_ROOM_STAIRS_LEFT",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_FENCE_CONNECTOR_LEFT",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_FENCE_CONNECTOR_RIGHT",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_FENCE_LEFT",
+      "TOB_DUNGEON_TREASURE_ROOM_WALL_FENCE_RIGHT",
+      "TOB_DUNGEON_TREASURE_ROOM_SPECTATOR_WALL_STRAIGHT",
+      "TOB_DUNGEON_TREASURE_ROOM_SPECTATOR_WALL_CORNER",
+      "TOB_DUNGEON_TREASURE_ROOM_SPECTATOR_WALL_CONNECTOR_LEFT",
+      "TOB_DUNGEON_TREASURE_ROOM_SPECTATOR_WALL_CONNECTOR_RIGHT",
+      "TOB_DUNGEON_TREASURE_ROOM_SPECTATOR_WALL_GATE"
     ],
     "uvType": "BOX",
     "uvOrientation": 100,
@@ -31548,52 +31548,52 @@
     "description": "Theatre of Blood - Stone Floor",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      32784,
-      32785,
-      32786,
-      32787,
-      32788,
-      32789,
-      32790,
-      32791,
-      32792,
-      32793,
-      32816,
-      32817,
-      32818,
-      32819,
-      32820,
-      32821,
-      32822,
-      32823,
-      32824,
-      32825,
-      32826,
-      32827,
-      32828,
-      32829,
-      32830,
-      32831,
-      32832,
-      32834,
-      32835,
-      32836,
-      32837,
-      32838,
-      32839,
-      32840,
-      32841,
-      32842,
-      32843,
-      32844,
-      32845,
-      32846,
-      32847,
-      32848,
-      32849,
-      32850,
-      32851,
-      32852
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_01",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_02",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_03",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_TALL_01",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_TALL_02",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_TALL_03",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_TALL_04",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_HIGHER_01",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_HIGHER_02",
+      "TOB_DUNGEON_WALKWAY_TOP_STEPS_HIGHER_03",
+      "TOB_DUNGEON_WALKWAY_FLOOR_BLANK",
+      "TOB_DUNGEON_WALKWAY_FLOOR_BLANK_TRIM",
+      "TOB_DUNGEON_WALKWAY_FLOOR_A",
+      "TOB_DUNGEON_WALKWAY_FLOOR_B",
+      "TOB_DUNGEON_WALKWAY_FLOOR_C",
+      "TOB_DUNGEON_WALKWAY_FLOOR_A_CORNER",
+      "TOB_DUNGEON_WALKWAY_FLOOR_C_CORNER",
+      "TOB_DUNGEON_WALKWAY_FLOOR_A_NOTRIM",
+      "TOB_DUNGEON_WALKWAY_FLOOR_C_NOTRIM",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_A",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_B",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_C",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_D",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_E",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_F",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_G",
+      "TOB_DUNGEON_WALKWAY_FLOOR_CORNER_H",
+      "TOB_DUNGEON_WALKWAY_FLOOR_WIDE_A",
+      "TOB_DUNGEON_WALKWAY_FLOOR_WIDE_B",
+      "TOB_DUNGEON_WALKWAY_FLOOR_WIDE_C",
+      "TOB_DUNGEON_WALKWAY_FLOOR_WIDE_D",
+      "TOB_DUNGEON_WALKWAY_FLOOR_END_A",
+      "TOB_DUNGEON_WALKWAY_FLOOR_END_B",
+      "TOB_DUNGEON_WALKWAY_FLOOR_END_C",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_A",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_B",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_C",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_D",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_E",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_F",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_G",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_H",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_I",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_J",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_K",
+      "TOB_DUNGEON_WALKWAY_CORNER_LARGE_L"
     ],
     "uvType": "MODEL_XZ",
     "uvOrientation": 100
@@ -31602,75 +31602,75 @@
     "description": "Theatre of Blood - Stone Walls",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      32763,
-      32764,
-      32765,
-      32766,
-      32767,
-      32768,
-      32769,
-      32770,
-      32771,
-      32772,
-      32775,
-      32776,
-      32777,
-      32781,
-      32782,
-      32783,
-      32794,
-      32795,
-      32796,
-      32797,
-      32798,
-      32799,
-      32800,
-      32801,
-      32802,
-      32803,
-      32804,
-      32805,
-      32806,
-      32807,
-      32810,
-      32811,
-      32812,
-      32813,
-      32814,
-      32815,
-      32866,
-      32867,
-      32868,
-      32869,
-      32870,
-      32871,
-      32872,
-      32873,
-      32967,
-      32974,
-      33038,
-      33039,
-      33040,
-      33041,
-      33042,
-      33043,
-      33044,
-      33045,
-      33046,
-      33047,
-      33048,
-      33049,
-      33050,
-      33051,
-      33053,
-      33054,
-      33055,
-      33056,
-      33057,
-      33058,
-      33060,
-      33061,
-      33062
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_CLEAN",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_PIPE",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_CORNER",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_DEATH_FLOOR_TILE",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_DEATH_MIDDLE_LEFT",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_DEATH_MIDDLE_RIGHT",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_DEATH_LEFT",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_DEATH_RIGHT",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_DEATH_MIDDLE_RIGHT_LVL2",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_DEATH_MIDDLE_LEFT_LVL2",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_BATLAMP",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_TALL",
+      "TOB_DUNGEON_WALKWAY_TOP_CORNER",
+      "TOB_DUNGEON_WALKWAY_TOP_CORNER_NOTILE",
+      "TOB_DUNGEON_WALKWAY_TOP_CORNER_BLANKTILE",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_STEPS",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_STEPS_MIRROR",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_STEPS",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_TALL_OUTSIDE_CORNER",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_TALL_STEP_TRANSITION_INSIDE_CORNER",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_TALL_STEP_TRANSITION_INSIDE_CORNER_MIRROR",
+      "TOB_DUNGEON_WALKWAY_TOP_SIDE_STEPS_MIRROR",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_TALL_STEPS",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_TALL_STEPS_MIRROR_END",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_TALL_STEPS_END",
+      "TOB_DUNGEON_WALKWAY_BOTTOM_SIDE_TALL_STEPS_MIRROR",
+      "TOB_DUNGEON_WALKWAY_TOP_ENTRANCE_STEPS_STATUE_LEFT",
+      "TOB_DUNGEON_WALKWAY_TOP_ENTRANCE_STEPS_STATUE_RIGHT",
+      "TOB_DUNGEON_WALKWAY_TOP_ENTRANCE_STEPS_EDGE",
+      "TOB_DUNGEON_WALKWAY_EXIT_SIDE",
+      "TOB_DUNGEON_WALKWAY_EXIT_SIDE_MIRROR",
+      "TOB_DUNGEON_WALKWAY_EXIT_FRONT",
+      "TOB_DUNGEON_WALKWAY_EXIT_STEPS_DOWN",
+      "TOB_DUNGEON_WALKWAY_EXIT_STEPS_UP",
+      "TOB_DUNGEON_WALKWAY_ENTRANCE_FRONT",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_STATUE_LEFT",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_STATUE_RIGHT",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_UPPER_STEPS_LEFT",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_UPPER_STEPS_RIGHT",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_LANDING_STRAIGHT_LEFT",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_LANDING_STRAIGHT_RIGHT",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_SIDE_TALL_STEPS",
+      "TOB_DUNGEON_NYLOCAS_WALKWAY_SIDE_TALL_STEPS_MIRROR",
+      "TOB_BLOAT_WALL_JOIN_M",
+      "TOB_DUNGEON_MAIDEN_BOTTOM_WALL_TUNNEL",
+      "TOB_DUNGEON_SOTETSEG_WALKWAY_TOP_STRAIGHT_END_LEFT",
+      "TOB_DUNGEON_SOTETSEG_WALKWAY_TOP_STRAIGHT_END_RIGHT",
+      "TOB_DUNGEON_SOTETSEG_WALKWAY_TOP_STRAIGHT_CAP_LEFT",
+      "TOB_DUNGEON_SOTETSEG_WALKWAY_TOP_STRAIGHT_CAP_RIGHT",
+      "TOB_DUNGEON_SOTETSEG_WALKWAY_TOP_WALKWAY_CAP_LEFT",
+      "TOB_DUNGEON_SOTETSEG_WALKWAY_TOP_WALKWAY_CAP_RIGHT",
+      "TOB_DUNGEON_SOTETSEG_FLAT_WALL_WALKWAY_CONNECTOR_LEFT",
+      "TOB_DUNGEON_SOTETSEG_FLAT_WALL_WALKWAY_CONNECTOR_RIGHT",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_A",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_B",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_C",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_D",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_E",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_F",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_RIGHT_A",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_RIGHT_B",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_RIGHT_C",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_RIGHT_D",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_RIGHT_E",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_RIGHT_F",
+      "TOB_DUNGEON_SOTETSEG_MAZE_BLOCKER_A",
+      "TOB_DUNGEON_SOTETSEG_MAZE_BLOCKER_B",
+      "TOB_DUNGEON_SOTETSEG_MAZE_BLOCKER_B_CORNER"
     ],
     "uvType": "BOX",
     "uvOrientation": 100,
@@ -31690,9 +31690,9 @@
     "description": "Theatre of Blood - Xarpus Walls",
     "baseMaterial": "GRAY_70",
     "objectIds": [
-      32745,
-      32746,
-      32748
+      "TOB_DUNGEON_XARPUS_ARENA_WALL_STRAIGHT",
+      "TOB_DUNGEON_XARPUS_ARENA_WALL_CORNER",
+      "TOB_DUNGEON_XARPUS_ARENA_WALL_BRIDGE_SIDE"
     ],
     "colorOverrides": [
       {
@@ -31707,9 +31707,9 @@
     "baseMaterial": "STONE_NORMALED",
     "areas": [ "THEATRE_OF_BLOOD" ],
     "objectIds": [
-      17487,
-      32684,
-      32749
+      "AREA_SANGUINE_CASTLE_LOWER_WALL1",
+      "TOB_ROOF",
+      "TOB_DUNGEON_XARPUS_UPPER_WALL_SINGLE"
     ]
   },
   {
@@ -31718,9 +31718,9 @@
     "uvType": "BOX",
     "areas": [ "THEATRE_OF_BLOOD" ],
     "objectIds": [
-      32670,
-      32752,
-      32751
+      "TOB_SURFACE_CASTLE_DOOR",
+      "TOB_DUNGEON_XARPUS_DEATH_WALL",
+      "TOB_DUNGEON_XARPUS_ARENA_DOOR_EXIT"
     ],
     "colorOverrides": [
       {
@@ -31740,8 +31740,8 @@
     "baseMaterial": "GRAY_75",
     "uvType": "BOX",
     "objectIds": [
-      32741,
-      32742
+      "TOB_SKELETON_WITH_WEAPON",
+      "TOB_SKELETON_WITHOUT_WEAPON"
     ],
     "colorOverrides": [
       {
@@ -31753,7 +31753,7 @@
   {
     "description": "Theatre of Blood - Xarpus - Hide Projectile Shadow",
     "castShadows": false,
-    "projectileIds": [ 1555 ]
+    "projectileIds": [ "TOB_XARPUS_ACIDSPIT" ]
   },
   {
     "description": "Theatre of Blood - Xarpus Buildings - Window",
@@ -31761,7 +31761,7 @@
     "uvType": "BOX",
     "areas": [ "THEATRE_OF_BLOOD" ],
     "objectIds": [
-      32662
+      "TOB_SURFACE_CASTLE_WINDOW_SINGLE"
     ],
     "colorOverrides": [
       {
@@ -31775,8 +31775,8 @@
     "baseMaterial": "STONE_NORMALED",
     "castShadows": false,
     "objectIds": [
-      33052,
-      33059
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_LEFT_G",
+      "TOB_DUNGEON_SOTETSEG_DIAG_WALL_RIGHT_G"
     ],
     "uvType": "BOX",
     "uvOrientation": 100,
@@ -31796,9 +31796,9 @@
     "description": "Theatre of Blood - Nylocas Arena Pillars",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      32862,
-      32876,
-      32899
+      "TOB_NYLOCAS_SUPPORT_PRISTINE",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_03",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_26"
     ],
     "uvType": "BOX"
   },
@@ -31806,45 +31806,45 @@
     "description": "Theatre of Blood - Nylocas Arena Floor",
     "baseMaterial": "ROCK_3",
     "objectIds": [
-      32874,
-      32877,
-      32878,
-      32879,
-      32880,
-      32881,
-      32882,
-      32883,
-      32884,
-      32885,
-      32886,
-      32887,
-      32888,
-      32889,
-      32890,
-      32892,
-      32893,
-      32894,
-      32895,
-      32896,
-      32897,
-      32891,
-      32898,
-      32900,
-      32901,
-      32902,
-      32903,
-      32904,
-      32905,
-      32906,
-      32907,
-      32908,
-      32909,
-      32910,
-      32911,
-      32912,
-      32913,
-      32863,
-      32864
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_01",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_04",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_05",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_06",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_07",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_08",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_09",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_10",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_11",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_12",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_13",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_14",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_15",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_16",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_17",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_19",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_20",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_21",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_22",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_23",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_24",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_18",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_25",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_27",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_28",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_29",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_30",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_31",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_32",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_33",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_34",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_35",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_36",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_37",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_38",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_39",
+      "TOB_DUNGEON_NYLOCAS_PLATFORM_40",
+      "TOB_NYLOCAS_SUPPORT_COLLAPSING",
+      "TOB_NYLOCAS_SUPPORT_DEAD"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -31863,27 +31863,27 @@
     "description": "Theatre of Blood - Nylocas Arena Web Platform",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      32914,
-      32915,
-      32916,
-      32917,
-      32918,
-      32919,
-      32920,
-      32921,
-      32922,
-      32923,
-      32924,
-      32925,
-      32926,
-      32927,
-      32928,
-      32929,
-      32930,
-      32931,
-      32932,
-      32933,
-      32934
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_REAR",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_LEFT_REAR",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_LEFT_FRONT",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_RIGHT_REAR",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_RIGHT_FRONT",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_01",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_02",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_03",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_04",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_05",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_06",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_07",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_08",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_09",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_10",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_11",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_12",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_13",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_14",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_15",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_16"
     ],
     "uvType": "BOX"
   },
@@ -31891,8 +31891,8 @@
     "description": "Theatre of Blood - Nylocas Arena Web Platform Connection",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
-      32935,
-      32936
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_CONNECTOR_LEFT",
+      "TOB_DUNGEON_NYLOCAS_WEB_WALKWAY_CONNECTOR_RIGHT"
     ],
     "uvType": "BOX",
     "colorOverrides": [
@@ -31907,8 +31907,8 @@
     "description": "Theatre of Blood - Door Arch",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      32808,
-      32809
+      "TOB_DUNGEON_WALKWAY_TOP_ENTRANCE",
+      "TOB_DUNGEON_WALKWAY_TOP_ENTRANCE_MIRROR"
     ],
     "uvType": "VANILLA",
     "uvOrientation": 100,
@@ -31924,16 +31924,16 @@
     "baseMaterial": "GRAY_90",
     "shadowOpacityThreshold": 0.1,
     "objectIds": [
-      32755,
-      33028,
-      47336
+      "TOB_ARENA_BARRIER",
+      "TOB_WALKWAY_VERZIK_BARRIER",
+      "TOB_WALKWAY_VERZIK_BARRIER_OP"
     ]
   },
   {
     "description": "Theatre of Blood - Bloat Jar",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      32957
+      "TOB_BLOAT_CHAMBER"
     ],
     "uvType": "GEOMETRY",
     "colorOverrides": [
@@ -31947,7 +31947,7 @@
     "description": "Theatre of Blood - Bloat Jar Top",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      32958
+      "TOB_BLOAT_TABLE"
     ],
     "uvType": "BOX"
   },
@@ -31955,13 +31955,13 @@
     "description": "Theatre of Blood - Hanging Hooks",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      32949,
-      32950,
-      32951,
-      32952,
-      32953,
-      32954,
-      32971
+      "TOB_BLOAT_CHAIN_HOOK_HAND1",
+      "TOB_BLOAT_CHAIN_HOOK_HAND2",
+      "TOB_BLOAT_CHAIN_HOOK_HAND1_ANIM",
+      "TOB_BLOAT_CHAIN_HOOK_HAND2_ANIM",
+      "TOB_BLOAT_CHAIN_HOOK_HEAD1",
+      "TOB_BLOAT_CHAIN_HOOK_HEAD2",
+      "TOB_BLOAT_CHAIN_HOOK_BOOTS"
     ],
     "uvType": "GEOMETRY"
   },
@@ -31969,11 +31969,11 @@
     "description": "Theatre of Blood - Body Parts",
     "baseMaterial": "METALLIC_1",
     "objectIds": [
-      32961,
-      32962,
-      32963,
-      32964,
-      32965
+      "TOB_BLOAT_CORPSE1",
+      "TOB_BLOAT_CORPSE2",
+      "TOB_BLOAT_CORPSE3",
+      "TOB_BLOAT_CORPSE4",
+      "TOB_BLOAT_CORPSE5"
     ],
     "uvType": "GEOMETRY"
   },
@@ -31981,13 +31981,13 @@
     "description": "Theatre of Blood - Bloat Jar Supports",
     "baseMaterial": "STONE_NORMALED",
     "objectIds": [
-      32955
+      "TOB_BLOAT_PILLAR"
     ],
     "uvType": "BOX"
   },
   {
     "description": "TOB Bloat - make floor objects brighter to improve falling shadow visibility",
-    "objectIds": [ 32944, 32945, 32946, 32947, 32948 ],
+    "objectIds": [ "TOB_BLOAT_GRATE_MIDDLE", "TOB_BLOAT_GRATE_NORTH", "TOB_BLOAT_GRATE_EAST", "TOB_BLOAT_GRATE_SOUTH", "TOB_BLOAT_GRATE_WEST" ],
     "baseMaterial": "GRAY_150"
   }
 ]


### PR DESCRIPTION
Added Support for GameVals [Jagex Config names]

**Why the build task?**:

I’ve added a build task that automatically generates the JSON files whenever the plugin is built. This eliminates the need for massive constant files. Since the JSONs are based on RuneLite’s (Jagexs) gamevals, any updates from RuneLite will automatically be reflected in our data.

These generated JSON files are gitignored because they are auto-generated artifacts and don’t need to be version-controlled. Since Jagex config names are stable and unlikely to change, this makes it so if objects shift or their IDs change, the gamevals will handle those updates correctly — preventing issues like incorrect lighting.