### PR TITLE
Pest Control Island Upgrade

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -60414,7 +60414,7 @@
     "objectIds": [ "PEST_SHELVES_RUNES_2" ],
     "colorOverrides": [
       {
-        "colors": "h == 6 || (h == 5 && s == 1) || (h == 4 && s == 1)",
+        "colors": "h == 6 || h == 5 && s == 1 || h == 4 && s == 1",
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX"
       }
@@ -60427,7 +60427,7 @@
     "objectIds": [ "PEST_SHELVES_RUNES_1" ],
     "colorOverrides": [
       {
-        "colors": "h == 6 || (h == 5 && s == 1) || (h == 4 && s == 1)",
+        "colors": "h == 6 || h == 5 && s == 1 || h == 4 && s == 1",
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX"
       }
@@ -60440,7 +60440,7 @@
     "objectIds": [ "PEST_SHELVES_RUNES_3" ],
     "colorOverrides": [
       {
-        "colors": "h == 6 || (h == 5 && s == 1) || (h == 4 && s == 1)",
+        "colors": "h == 6 || h == 5 && s == 1 || h == 4 && s == 1",
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX"
       },


### PR DESCRIPTION
Textures the buildings and objects within them, as well as the main fort wall.

Avoids texturing any docks or boats (including for the minigame) to ensure compatibility with #761 

Master/PR:
<img width="1278" height="587" alt="image" src="https://github.com/user-attachments/assets/6d0426a9-1868-4212-bfd9-57c04a8ad7c0" />
<img width="1278" height="587" alt="image" src="https://github.com/user-attachments/assets/7d9dc5ae-b987-4e87-b7ea-46ac16008cd4" />
