### PR TITLE
Allow configuring vanilla shadow hiding in model overrides

### DIFF
--- a/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
+++ b/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
@@ -75,6 +75,8 @@ public class ModelOverride
 	public WindDisplacement windDisplacementMode = WindDisplacement.DISABLED;
 	public int windDisplacementModifier = 0;
 	public boolean invertDisplacementStrength = false;
+	public int vanillaShadowOpacityThreshold = 155;
+	public float vanillaShadowHeightThreshold = 8;
 
 	@JsonAdapter(AABB.JsonAdapter.class)
 	public AABB[] hideInAreas = {};
@@ -210,6 +212,8 @@ public class ModelOverride
 			windDisplacementMode,
 			windDisplacementModifier,
 			invertDisplacementStrength,
+			vanillaShadowOpacityThreshold,
+			vanillaShadowHeightThreshold,
 			hideInAreas,
 			materialOverrides,
 			colorOverrides,

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -1068,6 +1068,14 @@
     ]
   },
   {
+    "description": "testing",
+    "npcIds": [
+      "GODWARS_ARMADYL_MALE_ARMOR02_BLUE"
+    ],
+    "vanillaShadowOpacityThreshold": 1,
+    "vanillaShadowHeightThreshold": 25
+  },
+  {
     "description": "Kourend - Hosidius - Apple Tree",
     "baseMaterial": "BARK",
     "objectIds": [


### PR DESCRIPTION
For easy performance comparison, when legacy brightness is enabled, the old method is used. When disabled, the new method is used. As far as I could tell, the performance impact was negligible.