### PR TITLE
Lands End objects

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -34832,7 +34832,7 @@
     "uvOrientation": 1024
   },
   {
-    "description": "Remmington House Walls",
+    "description": "Rimmington House Walls",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [ "RIMMINGTON_POOR_WALLS", "RIMMINGTON_POOR_WALLS_INTERNAL", "RIMMINGTON_WOOD_WALLS_WINDOW_SINGLE01", "RIMMINGTON_WOOD_WALLS_WINDOW_DOUBLE01" ],
     "uvType": "BOX",
@@ -34842,7 +34842,7 @@
     "flatNormals": true
   },
   {
-    "description": "Remmington House Roof - Corner",
+    "description": "Rimmington House Roof - Corner",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [ "RIMMINGTON_POOR_ROOF_EDGE", "RIMMINGTON_POOR_ROOF_EDGE_2", "RIMMINGTON_POOR_ROOF_EDGE_2_MIRROR", "RIMMINGTON_POOR_ROOF_EDGE_MIRROR", "RIMMINGTON_ROOFTOP3_FLAT", "RIMMINGTON_ROOFTOP1_MIRROR", "RIMMINGTON_ROOFTOP2_MIRROR", "RIMMINGTON_ROOFTOP3_MIRROR", "RIMMINGTON_ROOFTOP4_MIRROR", "RIMMINGTON_ROOFTOPEDGE", "RIMMINGTON_ROOFTOPEDGE_MIRROR", "RIMMINGTON_ROOFTOP2X2", "RIMMINGTON_ROOFTOP2X2_MIRROR" ],
     "uvType": "BOX",
@@ -34851,7 +34851,7 @@
     "flatNormals": true
   },
   {
-    "description": "Remmington House Roof - some models have weird rotations",
+    "description": "Rimmington House Roof - some models have weird rotations",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [ "RIMMINGTON_POOR_ROOF_EXTERNALWALL1", "RIMMINGTON_POOR_ROOF1", "RIMMINGTON_POOR_ROOF_EXTERNALWALL1_MIRROR", "RIMMINGTON_POOR_ROOF_MID2", "RIMMINGTON_ROOFTOP1", "RIMMINGTON_ROOFTOP2", "RIMMINGTON_ROOFTOP2_FLAT", "RIMMINGTON_ROOFTOP3", "RIMMINGTON_ROOFTOP4", "RIMMINGTON_ROOFTOP_EXTERNALWALL1", "RIMMINGTON_ROOFTOP_EXTERNALWALL2", "RIMMINGTON_ROOFTOP_EXTERNALWALL3", "RIMMINGTON_ROOFTOP_EXTERNALWALL1_MIRROR", "RIMMINGTON_ROOFTOP_EXTERNALWALL2_MIRROR", "RIMMINGTON_ROOFTOP_EXTERNALWALL3_MIRROR", "RIMMINGTON_ROOFTOP4X4" ],
     "uvType": "BOX",
@@ -60300,7 +60300,7 @@
     ]
   },
   {
-    "description": "Remmington - Lands End - Wooden - Shelves - With Boxes",
+    "description": "Rimmington - Lands End - Wooden - Shelves - With Boxes",
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "objectIds": [


### PR DESCRIPTION
Upgrades the few remaining untexured objects around Lands End.

Does not touch anything on the docks or boats or in the water to ensure compatibility with #761