### PR TITLE
Optimize transparent objects around Varrock

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -2833,13 +2833,8 @@
         "uvType": "BOX"
       },
       {
-        "description": "Green glass",
-        "colors": "h > 11",
-        "baseMaterial": "NONE"
-      },
-      {
-        "description": "Gold glass",
-        "colors": "h == 8 && s == 7",
+        "description": "Glass",
+        "colors": "a < 255",
         "baseMaterial": "NONE"
       }
     ],
@@ -2861,7 +2856,7 @@
       },
       {
         "description": "Green glass",
-        "colors": "h > 11",
+        "colors": "a < 255",
         "baseMaterial": "NONE"
       }
     ],
@@ -2882,8 +2877,8 @@
         "uvType": "BOX"
       },
       {
-        "description": "Gold glass",
-        "colors": "h == 7 && s > 3 ",
+        "description": "Glass",
+        "colors": "a < 255",
         "baseMaterial": "NONE"
       }
     ],
@@ -26209,9 +26204,8 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ 21549, 21594, 21630 ],
-        "baseMaterial": "NONE",
-        "uvType": "WORLD_XY"
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
       }
     ]
   },
@@ -26232,9 +26226,8 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ "h == 42" ],
-        "baseMaterial": "NONE",
-        "uvType": "WORLD_XY"
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
       }
     ]
   },
@@ -26255,9 +26248,8 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ "h == 42" ],
-        "baseMaterial": "NONE",
-        "uvType": "WORLD_XY"
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
       }
     ]
   },
@@ -26270,9 +26262,8 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ 21549, 21594, 21630 ],
-        "baseMaterial": "NONE",
-        "uvType": "WORLD_XY"
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
       }
     ]
   },
@@ -26293,9 +26284,8 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ 43011, 43054, 43102 ],
-        "baseMaterial": "NONE",
-        "uvType": "WORLD_XY"
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
       }
     ]
   },
@@ -26308,9 +26298,8 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ 43011, 43054, 43121 ],
-        "baseMaterial": "NONE",
-        "uvType": "WORLD_XY"
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
       }
     ]
   },
@@ -26346,9 +26335,8 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ 21535, 21576, 21630 ],
-        "baseMaterial": "NONE",
-        "uvType": "WORLD_XY"
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
       }
     ]
   },
@@ -26369,7 +26357,7 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ 43025, 43068, 43116 ],
+        "colors": "a < 255",
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }
@@ -26384,7 +26372,7 @@
     "uvOrientationZ": 512,
     "colorOverrides": [
       {
-        "colors": [ "h == 21" ],
+        "colors": "a < 255",
         "baseMaterial": "NONE",
         "uvType": "WORLD_XY"
       }
@@ -27078,7 +27066,7 @@
       },
       {
         "description": "Glass",
-        "colors": ["h == 8 && s == 5 && l < 5"],
+        "colors": "a < 255",
         "baseMaterial": "GRAY_75"
       }
     ]
@@ -27110,7 +27098,7 @@
       },
       {
         "description": "Glass",
-        "colors": "h == 8 && s == 5 && l < 5",
+        "colors": "a < 255",
         "baseMaterial": "GRAY_75"
       }
     ]


### PR DESCRIPTION
Turns more complex calculations such as "h == 8 && s > 2 && s < 5 && l >= 50"
into "a < 255"

While i was in there i also did it to the banks.

my idea is less calculations = less work for the CPU. 
remove more complex logic in favor of simplified reading.

no visible change.