### PR TITLE
Depth Bias Fixes

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -65238,6 +65238,9 @@
       "TEMPOROSS_BOSS_WHIRLPOOL",
       "TEMPOROSS_BOSS_READY"
     ],
+    "graphicsObjectIds": [
+      "TEMPOROSS_FISHING_SPOTANIM"
+    ],
     "depthBias": 255
   },
   {


### PR DESCRIPTION
Wasnt able to get it into a spot where it was totally under the ground, this was the best I could get it, also restores the green snake head thats usually on the scroll
<img width="755" height="600" alt="image" src="https://github.com/user-attachments/assets/0a7df4b9-ca75-477f-8822-246ff894d132" />
<img width="552" height="454" alt="image" src="https://github.com/user-attachments/assets/5111b674-cfb0-4531-b23e-278b0a6f86a3" />

PoH stuff
<img width="874" height="624" alt="java_UYWdZR3oDD" src="https://github.com/user-attachments/assets/773e0c1f-3d25-4be0-9daf-a9944625fce3" />
<img width="733" height="587" alt="java_FeNE3HQVBk" src="https://github.com/user-attachments/assets/045bbb1f-8d7d-4b67-97ab-8fce655de18d" />

<img width="727" height="519" alt="java_Tk3WtrUcFC" src="https://github.com/user-attachments/assets/33fa1afc-a190-4079-b6e8-f3e566c0e997" />
<img width="763" height="547" alt="java_PPZ8C7wavO" src="https://github.com/user-attachments/assets/1ac65f90-5802-439a-a200-9ee1dec1b941" />


https://github.com/user-attachments/assets/e5f845c0-1adf-4004-8ab8-1cdfbbda209f

https://github.com/user-attachments/assets/c7a7a8f8-2948-4963-b795-d2c3efa880e8

Certainly not perfect and I think theres some issue going on with the waters surface taking priority regardless, but it is slightly better especially on the attackable pools and the reward pools
<img width="2286" height="1416" alt="java_8pf7yKVC2U" src="https://github.com/user-attachments/assets/351283f9-cba2-48ea-a61a-2b2706381a3d" />
<img width="2286" height="1416" alt="java_OTTe4Yw7UM" src="https://github.com/user-attachments/assets/f38471c9-3a0c-4a19-a45c-37a4db7ee19b" />

https://github.com/user-attachments/assets/1002e1c4-9a3f-4e85-8026-a291ba389cb0

https://github.com/user-attachments/assets/055ba545-48ef-4ed9-a770-7945962b9a38


