### PR TITLE
Disable ImageStore Variant on AMD Cards

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -352,7 +353,7 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 	private AWTContext awtContext;
 	private Callback debugCallback;
 	private ComputeMode computeMode = ComputeMode.OPENGL;
-	private boolean isAMDGPU = false;
+	private boolean isAmdGpu;
 
 	private static final String LINUX_VERSION_HEADER =
 		"#version 420\n" +
@@ -576,14 +577,11 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 				useLowMemoryMode = config.lowMemoryMode();
 				BUFFER_GROWTH_MULTIPLIER = useLowMemoryMode ? 1.333f : 2;
 
-				String glRenderer = glGetString(GL_RENDERER);
-				String glVendor = glGetString(GL_VENDOR);
+				String glRenderer = Objects.requireNonNullElse(glGetString(GL_RENDERER), "Unknown");
+				String glVendor = Objects.requireNonNullElse(glGetString(GL_VENDOR), "Unknown");
 				String arch = System.getProperty("sun.arch.data.model", "Unknown");
-				if (glRenderer == null)
-					glRenderer = "Unknown";
-				else
-					isAMDGPU = glRenderer.contains("AMD") || glRenderer.contains("Radeon") || glVendor.contains("ATI");
-				log.info("Using device: {}", glRenderer);
+				isAmdGpu = glRenderer.contains("AMD") || glRenderer.contains("Radeon") || glVendor.contains("ATI");
+				log.info("Using device: {} ({})", glRenderer, glVendor);
 				log.info("Using driver: {}", glGetString(GL_VERSION));
 				log.info("Client is {}-bit", arch);
 				log.info("Low memory mode: {}", useLowMemoryMode);
@@ -960,7 +958,10 @@ public class HdPlugin extends Plugin implements DrawCallbacks {
 		uiProgram.compile(includes);
 
 		if (configDynamicLights != DynamicLights.NONE && configTiledLighting) {
-			if (GL_CAPS.GL_ARB_shader_image_load_store && tiledLightingImageStoreProgram.isViable() && configTiledLightingImageLoadStore && !isAMDGPU) {
+			if (!isAmdGpu && configTiledLightingImageLoadStore &&
+				GL_CAPS.GL_ARB_shader_image_load_store &&
+				tiledLightingImageStoreProgram.isViable()
+			) {
 				try {
 					tiledLightingImageStoreProgram.compile(includes
 						.define("TILED_IMAGE_STORE", true)


### PR DESCRIPTION
Fixes ImageStore variant causing issues on some AMD cards, this is a workaround until we're able to test the ImageStore variant on an AMD Card to debug why its occurring. Recreating due to [728](https://github.com/117HD/RLHD/pull/728) being closed & I can't reopen.

AMD - ImageStore:
<img width="1881" height="997" alt="image" src="https://github.com/user-attachments/assets/70668177-4dc6-447f-b30d-9db6fac55bc7" />


AMD - Layered:
<img width="1890" height="998" alt="image" src="https://github.com/user-attachments/assets/08e6fd68-492c-46ac-903d-f7219a7fb8be" />
