### PR TITLE
PoH - Fancy Stone Walls and Floors

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -32770,6 +32770,54 @@
     ]
   },
   {
+    "description": "PoH - Stone - Fancy Brick wall",
+    "baseMaterial": "STONE_NORMALED",
+    "uvType": "BOX",
+    "objectIds": [
+      "YANILLE_POH_WALL",
+      "YANILLE_POH_WALL_WINDOW",
+      "YANILLE_POH_ROOF"
+    ]
+  },
+  {
+    "description": "PoH - Stone - Wooden - Fancy Brick wall with wooden shutters",
+    "baseMaterial": "STONE_NORMALED",
+    "uvType": "BOX",
+    "objectIds": [
+      "POH_YANILLE_WINDOW_SHUTTERS"
+    ],
+    "colorOverrides": [
+      {
+        "description": "Wooden shutters",
+        "colors": "h == 6 && s == 4",
+        "baseMaterial": "WOOD_GRAIN_3",
+        "uvType": "BOX",
+        "uvOrientation": 512,
+        "uvScale": 0.6
+      }
+    ]
+  },
+  {
+    "description": "PoH - Stone - Wooden - Fancy Brick wall - door",
+    "baseMaterial": "WOOD_GRAIN_3",
+    "uvType": "BOX",
+    "uvScale": 0.8,
+    "objectIds": [
+      "YANILLE_POH_DOUBLE_DOORL",
+      "YANILLE_POH_DOUBLE_DOORL_OPEN",
+      "YANILLE_POH_DOUBLE_DOOR_OPEN",
+      "YANILLE_POH_DOUBLE_DOOR"
+    ],
+    "colorOverrides": [
+      {
+        "description": "Wooden shutters",
+        "colors": "h == 8 && s == 1",
+        "baseMaterial": "STONE_NORMALED",
+        "uvType": "BOX"
+      }
+    ]
+  },
+  {
     "description": "Post with rope",
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -4127,6 +4127,14 @@
     "blended": false
   },
   {
+    "name": "POC_FANCY_BRICK_INTERIOR",
+    "area": "PLAYER_OWNED_HOUSE",
+    "overlayIds": [ 79 ],
+    "groundMaterial": "BRICK_PATHS",
+    "blended": false,
+    "shiftLightness": 6
+  },
+  {
     "name": "LAND_OF_GOBLINS_WATER_FIX",
     "area": "LAND_OF_GOBLINS_CUTSCENE_WATER",
     "overlayIds": [


### PR DESCRIPTION
Assigns materials to the Fancy Stone Walls (Yanille), also defines the floors to be tile instead of dirt

Master/PR:
![image](https://github.com/user-attachments/assets/3a735757-406c-41e4-8ac3-043c3f547c70)
![image](https://github.com/user-attachments/assets/4e8c6555-befb-47d7-98f1-bf47c6c5f931)
![image](https://github.com/user-attachments/assets/bb599cf7-5eeb-4778-bca5-f33b84b8a539)
![image](https://github.com/user-attachments/assets/6275cf30-9e0e-4fd1-8d37-abdf733978ab)
