### PR TITLE
Grass fixes

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -2873,7 +2873,42 @@
     "uvScale": 0.32
   },
   {
-    "description": "Short grass with rock objects usually found around Farming Patches",
+    "description": "Farming Guild - Farming patch Edges with grass made of stone and edged with wood",
+    "baseMaterial": "GRAY_75",
+    "flatNormals": true,
+    "castShadows": false,
+    "windDisplacementMode": "OBJECT",
+    "objectIds": [
+      "KEBOS_FARMING_GUILD_BORDER_STRAIGHT",
+      "KEBOS_FARMING_GUILD_BORDER_CORNER",
+      "KEBOS_FARMING_GUILD_BORDER_CORNER_OUTSIDE",
+      "TGOD_GARDEN_TEMPLE_FARMING_BORDER_STRAIGHT",
+      "TGOD_GARDEN_TEMPLE_FARMING_BORDER_CORNER_OUTSIDE"
+    ],
+    "colorOverrides": [
+      {
+        "colors": "h == 7",
+        "baseMaterial": "ROCK_1_LIGHT",
+        "uvType": "BOX",
+        "uvScale": 0.6
+      },
+      {
+        "colors": "h == 5",
+        "baseMaterial": "STONE_NORMALED",
+        "uvType": "BOX",
+        "uvScale": 0.5
+      },
+      {
+        "colors": "h == 6",
+        "baseMaterial": "BARK",
+        "uvType": "BOX",
+        "uvScale": 0.5,
+        "uvOrientation": 512
+      }
+    ]
+  },
+  {
+    "description": "Varrock - Farming Patch Edges with grass around them",
     "baseMaterial": "GRAY_75",
     "flatNormals": true,
     "castShadows": false,
@@ -2881,12 +2916,7 @@
     "objectIds": [
       "FAI_VARROCK_FARMING_BORDER_STRAIGHT",
       "FARMING_BORDER_STRAIGHT",
-      "FARMING_BORDER_CORNER",
-      "KEBOS_FARMING_GUILD_BORDER_STRAIGHT",
-      "KEBOS_FARMING_GUILD_BORDER_CORNER",
-      "KEBOS_FARMING_GUILD_BORDER_CORNER_OUTSIDE",
-      "TGOD_GARDEN_TEMPLE_FARMING_BORDER_STRAIGHT",
-      "TGOD_GARDEN_TEMPLE_FARMING_BORDER_CORNER_OUTSIDE"
+      "FARMING_BORDER_CORNER"
     ],
     "colorOverrides": [
       {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13325,8 +13325,6 @@
       {
         "description": "Grass",
         "colors": "s == 7",
-        "flatNormals": true,
-        "upwardsNormals": true,
         "baseMaterial": "GRAY_65",
         "windDisplacementMode": "OBJECT"
       },

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13326,7 +13326,8 @@
         "description": "Grass",
         "colors": "s == 7",
         "flatNormals": true,
-        "baseMaterial": "GRAY_85",
+        "upwardsNormals": true,
+        "baseMaterial": "GRAY_65",
         "windDisplacementMode": "OBJECT"
       },
       {
@@ -13373,23 +13374,34 @@
     ]
   },
   {
-    "description": "Objects - Jungle grass",
-    "flatNormals": true,
+    "description": "Karamja - Mos le Harmless  - Plant - Jungle grass",
     "windDisplacementMode": "OBJECT",
-    "baseMaterial": "GRAY_85",
+    "baseMaterial": "GRAY_65",
+    "castShadows": false,
     "objectIds": [
+      "JUNGLE2",
       "JUNGLEFLOOR1",
       "JUNGLEFLOOR2",
       "JUNGLEFLOOR3",
+      "HARMLESS_DEAD_GRASS1",
+      "HARMLESS_DEAD_GRASS2",
+      "HARMLESS_DEAD_GRASS3"
+    ]
+  },
+  {
+    "description": "Ape Atoll  - Plant - Jungle grass",
+    "windDisplacementMode": "OBJECT",
+    "baseMaterial": "GRAY_50",
+    "castShadows": false,
+    "upwardsNormals": true,
+    "terrainVertexSnap": true,
+    "objectIds": [
       "MM_JUNGLE_GRASS1",
       "MM_JUNGLE_GRASS2",
       "MM_JUNGLE_GRASS3",
       "MM_LONG_JUNGLE_GRASS1",
       "MM_LONG_JUNGLE_GRASS2",
-      "MM_LONG_JUNGLE_GRASS3",
-      "HARMLESS_DEAD_GRASS1",
-      "HARMLESS_DEAD_GRASS2",
-      "HARMLESS_DEAD_GRASS3"
+      "MM_LONG_JUNGLE_GRASS3"
     ]
   },
   {

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -13326,7 +13326,8 @@
         "description": "Grass",
         "colors": "s == 7",
         "baseMaterial": "GRAY_65",
-        "windDisplacementMode": "OBJECT"
+        "windDisplacementMode": "OBJECT",
+        "castShadows": false
       },
       {
         "description": "Leaves",


### PR DESCRIPTION
* Fixes #720 by defining the wood and the grout in the model definition.

* Fixes bug reported in Discord where Grass in Tai Bwo Wana is noisy due to shadows by disabling them on the model.

Note: there is some flickering in the area during the autumn theme. this is present on Master but improved with the changes. a proper fix should be identified for that issue when possible.