### PR TITLE
Fixed Redundant call to `GetModel` on the LocalPlayer

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -1706,9 +1706,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 
 				if (configCharacterDisplacement) {
 					// The local player needs to be added first for distance culling
-					Model playerModel = localPlayer.getModel();
-					if (playerModel != null)
-						uboCompute.addCharacterPosition(lp.getX(), lp.getY(), (int) (LOCAL_TILE_SIZE * 1.33f));
+					uboCompute.addCharacterPosition(lp.getX(), lp.getY(), (int) (LOCAL_TILE_SIZE * 1.33f));
 				}
 
 				// Calculate the viewport dimensions before scaling in order to include the extra padding


### PR DESCRIPTION
The call to `GetModel` was redundant and causing internal crash within the API:
```
java.lang.NullPointerException: Cannot read the array length because "this.co" is null
    at jn.an(jn.java:48619)
    at jn.ak(jn.java:27599)
    at jn.ax(jn.java:649)
    at ij.ai(ij.java:38964)
    at hh.ao(hh.java:482)
    at oz.ai(oz.java:282)
    at cv.ao(cv.java:4232)
    at cv.at(cv.java:16314)
    at iz.xq(iz.java)
    at iz.getModel(iz.java:39223)
    at rs117.hd.HdPlugin.drawScene(HdPlugin.java:1709)
    at it.vv(it.java:16864)
    at it.iz(it.java:7048)
    at rw.ic(rw.java:3237)
    at ck.mm(ck.java:8920)
    at ck.mm(ck.java:8957)
    at ck.mm(ck.java:8957)
    at ck.mm(ck.java:8957)
    at ge.mq(ge.java:8791)
    at client.tc(client.java:14033)
    at client.bo(client.java:12131)
    at bl.ji(bl.java:513)
    at bl.bv(bl.java)
    at bl.run(bl.java:31598)
    at java.base/java.lang.Thread.run(Thread.java:1583)
```