### PR TITLE
Fix jungle grass having incorrect normals

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13276,8 +13276,8 @@
       {
         "description": "Grass",
         "colors": "s == 7",
-        "upwardsNormals": true,
-        "baseMaterial": "GRAY_75",
+        "flatNormals": true,
+        "baseMaterial": "GRAY_85",
         "windDisplacementMode": "OBJECT"
       },
       {
@@ -13325,9 +13325,9 @@
   },
   {
     "description": "Objects - Jungle grass",
-    "upwardsNormals": true,
+    "flatNormals": true,
     "windDisplacementMode": "OBJECT",
-    "baseMaterial": "GRAY_75",
+    "baseMaterial": "GRAY_85",
     "objectIds": [
       "JUNGLEFLOOR1",
       "JUNGLEFLOOR2",


### PR DESCRIPTION
Was really bright on one side, this fixes it

<img width="2286" height="1416" alt="java_jCU7dxLPSx" src="https://github.com/user-attachments/assets/fd6cfd75-7029-403e-a483-26d2f7a9f9f6" />
<img width="2286" height="1416" alt="java_1SMI1s5i7w" src="https://github.com/user-attachments/assets/4df48b05-7b49-4660-b187-efd384bdce3b" />

https://github.com/user-attachments/assets/f0331908-159b-4e8f-af2d-85cec9d7fe54

