### PR TITLE
Apply area hiding to the Catacombs of Kourend

### DIFF
--- a/src/main/resources/rs117/hd/scene/areas.json
+++ b/src/main/resources/rs117/hd/scene/areas.json
@@ -4720,7 +4720,8 @@
     "name": "KOUREND_CATACOMBS_DUNGEON",
     "aabbs": [
       [ 1584, 9976, 1751, 10111 ]
-    ]
+    ],
+    "hideOtherAreas": true
   },
   {
     "name": "KOUREND_CATACOMBS",


### PR DESCRIPTION
Area hiding here fixes a potential edge case of overdraw caused by unrelated areas