### PR TITLE
Fix duplicate entries in area.json

### DIFF
--- a/src/main/resources/rs117/hd/scene/areas.json
+++ b/src/main/resources/rs117/hd/scene/areas.json
@@ -2844,18 +2844,6 @@
     ]
   },
   {
-    "name": "MORYTANIA_SLAYER_TOWER",
-    "aabbs": [
-      [ 3405, 3531, 3452, 3579 ]
-    ]
-  },
-  {
-    "name": "CANIFIS",
-    "regions": [
-      13878
-    ]
-  },
-  {
     "name": "MORYTANIA_SPIDER_CAVES",
     "aabbs": [
       [ 3648, 9792, 3711, 9871 ],


### PR DESCRIPTION
There were duplicate entries for the Slayer Tower and Canfis, i removed them.