### PR TITLE
Arceuus Crystals fixes

### DIFF
--- a/src/main/resources/rs117/hd/scene/materials.json
+++ b/src/main/resources/rs117/hd/scene/materials.json
@@ -2183,6 +2183,12 @@
     "specularGloss": 90.0
   },
   {
+    "name": "CRYSTAL",
+    "parent": "GRAY_75",
+    "specularStrength": 0.5,
+    "specularGloss": 100
+  },
+  {
     "name": "LEAVES_YELLOW_SIDE",
     "parent": "LEAVES_SIDE"
   },

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -36388,8 +36388,6 @@
       "THRONE_ICE01_SPIKES04",
       "THRONE_ICE01_SPIKES05",
       "THRONE_ICE01_SPIKES06",
-      "ARCHEUS_CRYSTAL_SMALLEST",
-      "ARCHEUS_CRYSTAL_SMALLEST_01",
       "THRONE_ICE01_SPIKES01",
       "THRONE_ICE01_SPIKES02"
     ],
@@ -57183,5 +57181,49 @@
         "uvType": "BOX"
       }
     ]
+  },
+  {
+    "description": "Arceuus - Crystal",
+    "baseMaterial": "CRYSTAL",
+    "uvType": "BOX",
+    "terrainVertexSnap": true,
+    "objectIds": [
+      "ARCHEUS_CRYSTAL_MEDIUM",
+      "ARCHEUS_CRYSTAL_LARGE",
+      "ARCHEUS_CRYSTAL_SMALL_DARK",
+      "ARCHEUS_CRYSTAL_MEDIUM_DARK",
+      "ARCHEUS_CRYSTAL_LARGE_DARK",
+      "ARCHEUS_CRYSTAL_MEDIUM_RED",
+      "ARCHEUS_CRYSTAL_MEDIUM_REFLECT_RED",
+      "ARCHEUS_CRYSTAL_LARGE_REFLECT_RED",
+      "ARCHEUS_CRYSTAL_SMALL_RED"
+    ]
+  },
+  {
+    "description": "Arceuus - Crystal - Vertex Snap Disabled",
+    "baseMaterial": "CRYSTAL",
+    "uvType": "BOX",
+    "objectIds": [
+      "ARCHEUS_CRYSTAL_SMALL"
+    ]
+  },
+  {
+    "description": "Arceuus - Crystal - Small",
+    "baseMaterial": "CRYSTAL",
+    "uvType": "BOX",
+    "terrainVertexSnap": true,
+    "objectIds": [
+      "ARCHEUS_CRYSTAL_SMALLEST",
+      "ARCHEUS_CRYSTAL_SMALLEST_01",
+      "ARCHEUS_CRYSTAL_SMALLEST_02",
+      "ARCHEUS_CRYSTAL_SMALLEST",
+      "ARCHEUS_CRYSTAL_SMALLEST_DARK_01",
+      "ARCHEUS_CRYSTAL_SMALLEST_DARK_02",
+      "ARCHEUS_CRYSTAL_SMALLEST_RED",
+      "ARCHEUS_CRYSTAL_SMALLEST_RED_01",
+      "ARCHEUS_CRYSTAL_SMALLEST_RED_02"
+
+    ],
+    "shadowOpacityThreshold": 0.9
   }
 ]


### PR DESCRIPTION
Applies a light gloss and reflection to the crystals around Arceuus
Applies vertex snap to most of the crystals; avoids one cause it horrible is broken when it's enable due to Jagex hiding some of the model under the slope itself.
Fix Peter Pan shadows on small crystals

Visually identical at worse case angles, reflective and properly attached to the ground at best.