### PR TITLE
Replace brightness option with gamma correction

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -135,6 +135,7 @@ import static rs117.hd.utils.HDUtils.MAX_FLOAT_WITH_128TH_PRECISION;
 import static rs117.hd.utils.HDUtils.PI;
 import static rs117.hd.utils.HDUtils.clamp;
 import static rs117.hd.utils.ResourcePath.path;
+import static rs117.hd.utils.Vector.pow;
 
 @PluginDescriptor(
 	name = "117 HD",
@@ -2126,7 +2127,8 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 			glUniform3fv(uniWaterColorMid, waterColorMid);
 			glUniform3fv(uniWaterColorDark, waterColorDark);
 
-			glUniform1f(uniGammaCorrection, 100f / config.brightness());
+			float gammaCorrection = 100f / config.brightness();
+			glUniform1f(uniGammaCorrection, gammaCorrection);
 			float ambientStrength = environmentManager.currentAmbientStrength;
 			float directionalStrength = environmentManager.currentDirectionalStrength;
 			if (config.useLegacyBrightness()) {
@@ -2209,7 +2211,14 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 
 			// Clear scene
 			frameTimer.begin(Timer.CLEAR_SCENE);
-			glClearColor(fogColor[0], fogColor[1], fogColor[2], 1f);
+
+			float[] gammaCorrectedFogColor = pow(fogColor, gammaCorrection);
+			glClearColor(
+				gammaCorrectedFogColor[0],
+				gammaCorrectedFogColor[1],
+				gammaCorrectedFogColor[2],
+				1f
+			);
 			glClearDepthf(0);
 			glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 			frameTimer.end(Timer.CLEAR_SCENE);

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -287,19 +287,52 @@ public interface HdPluginConfig extends Config
 		return Contrast.DEFAULT;
 	}
 
+	String KEY_BRIGHTNESS = "screenBrightness";
+	@Range(
+		min = 50,
+		max = 200
+	)
+	@Units(Units.PERCENT)
+	@ConfigItem(
+		keyName = KEY_BRIGHTNESS,
+		name = "Brightness",
+		description =
+			"Controls the brightness of the game, except for UI.<br>" +
+			"Adjust until the dot on the left is barely visible.",
+		position = 13,
+		section = generalSettings
+	)
+	default int brightness() {
+		return 100;
+	}
+
+	@ConfigItem(
+		keyName = "useLegacyBrightness",
+		name = "Enable Legacy Brightness",
+		description = "Whether the old brightness option below should be used instead of the new brightness option.",
+		position = 14,
+		section = generalSettings
+	)
+	default boolean useLegacyBrightness() {
+		return false;
+	}
+
 	@Range(
 		min = 1,
 		max = 50
 	)
 	@ConfigItem(
 		keyName = "brightness2",
-		name = "Brightness",
-		description = "Controls the brightness of environmental lighting.<br>" +
+		name = "Legacy Brightness",
+		description =
+			"Controls the strength of the sun and ambient lighting.<br>" +
 			"A brightness value of 20 is recommended.",
-		position = 13,
+		position = 15,
 		section = generalSettings
 	)
-	default int brightness() { return 20; }
+	default int legacyBrightness() {
+		return 20;
+	}
 
 
 	/*====== Lighting settings ======*/

--- a/src/main/java/rs117/hd/HdPluginConfig.java
+++ b/src/main/java/rs117/hd/HdPluginConfig.java
@@ -297,8 +297,8 @@ public interface HdPluginConfig extends Config
 		keyName = KEY_BRIGHTNESS,
 		name = "Brightness",
 		description =
-			"Controls the brightness of the game, except for UI.<br>" +
-			"Adjust until the dot on the left is barely visible.",
+			"Controls the brightness of the game, excluding UI.<br>" +
+			"Adjust until the disk on the left is barely visible.",
 		position = 13,
 		section = generalSettings
 	)
@@ -309,7 +309,9 @@ public interface HdPluginConfig extends Config
 	@ConfigItem(
 		keyName = "useLegacyBrightness",
 		name = "Enable Legacy Brightness",
-		description = "Whether the old brightness option below should be used instead of the new brightness option.",
+		description =
+			"Whether the legacy brightness option below should be applied.<br>" +
+			"We recommend leaving this disabled.",
 		position = 14,
 		section = generalSettings
 	)

--- a/src/main/java/rs117/hd/utils/Vector.java
+++ b/src/main/java/rs117/hd/utils/Vector.java
@@ -31,6 +31,16 @@ public class Vector {
 		return out;
 	}
 
+	public static float[] pow(float[] out, float[] in, float exp) {
+		for (int i = 0; i < out.length; i++)
+			out[i] = (float) Math.pow(in[i], exp);
+		return out;
+	}
+
+	public static float[] pow(float[] in, float exp) {
+		return pow(new float[in.length], in, exp);
+	}
+
 	public static float dot(int[] a, int[] b) {
 		float f = 0;
 		int len = Math.min(a.length, b.length);

--- a/src/main/resources/rs117/hd/frag.glsl
+++ b/src/main/resources/rs117/hd/frag.glsl
@@ -37,6 +37,7 @@ uniform sampler2D shadowMap;
 uniform vec3 cameraPos;
 uniform float drawDistance;
 uniform int expandedMapLoadingChunks;
+uniform float gammaCorrection;
 uniform mat4 lightProjectionMatrix;
 uniform float elapsedTime;
 uniform float colorBlindnessIntensity;
@@ -516,6 +517,8 @@ void main() {
 
         outputColor.rgb = mix(outputColor.rgb, fogColor, combinedFog);
     }
+
+    outputColor.rgb = pow(outputColor.rgb, vec3(gammaCorrection));
 
     FragColor = outputColor;
 }

--- a/src/main/resources/rs117/hd/fragui.glsl
+++ b/src/main/resources/rs117/hd/fragui.glsl
@@ -41,6 +41,7 @@ uniform vec4 alphaOverlay;
 #include scaling/bicubic.glsl
 #include utils/constants.glsl
 #include utils/color_blindness.glsl
+#include utils/gamma_calibration_ui.glsl
 
 #if SHADOW_MAP_OVERLAY
 uniform sampler2D shadowMap;
@@ -85,6 +86,8 @@ void main() {
 
     c = alphaBlend(c, alphaOverlay);
     c.rgb = colorBlindnessCompensation(c.rgb);
+
+    gammaCalibrationUi(c, TexCoord, targetDimensions);
 
     FragColor = c;
 }

--- a/src/main/resources/rs117/hd/utils/gamma_calibration_ui.glsl
+++ b/src/main/resources/rs117/hd/utils/gamma_calibration_ui.glsl
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Hooder <ahooder@protonmail.com>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+uniform bool showGammaCalibration;
+uniform float gammaCalibrationTimer;
+uniform float gammaCorrection;
+
+#include utils/constants.glsl
+#include utils/color_utils.glsl
+
+void gammaCalibrationUi(inout vec4 dst, vec2 uv, ivec2 dimensions) {
+    if (!showGammaCalibration)
+        return;
+
+    const float minBrightness = .02;
+    const int numDots = 3;
+    const int height = 100;
+    const vec2 dims = vec2(height * numDots, height);
+    const ivec2 pad = ivec2(32, 16);
+    const float lineFeather = .02;
+    const float dotRadius = .4;
+    const float timerDotRadius = .1;
+
+    uv *= dimensions;
+    uv -= dimensions / 2;
+    vec2 coord = abs(uv) / (dims / 2 + pad);
+    if (max(coord.x, coord.y) > 1)
+        return;
+    uv /= dims.y;
+
+    vec4 src = vec4(vec3(0), smoothstep(0, .05, gammaCalibrationTimer));
+
+    float dotIndex = floor(mod(uv.x + numDots / 2. + 1, numDots + 1));
+    vec2 dotUv = uv;
+    dotUv.x = fract(dotUv.x + .5) - .5;
+    float dot = smoothstep(dotRadius, dotRadius - lineFeather, length(dotUv));
+    dot *= mix(minBrightness, 1, (dotIndex - 1) / (numDots - 1));
+    dot = pow(dot, gammaCorrection);
+    src.rgb += vec3(dot);
+
+    vec2 cornerDotUv = uv - (vec2(numDots / 2., .5) + (pad - 20) / dims.y);
+    float cornerDot = smoothstep(0, lineFeather, timerDotRadius - length(cornerDotUv));
+    float angle = fract(.25 + atan(cornerDotUv.y, cornerDotUv.x) / (2 * PI));
+    cornerDot *= mix(.1, 1, smoothstep(0, lineFeather, gammaCalibrationTimer - angle));
+    src.rgb += vec3(cornerDot);
+
+    dst = mix(dst, src, src.a);
+}


### PR DESCRIPTION
The new option is similar to brightness adjustment found in other games. It affects the entire image equally, apart from the UI, and is more appropriate for adjustment to different screens under different viewing conditions.

The old brightness option directly influenced directional and ambient lighting in a linear fashion, with an arbitrary default value of 20. While this works okay for the most part, it doesn't affect lights or other sources of brightness, nor does it map very well to human perception. A positive side effect of this, however, is that you could imitate night lighting to an extent, which is no longer possible with the new option. It is kept around as a legacy option in case users complain, and until we can provide night lighting in a better way.

https://github.com/user-attachments/assets/9f969b2a-9305-49bf-bc03-00d903153118

It might be nice to also make this calibration popup a movable RuneLite overlay, like our shadow map overlay dev tool.