### PR TITLE
TiledLighting Bin Sorting

### DIFF
--- a/src/main/resources/rs117/hd/tiled_lighting_frag.glsl
+++ b/src/main/resources/rs117/hd/tiled_lighting_frag.glsl
@@ -133,8 +133,8 @@ void main() {
 #endif
 
 #if USE_SORTING_BIN
-                const float PROXIMITY_WEIGHT = 0.7;
-                float distanceScore = sqrt(lightDistSqr) / (drawDistance * 128);
+                const float PROXIMITY_WEIGHT = 0.75;
+                float distanceScore = 1.0 - (sqrt(lightDistSqr) / (drawDistance * 128));
                 float combinedScore = (lightTileCos * PROXIMITY_WEIGHT) + distanceScore * (1.0 - PROXIMITY_WEIGHT);
 
                 for (int i = 0; i < SORTING_BIN_SIZE; i++) {

--- a/src/main/resources/rs117/hd/tiled_lighting_frag.glsl
+++ b/src/main/resources/rs117/hd/tiled_lighting_frag.glsl
@@ -21,7 +21,6 @@ out ivec4 TiledData;
 in vec2 fUv;
 
 #define USE_SORTING_BIN 1
-
 #if USE_SORTING_BIN
     #if TILED_IMAGE_STORE
         #define SORTING_BIN_SIZE TILED_LIGHTING_LAYER_COUNT * 4
@@ -34,7 +33,7 @@ in vec2 fUv;
     };
 #endif
 
-#define USE_LIGHTS_MASK !USE_SORTING_BIN
+#define USE_LIGHTS_MASK !USE_SORTING_BIN || !TILED_IMAGE_STORE
 
 void main() {
     ivec2 pixelCoord = ivec2(gl_FragCoord.xy);

--- a/src/main/resources/rs117/hd/tiled_lighting_frag.glsl
+++ b/src/main/resources/rs117/hd/tiled_lighting_frag.glsl
@@ -134,7 +134,7 @@ void main() {
 
 #if USE_SORTING_BIN
                 const float PROXIMITY_WEIGHT = 0.75;
-                float distanceScore = 1.0 - (sqrt(lightDistSqr) / (drawDistance * 128));
+                float distanceScore = clamp(1.0 - sqrt(lightDistSqr) / (sqrt(lightRadiusSqr) + 1e-6), 0.0, 1.0);
                 float combinedScore = (lightTileCos * PROXIMITY_WEIGHT) + distanceScore * (1.0 - PROXIMITY_WEIGHT);
 
                 for (int i = 0; i < SORTING_BIN_SIZE; i++) {


### PR DESCRIPTION
Added PROXIMITY_WEIGHT sorting for each tile, tiles now take into consideration both the distance & proximity to the tiles cone.

Before Vs After (Switching occur half way through comparisons):

https://github.com/user-attachments/assets/ba01ee3b-023a-47b2-bfc4-7dd3c6ea9c9d

https://github.com/user-attachments/assets/b8d5f704-1623-4c7f-99fb-0b3490906575



