### PR TITLE
Temporarily disable normals on dirt

### DIFF
--- a/src/main/resources/rs117/hd/scene/materials.json
+++ b/src/main/resources/rs117/hd/scene/materials.json
@@ -844,7 +844,6 @@
   },
   {
     "name": "DIRT_1",
-    "normalMap": "DIRT_1_N",
     "specularStrength": 0.25,
     "specularGloss": 18.0
   },
@@ -858,7 +857,6 @@
   },
   {
     "name": "DIRT_2",
-    "normalMap": "DIRT_2_N",
     "specularStrength": 0.25,
     "specularGloss": 18.0
   },


### PR DESCRIPTION
This is a shot in the dark, close this if its not something we are interested in but I feel like the textures and normal maps are far too low resolution and just get stretched and warped badly on steep slopes, and there come up all over the game. Below is one of the worse examples

<img width="2286" height="1416" alt="java_tJNxaUC9ea" src="https://github.com/user-attachments/assets/9aeec22f-1c4f-4ed9-b4d0-912d47968910" />
<img width="2286" height="1416" alt="java_VETqReVJTx" src="https://github.com/user-attachments/assets/9d421144-c712-478a-ad20-9706ec51ba93" />

Currently we try and mitigate this by using dirt_vert in places this happens, but it simply happens too frequently and in too many places