### PR TITLE
Brimhaven dungeon upgrade

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -38638,5 +38638,32 @@
         "uvScale": 0.5
       }
     ]
+  },
+  {
+    "description": "Karamja - Brimhaven - Dungeon Entrance with tree - NEEDS PROPER UV FIX for bark and stone bricks",
+    "baseMaterial": "GRUNGE_3_DARK",
+    "uvType": "BOX",
+    "uvScale": 0.62,
+    "uvOrientation": 343,
+    "objectIds": [
+      "DUNGEON_TREE_UNPAID"
+    ],
+    "colorOverrides": [
+      {
+        "colors": "h == 14",
+        "baseMaterial": "LEAF_VEINS",
+        "uvType": "BOX",
+        "uvOrientation": 179,
+        "uvScale": 0.3
+      },
+      {
+        "description": "Stone",
+        "colors": "h == 8 && s == 1",
+        "baseMaterial": "ROCK_3_SMOOTH",
+        "uvType": "BOX",
+        "uvOrientation": 313,
+        "uvScale": 0.5
+      }
+    ]
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -38646,7 +38646,8 @@
     "uvScale": 0.62,
     "uvOrientation": 343,
     "objectIds": [
-      "DUNGEON_TREE_UNPAID"
+      "DUNGEON_TREE_UNPAID",
+      "DUNGEON_TREE_OPEN"
     ],
     "colorOverrides": [
       {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -27766,6 +27766,23 @@
     ]
   },
   {
+    "description": "Skeleton with sword in back named corpse",
+    "baseMaterial": "BONE",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "objectIds": [
+      "CORPSE4_NOBLOCK"
+    ],
+    "colorOverrides": [
+      {
+        "description": "Helmet",
+        "baseMaterial": "METALLIC_1_LIGHT",
+        "colors": "h == 0 && s == 0",
+        "uvType": "BOX"
+      }
+    ]
+  },
+  {
     "description": "Skeleton named corpse",
     "baseMaterial": "BONE",
     "objectIds": [

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -3700,8 +3700,10 @@
     ]
   },
   {
-    "description": "KARAMJA_DUNGEON_WALLS",
+    "description": "Karamja - Brimhaven Dungeon - Walls",
     "baseMaterial": "GRUNGE_1",
+    "uvType": "BOX",
+    "uvScale": 0.6,
     "objectIds": [
       "CAVEWALL_FACE1_LEV2",
       "KARAM_CAVEWALL_FACE1",
@@ -3711,6 +3713,15 @@
       "KARAM_CAVEWALL_VINE_LEV2",
       "KARAM_DUNGEON_CAVESTAIRS2",
       "KARAM_DUNGEON_CAVESTAIRS_LEV2_DOWN2"
+    ]
+  },
+  {
+    "description": "Karamja - Brimhaven Dungeon - Walls - Exit",
+    "baseMaterial": "GRUNGE_1",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "objectIds": [
+      "KARAM_DUNGEON_EXIT"
     ]
   },
   {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -38731,6 +38731,15 @@
       "VINE_STRAIGHT",
       "VINE_JUNCTION",
       "VINE_DIAG3"
+    ],
+    "colorOverrides": [
+      {
+        "colors": "h == 7 && s == 2",
+        "baseMaterial": "LEAF_VEINS_LIGHT",
+        "uvType": "BOX",
+        "uvOrientation": 1313,
+        "uvScale": 0.4
+      }
     ]
   },
   {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -11991,10 +11991,20 @@
   {
     "description": "ROUNDED_CAVE_WALLS_WITH_PIPE",
     "baseMaterial": "GRUNGE_1",
+    "uvType": "BOX",
     "objectIds": [
-      "TAVERLY_DUNGEON_PIPE_SC"
+      "TAVERLY_DUNGEON_PIPE_SC",
+      "KARAM_DUNGEON_PIPE"
     ],
-    "uvType": "BOX"
+    "colorOverrides": [
+      {
+        "description": "Pipe",
+        "colors": "h == 10",
+        "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
+        "uvType": "BOX",
+        "uvScale": 0.6
+      }
+    ]
   },
   {
     "description": "Objects - Rock Stairs - Large",
@@ -21058,7 +21068,8 @@
       "NECROPOLIS_SKELETON_2",
       "NECROPOLIS_SKELETON_3",
       "AKD_HUGHES_SKELETON_1_NOOP",
-      "GA_SKELETON"
+      "GA_SKELETON",
+      "CORPSE2_NOBLOCK"
     ],
     "uvType": "BOX",
     "uvOrientation": 768,
@@ -27738,12 +27749,21 @@
   {
     "description": "Skeleton with helmet named corpse",
     "baseMaterial": "BONE",
+    "uvType": "BOX",
+    "uvScale": 0.6,
     "objectIds": [
       "SLAYER_CORPSE3",
-      "ROGUESDEN_CORPSE3"
+      "ROGUESDEN_CORPSE3",
+      "CORPSE3_NOBLOCK"
     ],
-    "uvType": "BOX",
-    "uvScale": 0.6
+    "colorOverrides": [
+      {
+        "description": "Helmet",
+        "baseMaterial": "METALLIC_1_LIGHT",
+        "colors": "h == 0 && s == 0",
+        "uvType": "BOX"
+      }
+    ]
   },
   {
     "description": "Skeleton named corpse",
@@ -38677,6 +38697,74 @@
         "uvType": "BOX",
         "uvOrientation": 313,
         "uvScale": 0.5
+      }
+    ]
+  },
+  {
+    "description": "Karamja - Brimhaven - Dungeon floor roots",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "uvOrientation": 343,
+    "objectIds": [
+      "VINE_END",
+      "VINE_CORNER",
+      "VINE_DIAG2",
+      "VINE_DIAG1",
+      "VINE_STRAIGHT",
+      "VINE_JUNCTION",
+      "VINE_DIAG3"
+    ]
+  },
+  {
+    "description": "Karamja - Brimhaven - Dungeon floor roots - Rotated",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "uvOrientation": -128,
+    "objectIds": [
+      "VINE_END_DIAG",
+      "VINE_DIAGFILLER"
+    ]
+  },
+  {
+    "description": "Karamja - Brimhaven - Dungeon wall roots",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "uvOrientation": 179,
+    "objectIds": [
+      "KARAM_WALL_ROOT_1",
+      "KARAM_WALL_ROOT_2",
+      "KARAM_WALL_ROOT_3"
+    ]
+  },
+  {
+    "description": "Karamja - Brimhaven - Dungeon wall roots - chopable",
+    "baseMaterial": "LIGHT_BARK",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "uvOrientation": 212,
+    "objectIds": [
+      "KARAM_DUNGEON_VINEBLOCKING1",
+      "KARAM_DUNGEON_VINEBLOCKING2"
+    ]
+  },
+  {
+    "description": "Karamja - Brimhaven - Stone - Pillars with torches",
+    "baseMaterial": "STONE_NORMALED",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "uvOrientation": 179,
+    "objectIds": [
+      "STONEPILLAR_LBROWN_WITHTORCH"
+    ],
+    "colorOverrides": [
+      {
+        "description": "Flames",
+        "colors": "a < 255",
+        "baseMaterial": "NONE"
+
       }
     ]
   }

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -38793,5 +38793,17 @@
 
       }
     ]
+  },
+  {
+    "description": "Karamja -  Brimhaven Dungeon - Tropical Tree Log Agility Shortcut",
+    "baseMaterial": "LIGHT_BARK",
+    "objectIds": [
+      "KARAM_DUNGEON_BAMBOO_LOGBALANCE1",
+      "KARAM_DUNGEON_BAMBOO_LOGBALANCE2",
+      "KARAM_DUNGEON_BAMBOO_LOGBALANCE3"
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.62,
+    "uvOrientationY": 512
   }
 ]

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -3712,7 +3712,9 @@
       "KARAM_CAVEWALL_VINE",
       "KARAM_CAVEWALL_VINE_LEV2",
       "KARAM_DUNGEON_CAVESTAIRS2",
-      "KARAM_DUNGEON_CAVESTAIRS_LEV2_DOWN2"
+      "KARAM_DUNGEON_CAVESTAIRS_LEV2_DOWN2",
+      "KARAM_DUNGEON_LAVAWALL_LEV1",
+      "KARAM_DUNGEON_LAVAWALL_LEV2"
     ]
   },
   {
@@ -11994,7 +11996,8 @@
     "uvType": "BOX",
     "objectIds": [
       "TAVERLY_DUNGEON_PIPE_SC",
-      "KARAM_DUNGEON_PIPE"
+      "KARAM_DUNGEON_PIPE",
+      "KARAM_DUNGEON_PIPE2"
     ],
     "colorOverrides": [
       {
@@ -27786,6 +27789,7 @@
     "description": "Skeleton named corpse",
     "baseMaterial": "BONE",
     "objectIds": [
+      "CORPSE_NOBLOCK",
       "CORPSE2",
       "CORPSE3",
       "SLAYER_CORPSE1",
@@ -38743,6 +38747,27 @@
     ]
   },
   {
+    "description": "Karamja - Brimhaven - Climable green vines",
+    "baseMaterial": "LEAF_VEINS",
+    "uvType": "BOX",
+    "uvScale": 0.6,
+    "uvOrientation": 343,
+    "objectIds": [
+      "KARAM_CAVEWALL_VINE_CLIMBABLE_TAIL",
+      "KARAM_CAVEWALL_VINE_CLIMBABLE_BOTTOM",
+      "KARAM_CAVEWALL_VINE_CLIMBABLE_MIDDLE",
+      "KARAM_CAVEWALL_VINE_CLIMBABLE_TOP"
+    ],
+    "colorOverrides": [
+      {
+        "colors": "h == 6",
+        "baseMaterial": "GRUNGE_1",
+        "uvType": "BOX",
+        "uvScale": 0.6
+      }
+    ]
+  },
+  {
     "description": "Karamja - Brimhaven - Dungeon floor roots - Rotated",
     "baseMaterial": "LIGHT_BARK",
     "uvType": "BOX",
@@ -38773,7 +38798,17 @@
     "uvOrientation": 212,
     "objectIds": [
       "KARAM_DUNGEON_VINEBLOCKING1",
-      "KARAM_DUNGEON_VINEBLOCKING2"
+      "KARAM_DUNGEON_VINEBLOCKING2",
+      "KARAM_DUNGEON_VINEBLOCKING3"
+    ],
+    "colorOverrides": [
+      {
+        "colors": "h == 7 && s == 2",
+        "baseMaterial": "LEAF_VEINS_LIGHT",
+        "uvType": "BOX",
+        "uvOrientation": 1313,
+        "uvScale": 0.4
+      }
     ]
   },
   {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -11103,12 +11103,21 @@
   },
   {
     "description": "Objects - Fungus - Medium",
-    "baseMaterial": "GRUNGE_2",
+    "baseMaterial": "GRUNGE_3",
     "objectIds": [
       "NASTYFUNGUS_DARK",
       "WILDERNESSFUNGUS",
       "NEW_NASTYFUNGUS_DARK",
       "NEW_NASTYFUNGUS_SMALL_DARK"
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.6
+  },
+  {
+    "description": "Objects - Fungus - Big",
+    "baseMaterial": "GRUNGE_3",
+    "objectIds": [
+      "NASTYFUNGUS_DARK_BIG"
     ],
     "uvType": "BOX",
     "uvScale": 0.8

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -18186,6 +18186,8 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       "SKEWSTEPS1_LBROWN",
+      "SKEWSTEPS1_DIAG_LEFT1_LBROWN",
+      "SKEWSTEPS1_DIAG_RIGHT1_LBROWN",
       "CANAFIS_SKEWSTEPS"
     ],
     "uvType": "BOX",


### PR DESCRIPTION
Defines missing objects in the Brimhaven Dungeon; adding materials where able.

NOTE: the entrance needs proper UVs to fix; I have assigned the grunge texture so it has SOMETHING; The root cause is the HSL of the trunk and bricks are the same unfortunately...

Master/PR:
![image](https://github.com/user-attachments/assets/b7c78a14-2990-449f-bc2a-5966abd56da2)
![image](https://github.com/user-attachments/assets/d4ec32be-b6d4-42e4-bc1f-3aa6336946ae)
![image](https://github.com/user-attachments/assets/a1c72ee4-a096-4301-8570-b06568efc1f0)
![image](https://github.com/user-attachments/assets/8a9196a5-4660-4a5c-a515-38aca4963f3c)
![image](https://github.com/user-attachments/assets/f11d8a40-b935-4733-b500-8b545f170a37)
![image](https://github.com/user-attachments/assets/e235b8da-7fd2-412d-9c8c-cf9e48a25578)
![image](https://github.com/user-attachments/assets/543a8e4a-f919-47e7-8fa1-c26e5afd77aa)
![image](https://github.com/user-attachments/assets/ad413954-a545-46d0-961c-8159d7d0e8e6)
![image](https://github.com/user-attachments/assets/fe352dee-0130-4fad-865d-d7eca4aae3e9)
![image](https://github.com/user-attachments/assets/9fa72e02-455c-40c8-b34c-dff47bd27593)
