### PR TITLE
Fix OpenCL buffer cleanup crash when switching renderers

### DIFF
--- a/src/main/java/rs117/hd/utils/buffer/SharedGLBuffer.java
+++ b/src/main/java/rs117/hd/utils/buffer/SharedGLBuffer.java
@@ -17,7 +17,7 @@ public class SharedGLBuffer extends GLBuffer {
 	}
 
 	private void releaseCLBuffer() {
-		if (clId != 0)
+		if (clId != 0 && OpenCLManager.context != 0)
 			clReleaseMemObject(clId);
 		clId = 0;
 	}


### PR DESCRIPTION
When disabling 'use legacy render' config.:

```
2025-11-07 11:55:06 PST [Client] ERROR rs117.hd.HdPlugin - Error while changing settings:
java.lang.IllegalStateException: OpenCL library has not been loaded.
	at org.lwjgl.opencl.CL.check(CL.java:218)
	at org.lwjgl.opencl.CL.getICD(CL.java:230)
	at org.lwjgl.opencl.CL10.clReleaseMemObject(CL10.java:4370)
	at rs117.hd.utils.buffer.SharedGLBuffer.releaseCLBuffer(SharedGLBuffer.java:21)
	at rs117.hd.utils.buffer.SharedGLBuffer.destroy(SharedGLBuffer.java:27)
	at rs117.hd.renderer.legacy.LegacyRenderer.destroyModelSortingBins(LegacyRenderer.java:417)
	at rs117.hd.renderer.legacy.LegacyRenderer.destroy(LegacyRenderer.java:260)
	at rs117.hd.HdPlugin.lambda$shutDown$3(HdPlugin.java:676)
	at net.runelite.client.callback.ClientThread.lambda$invoke$0(ClientThread.java:49)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:62)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:47)
	at rs117.hd.HdPlugin.shutDown(HdPlugin.java:635)
	at rs117.hd.HdPlugin.lambda$restartPlugin$5(HdPlugin.java:713)
	at net.runelite.client.callback.ClientThread.lambda$invoke$0(ClientThread.java:49)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:62)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:47)
	at rs117.hd.HdPlugin.restartPlugin(HdPlugin.java:712)
	at rs117.hd.HdPlugin.lambda$processPendingConfigChanges$13(HdPlugin.java:1587)
	at net.runelite.client.callback.ClientThread.lambda$invoke$0(ClientThread.java:49)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:239)
	at client.gt(client.java:51832)
	at client.bf(client.java)
	at bm.bo(bm.java:463)
	at bm.bu(bm.java)
	at bm.run(bm.java:48878)
	at java.base/java.lang.Thread.run(Unknown Source)
```

The crash occurred because OpenCLManager.shutDown() destroys the OpenCL context before SharedGLBuffer.releaseCLBuffer() attempts to release CL memory objects.

- Added context check before calling clReleaseMemObject() to prevent accessing freed OpenCL resources.