### PR TITLE
Improved RenderDoc Capture Readbillity

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -592,7 +592,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 				if (log.isDebugEnabled() && glCaps.glDebugMessageControl != 0) {
 					debugCallback = GLUtil.setupDebugMessageCallback();
 					if (debugCallback != null) {
-						// Hide our own debug push & pop groups
+						// Hide our own debug group messages
 						glDebugMessageControl(
 							GL_DEBUG_SOURCE_APPLICATION,
 							GL_DEBUG_TYPE_PUSH_GROUP,
@@ -600,7 +600,6 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 							(int[]) null,
 							false
 						);
-
 						glDebugMessageControl(
 							GL_DEBUG_SOURCE_APPLICATION,
 							GL_DEBUG_TYPE_POP_GROUP,

--- a/src/main/java/rs117/hd/overlays/Timer.java
+++ b/src/main/java/rs117/hd/overlays/Timer.java
@@ -33,37 +33,37 @@ public enum Timer {
 	SWAP_BUFFERS,
 	;
 
-	public final boolean isGpuTimer;
 	public final String name;
+	public final boolean isGpuTimer;
 	public final boolean gpuDebugGroup;
 
 	Timer() {
+		name = enumToName(name());
 		isGpuTimer = false;
 		gpuDebugGroup = false;
-		name = enumToName(name());
 	}
 
 	Timer(boolean isGpuTimer) {
-		this.isGpuTimer = isGpuTimer;
 		name = enumToName(name());
-		gpuDebugGroup = true;
+		this.isGpuTimer = isGpuTimer;
+		gpuDebugGroup = isGpuTimer;
 	}
 
 	Timer(boolean isGpuTimer, @Nonnull String name) {
-		this.isGpuTimer = isGpuTimer;
 		this.name = name;
-		gpuDebugGroup = true;
+		this.isGpuTimer = isGpuTimer;
+		gpuDebugGroup = isGpuTimer;
 	}
 
 	Timer(boolean isGpuTimer, boolean gpuDebugGroup) {
+		name = enumToName(name());
 		this.isGpuTimer = isGpuTimer;
 		this.gpuDebugGroup = gpuDebugGroup;
-		name = enumToName(name());
 	}
 
 	Timer(@Nonnull String name) {
-		isGpuTimer = false;
 		this.name = name;
+		isGpuTimer = false;
 		gpuDebugGroup = false;
 	}
 


### PR DESCRIPTION
Push & Pop GLDebugGroups when GPU Timers are started & stops, helps group events together in captures improving readability.

Before:
![Screenshot from 2025-06-19 01-15-19](https://github.com/user-attachments/assets/a8f96413-8467-4876-bf79-353010205634)

After:
![Screenshot from 2025-06-19 01-51-40](https://github.com/user-attachments/assets/eb00e5d4-b48c-44eb-8216-7e90df4ab6e5)
