### PR TITLE
fix(opencl): Call `clReleaseEvent` to prevent memory leak

### DIFF
--- a/src/main/java/rs117/hd/opengl/compute/OpenCLManager.java
+++ b/src/main/java/rs117/hd/opengl/compute/OpenCLManager.java
@@ -477,14 +477,14 @@ public class OpenCLManager {
 
 			// Release OpenCL events to prevent memory leak
 			// Events are reference-counted host memory objects that must be explicitly freed
-			long acquireEventPtr = acquireEvent.get(0);
-			if (acquireEventPtr != 0)
-				clReleaseEvent(acquireEventPtr);
+			long pointer = acquireEvent.get(0);
+			if (pointer != 0L)
+				clReleaseEvent(pointer);
 
 			for (int i = 0; i < computeEvents.limit(); ++i) {
-				long ptr = computeEvents.get(i);
-				if (ptr != 0L)
-					clReleaseEvent(ptr);
+				pointer = computeEvents.get(i);
+				if (pointer != 0L)
+					clReleaseEvent(pointer);
 			}
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/117HD/RLHD/issues/184 

All CL events need to be manually released from memory otherwise they stick around forever. 

These tests were run back to back with the renderer at 30fps, and the leak would only be worse at higher FPS, more usage

# Runelite (`117hd_xJ2ZUKTERx1pvve-u57oLZy292Pxgyk4-46asSpDpuE.jar`) 
## After launch
<img width="825" height="57" alt="Screenshot 2025-10-28 at 5 02 48 PM" src="https://github.com/user-attachments/assets/6881e9ba-41d3-4f31-b353-28e81b626032" />

## After 2hrs of gemstone crab fighting
<img width="882" height="67" alt="Screenshot 2025-10-28 at 5 01 06 PM" src="https://github.com/user-attachments/assets/b3fd36d2-80cc-4c63-b7a3-da2b5d76b767" />

## After logging out
<img width="823" height="64" alt="Screenshot 2025-10-28 at 5 01 42 PM" src="https://github.com/user-attachments/assets/0c912f8a-49a5-4fc9-a31a-b26a9a11cfa2" />

# Patch
## After launch
<img width="814" height="62" alt="Screenshot 2025-10-28 at 7 10 30 PM" src="https://github.com/user-attachments/assets/2c8490db-a297-454a-865c-66220132e16d" />

## After 2hrs of gemstone crab fighting (seems to float up to 4gb and GC back down to 3.8gb) but still saving a GB+
<img width="814" height="58" alt="Screenshot 2025-10-28 at 7 04 10 PM" src="https://github.com/user-attachments/assets/f3df82a2-856a-468f-b43e-0e1e85ebbb1c" />

## After logging out
<img width="823" height="60" alt="Screenshot 2025-10-28 at 7 09 57 PM" src="https://github.com/user-attachments/assets/a8e8cc8e-a5d9-4121-96bd-d6ef84de8c08" />
