### PR TITLE
Fix InvertDisplacement not masking VertexFlags correctly

### DIFF
--- a/src/main/resources/rs117/hd/opengl/compute/priority_render.cl
+++ b/src/main/resources/rs117/hd/opengl/compute/priority_render.cl
@@ -383,7 +383,7 @@ float3 applyCharacterDisplacement(
 float getModelWindDisplacementMod(int vertexFlags) {
     const float modifiers[7] = { 0.25f, 0.5f, 0.7f, 1.0f, 1.25f, 1.5f, 2.0f };
     int modifierIDx = (vertexFlags >> MATERIAL_FLAG_WIND_MODIFIER) & 0x7;
-    float invertDisplacement = vertexFlags >> MATERIAL_FLAG_INVERT_DISPLACEMENT_STRENGTH == 1 ? -1.0f : 1.0f;
+    float invertDisplacement = ((vertexFlags >> MATERIAL_FLAG_INVERT_DISPLACEMENT_STRENGTH & 1) == 1) ? -1.0 : 1.0;
     return modifiers[modifierIDx] * invertDisplacement;
 }
 

--- a/src/main/resources/rs117/hd/priority_render.glsl
+++ b/src/main/resources/rs117/hd/priority_render.glsl
@@ -254,7 +254,7 @@ vec3 applyCharacterDisplacement(vec3 characterPos, vec2 vertPos, float height, f
 float getModelWindDisplacementMod(int vertexFlags) {
     const float modifiers[7] = { 0.25, 0.5, 0.75, 1.0, 1.25, 1.5, 2.0};
     int modifierIDx = (vertexFlags >> MATERIAL_FLAG_WIND_MODIFIER) & 0x7;
-    float invertDisplacement = (vertexFlags >> MATERIAL_FLAG_INVERT_DISPLACEMENT_STRENGTH == 1) ? -1.0 : 1.0;
+    float invertDisplacement = ((vertexFlags >> MATERIAL_FLAG_INVERT_DISPLACEMENT_STRENGTH & 1) == 1) ? -1.0 : 1.0;
     return modifiers[modifierIDx] * invertDisplacement;
 }
 


### PR DESCRIPTION
invertDisplacement should have been masking the first bit, otherwise it'll be reading whatever bits are above it too