### PR TITLE
GLBuffer Map & Unmap Support

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -3169,16 +3169,12 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 				if (enableDetailedTimers)
 					frameTimer.end(Timer.MODEL_PUSHING);
 
-				modelInfo.setVertexOffset(vertexOffset);
-				modelInfo.setUVOffset(uvOffset);
-
 				// add this temporary model to the map for batching purposes
 				if (configModelBatching)
 					frameModelInfoMap.put(batchHash, new ModelOffsets(faceCount, vertexOffset, uvOffset));
 			}
 
-			if (modelInfo.getVertexOffset() != -1)
-				drawnDynamicRenderableCount++;
+			drawnDynamicRenderableCount++;
 
 			if (configCharacterDisplacement && renderable instanceof Actor) {
 				if (enableDetailedTimers)
@@ -3208,7 +3204,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 		if (enableDetailedTimers)
 			frameTimer.end(Timer.DRAW_RENDERABLE);
 
-		if (modelInfo.getVertexOffset() == -1)
+		if (vertexOffset == -1)
 			return; // Hidden model
 
 		bufferForTriangles(faceCount)

--- a/src/main/java/rs117/hd/data/ModelInfo.java
+++ b/src/main/java/rs117/hd/data/ModelInfo.java
@@ -1,0 +1,80 @@
+package rs117.hd.data;
+
+import lombok.Getter;
+
+public class ModelInfo {
+	public static final int VERTEX_OFFSET_IDX = 0;
+	public static final int UV_OFFSET_IDX = 1;
+	public static final int FACE_COUNT_IDX = 2;
+	public static final int RENDER_BUFFER_OFFSET_IDX = 3;
+	public static final int MODEL_FLAGS_IDX = 4;
+	public static final int X_POSITION_IDX = 5;
+	public static final int Y_POSITION_AND_HEIGHT_IDX = 6;
+	public static final int Z_POSITION_IDX = 7;
+
+	@Getter
+	private final int[] stagingData = new int[8];
+
+	public int getVertexOffset() { return stagingData[VERTEX_OFFSET_IDX]; }
+
+	public ModelInfo setVertexOffset(int vertexOffset) {
+		stagingData[VERTEX_OFFSET_IDX] = vertexOffset;
+		return this;
+	}
+
+	public int getUVOffset() { return stagingData[UV_OFFSET_IDX]; }
+
+	public ModelInfo setUVOffset(int uvOffset) {
+		stagingData[UV_OFFSET_IDX] = uvOffset;
+		return this;
+	}
+
+	public int getFaceOffset() { return stagingData[FACE_COUNT_IDX]; }
+
+	public ModelInfo setFaceCount(int faceCount) {
+		stagingData[FACE_COUNT_IDX] = faceCount;
+		return this;
+	}
+
+	public int getRenderBufferOffset() { return stagingData[RENDER_BUFFER_OFFSET_IDX]; }
+
+	public ModelInfo setRenderBufferOffset(int renderBufferOffset) {
+		stagingData[RENDER_BUFFER_OFFSET_IDX] = renderBufferOffset;
+		return this;
+	}
+
+	public int getModelFlags() { return stagingData[MODEL_FLAGS_IDX]; }
+
+	public ModelInfo setModelFlags(int flags) {
+		stagingData[MODEL_FLAGS_IDX] = flags;
+		return this;
+	}
+
+	public int getPositionX() { return stagingData[X_POSITION_IDX]; }
+
+	public ModelInfo setPositionX(int x) {
+		stagingData[X_POSITION_IDX] = x;
+		return this;
+	}
+
+	public int getPositionY() { return (stagingData[Y_POSITION_AND_HEIGHT_IDX] >> 16) & 0xFFFF; }
+
+	public int getHeight() { return stagingData[Y_POSITION_AND_HEIGHT_IDX] & 0xFFFF; }
+
+	public ModelInfo setPositionYAndHeight(int packed) {
+		stagingData[Y_POSITION_AND_HEIGHT_IDX] = packed;
+		return this;
+	}
+
+	public ModelInfo setPositionYAndHeight(int y, int height) {
+		// Pack Y into the upper bits to easily preserve the sign
+		return setPositionYAndHeight(y << 16 | height & 0xFFFF);
+	}
+
+	public int getPositionZ() { return stagingData[Z_POSITION_IDX]; }
+
+	public ModelInfo setPositionZ(int z) {
+		stagingData[Z_POSITION_IDX] = z;
+		return this;
+	}
+}

--- a/src/main/java/rs117/hd/data/ModelInfo.java
+++ b/src/main/java/rs117/hd/data/ModelInfo.java
@@ -11,9 +11,10 @@ public class ModelInfo {
 	public static final int X_POSITION_IDX = 5;
 	public static final int Y_POSITION_AND_HEIGHT_IDX = 6;
 	public static final int Z_POSITION_IDX = 7;
+	public static final int ELEMENT_COUNT = 8;
 
 	@Getter
-	private final int[] stagingData = new int[8];
+	private final int[] stagingData = new int[ELEMENT_COUNT];
 
 	public int getVertexOffset() { return stagingData[VERTEX_OFFSET_IDX]; }
 

--- a/src/main/java/rs117/hd/utils/buffer/GLBuffer.java
+++ b/src/main/java/rs117/hd/utils/buffer/GLBuffer.java
@@ -210,7 +210,7 @@ public class GLBuffer
 	@RequiredArgsConstructor
 	public enum AccessFlags {
 		Write(GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT),
-		Read(GL_MAP_READ_BIT | GL_MAP_FLUSH_EXPLICIT_BIT),
+		Read(GL_MAP_READ_BIT),
 		ReadWrite(GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT);
 
 		public final int glMapBufferRangeFlags;

--- a/src/main/java/rs117/hd/utils/buffer/GLBuffer.java
+++ b/src/main/java/rs117/hd/utils/buffer/GLBuffer.java
@@ -24,6 +24,7 @@
  */
 package rs117.hd.utils.buffer;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
@@ -43,6 +44,8 @@ public class GLBuffer
 	public final String name;
 	public final int target;
 	public final int usage;
+
+	public final GLMappedBuffer mapped = new GLMappedBuffer(this);
 
 	public int id;
 	public long size;
@@ -68,37 +71,86 @@ public class GLBuffer
 		}
 	}
 
+	public GLMappedBuffer map(AccessFlags accessFlags, GLMappedType bufferType) {
+		return map(accessFlags, 0, bufferType);
+	}
+
+	public GLMappedBuffer map(AccessFlags accessFlags, long bytesOffset, GLMappedType bufferType) {
+		if (!mapped.isMapped()) {
+			glBindBuffer(target, id);
+			ByteBuffer buf = glMapBufferRange(target, bytesOffset, size - bytesOffset, accessFlags.glMapBufferRangeFlags);
+			if (buf != null) {
+				mapped.buffer = buf;
+				mapped.bufferInt = bufferType == GLMappedType.INT ? mapped.buffer.asIntBuffer() : null;
+				mapped.bufferFloat = bufferType == GLMappedType.FLOAT ? mapped.buffer.asFloatBuffer() : null;
+				mapped.accessFlags = accessFlags;
+				mapped.bufferType = bufferType;
+				mapped.bytesOffset = bytesOffset;
+			}
+			HdPlugin.checkGLErrors();
+		}
+
+		return mapped;
+	}
+
+	public void unmap(boolean flush) {
+		if (mapped.isMapped()) {
+			glBindBuffer(target, id);
+			if (flush) {
+				glFlushMappedBufferRange(target, mapped.bytesOffset, mapped.buffer.position());
+			}
+			glUnmapBuffer(target);
+			mapped.buffer = null;
+			mapped.bufferInt = null;
+			mapped.bufferFloat = null;
+			glBindBuffer(target, 0);
+			HdPlugin.checkGLErrors();
+		}
+	}
+
 	public void ensureCapacity(long numBytes) {
 		ensureCapacity(0, numBytes);
 	}
 
 	public void ensureCapacity(long byteOffset, long numBytes) {
-		numBytes += byteOffset;
-		if (numBytes <= size) {
+		long newSize = byteOffset + numBytes;
+		if (newSize <= size) {
 			glBindBuffer(target, id);
 			return;
 		}
 
-		numBytes = HDUtils.ceilPow2(numBytes);
-		if (log.isDebugEnabled() && numBytes > 1e6)
-			log.debug("Resizing buffer '{}'\t{}", name, String.format("%.2f MB -> %.2f MB", size / 1e6, numBytes / 1e6));
+		newSize = HDUtils.ceilPow2(newSize);
+		if (log.isDebugEnabled() && newSize > 1e6)
+			log.debug("Resizing buffer '{}'\t{}", name, String.format("%.2f MB -> %.2f MB", size / 1e6, newSize / 1e6));
+
+		int mappedBufferByteOffset = -1;
+		if (mapped.isMapped()) {
+			mappedBufferByteOffset = mapped.position() * mapped.bufferType.stride;
+			mapped.buffer.position(mappedBufferByteOffset);
+			unmap(false);
+		}
 
 		if (byteOffset > 0) {
 			// Create a new buffer and copy the old data to it
 			int oldBuffer = id;
 			id = glGenBuffers();
 			glBindBuffer(target, id);
-			glBufferData(target, numBytes, usage);
+			glBufferData(target, newSize, usage);
 
 			glBindBuffer(GL_COPY_READ_BUFFER, oldBuffer);
 			glCopyBufferSubData(GL_COPY_READ_BUFFER, target, 0, 0, byteOffset);
 			glDeleteBuffers(oldBuffer);
 		} else {
 			glBindBuffer(target, id);
-			glBufferData(target, numBytes, usage);
+			glBufferData(target, newSize, usage);
 		}
 
-		size = numBytes;
+		size = newSize;
+
+		if (mappedBufferByteOffset != -1) {
+			map(mapped.accessFlags, mapped.bytesOffset, mapped.bufferType);
+			mapped.setPositionInBytes(mappedBufferByteOffset);
+		}
 
 		if (log.isDebugEnabled() && HdPlugin.GL_CAPS.OpenGL43) {
 			GL43C.glObjectLabel(GL43C.GL_BUFFER, id, name);
@@ -111,6 +163,7 @@ public class GLBuffer
 	}
 
 	public void upload(ByteBuffer data, long byteOffset) {
+		unmap(true);
 		long numBytes = data.remaining();
 		ensureCapacity(byteOffset, numBytes);
 		glBufferSubData(target, byteOffset, data);
@@ -121,6 +174,7 @@ public class GLBuffer
 	}
 
 	public void upload(IntBuffer data, long byteOffset) {
+		unmap(true);
 		long numBytes = 4L * data.remaining();
 		ensureCapacity(byteOffset, numBytes);
 		glBufferSubData(target, byteOffset, data);
@@ -131,6 +185,7 @@ public class GLBuffer
 	}
 
 	public void upload(FloatBuffer data, long byteOffset) {
+		unmap(true);
 		long numBytes = 4L * data.remaining();
 		ensureCapacity(byteOffset, numBytes);
 		glBufferSubData(target, byteOffset, data);
@@ -150,5 +205,151 @@ public class GLBuffer
 
 	public void upload(GpuFloatBuffer data, long byteOffset) {
 		upload(data.getBuffer(), byteOffset);
+	}
+
+	@RequiredArgsConstructor
+	public enum AccessFlags {
+		Write(GL_WRITE_ONLY, GL40.GL_MAP_WRITE_BIT | GL40.GL_MAP_FLUSH_EXPLICIT_BIT),
+		Read(GL_READ_ONLY, GL40.GL_MAP_READ_BIT | GL40.GL_MAP_FLUSH_EXPLICIT_BIT),
+		ReadWrite(GL_READ_WRITE, GL40.GL_MAP_READ_BIT | GL40.GL_MAP_WRITE_BIT | GL40.GL_MAP_FLUSH_EXPLICIT_BIT);
+
+		public final int glMapBufferType;
+		public final int glMapBufferRangeFlags;
+	}
+
+	@RequiredArgsConstructor
+	public enum GLMappedType {
+		BYTE(1),
+		INT(4),
+		FLOAT(4);
+
+		public final int stride;
+	}
+
+	@RequiredArgsConstructor
+	public static final class GLMappedBuffer {
+		private final GLBuffer owner;
+
+		private AccessFlags accessFlags;
+		private GLMappedType bufferType;
+		private long bytesOffset;
+
+		private ByteBuffer buffer;
+		private IntBuffer bufferInt;
+		private FloatBuffer bufferFloat;
+
+		public boolean isMapped() {
+			return buffer != null;
+		}
+
+		public <T extends Buffer> T getBuffer() {
+			if (buffer == null) {
+				return null;
+			}
+
+			switch (bufferType) {
+				case BYTE:
+					return (T) buffer;
+				case INT:
+					return (T) bufferInt;
+				case FLOAT:
+					return (T) bufferFloat;
+				default:
+					throw new IllegalStateException("Unexpected value: " + bufferType);
+			}
+		}
+
+		public int position() {
+			Buffer buf = getBuffer();
+			if (buf != null) {
+				return buf.position();
+			}
+			return 0;
+		}
+
+		public void setPositionInBytes(int bytesOffset) {
+			if (buffer != null) buffer.position(bytesOffset);
+			if (bufferInt != null) bufferInt.position(bytesOffset / 4);
+			if (bufferFloat != null) bufferFloat.position(bytesOffset / 4);
+		}
+
+		public GLMappedBuffer ensureCapacity(int size) {
+			long numBytes = bytesOffset + ((position() + size) * (long) bufferType.stride);
+			if (numBytes > owner.size) {
+				owner.ensureCapacity(numBytes);
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(int value) {
+			if (bufferInt != null) {
+				bufferInt.put(value);
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(float value) {
+			if (bufferFloat != null) {
+				bufferFloat.put(value);
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(int x, int y, int z, int w) {
+			if (bufferInt != null) {
+				bufferInt.put(x);
+				bufferInt.put(y);
+				bufferInt.put(z);
+				bufferInt.put(w);
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(float x, float y, float z, float w) {
+			if (bufferFloat != null) {
+				bufferFloat.put(x);
+				bufferFloat.put(y);
+				bufferFloat.put(z);
+				bufferFloat.put(w);
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(float x, float y, float z, int w) {
+			if (bufferFloat != null) {
+				bufferFloat.put(x);
+				bufferFloat.put(y);
+				bufferFloat.put(z);
+				bufferFloat.put(Float.intBitsToFloat(w));
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(int[] array) {
+			if (bufferInt != null && array != null) {
+				bufferInt.put(array);
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(float[] array) {
+			if (bufferFloat != null && array != null) {
+				bufferFloat.put(array);
+			}
+			return this;
+		}
+
+		public GLMappedBuffer put(IntBuffer inBuffer) {
+			if (bufferInt != null) {
+				bufferInt.put(inBuffer);
+			}
+			return this;
+		}
+
+		public void put(FloatBuffer inBuffer) {
+			if (bufferFloat != null) {
+				bufferFloat.put(inBuffer);
+			}
+		}
 	}
 }

--- a/src/main/java/rs117/hd/utils/buffer/GLBuffer.java
+++ b/src/main/java/rs117/hd/utils/buffer/GLBuffer.java
@@ -209,11 +209,10 @@ public class GLBuffer
 
 	@RequiredArgsConstructor
 	public enum AccessFlags {
-		Write(GL_WRITE_ONLY, GL40.GL_MAP_WRITE_BIT | GL40.GL_MAP_FLUSH_EXPLICIT_BIT),
-		Read(GL_READ_ONLY, GL40.GL_MAP_READ_BIT | GL40.GL_MAP_FLUSH_EXPLICIT_BIT),
-		ReadWrite(GL_READ_WRITE, GL40.GL_MAP_READ_BIT | GL40.GL_MAP_WRITE_BIT | GL40.GL_MAP_FLUSH_EXPLICIT_BIT);
+		Write(GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT),
+		Read(GL_MAP_READ_BIT | GL_MAP_FLUSH_EXPLICIT_BIT),
+		ReadWrite(GL_MAP_READ_BIT | GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT);
 
-		public final int glMapBufferType;
 		public final int glMapBufferRangeFlags;
 	}
 


### PR DESCRIPTION
Adds the ability to map a GLBuffer with support for remapping after `ensureCapacity` reallocates the buffer.

Example Use:
`GLBuffer.GLMappedBuffer modelPassthroughBuffer = hModelPassthroughBuffer.map(GLBuffer.AccessFlags.Write, GLBuffer.GLMappedType.INT);`

Maps Buffer using `glMapBufferRange` setting the Write & Explicit Flush Bit, Unmapping takes a flush boolean passing in true `  will flush the written data using `glFlushMappedBufferRange`

GLBuffer.GLMappedType.Byte, GLBuffer.GLMappedType.INT, GLBuffer.GLMappedType.Float. Controls which buffer is used for writing & keeping the mapped ByteBuffer's position in sync with data written.

`modelPassthroughBuffer` & `modelSortingBuffers` updated to Map buffers instead of writing to staging memory before uploading.

Added class: `ModelInfo` to back data written explicitly with a staging array, to avoid calling put() & to make it easier to modify ModelInfo layout without needing to change more code.

