### PR TITLE
Make falling rock shadows slightly more visible

### DIFF
--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -38012,11 +38012,12 @@
   {
     "description": "Grotesque Guardians Flames",
     "graphicsObjectIds": [
-      "GG_DUSK_LIGHTNING_ENRAGED"
+      "GG_DUSK_LIGHTNING_ENRAGED",
+      "GG_DUSK_LIGHTNING_DAWN_DEATH"
     ],
-    "offset": [ 0, 10, 0 ],
-    "radius": 175,
-    "strength": 20,
+    "offset": [ 0, 20, 0 ],
+    "radius": 185,
+    "strength": 22,
     "color": [
       50,
       0,
@@ -38044,25 +38045,6 @@
       255
     ],
     "type": "STATIC"
-  },
-  {
-    "description": "Grotesque Guardians Dusk Heal Orb",
-    "objectIds": [
-      "GARGBOSS_HEALSPHERE_SMALL",
-      "GARGBOSS_HEALSPHERE_MED",
-      "GARGBOSS_HEALSPHERE_LARGE"
-    ],
-    "offset": [ 0, 10, 0 ],
-    "radius": 200,
-    "strength": 20,
-    "color": [
-      50,
-      0,
-      255
-    ],
-    "type": "STATIC",
-    "fadeInDuration": 100,
-    "fadeOutDuration": 150
   },
   {
     "description": "Paterdomus Temple Basement Monument lights",

--- a/src/main/resources/rs117/hd/scene/materials.json
+++ b/src/main/resources/rs117/hd/scene/materials.json
@@ -1059,6 +1059,11 @@
     "brightness": 0.25
   },
   {
+    "name": "GRAY_05",
+    "parent": "NONE",
+    "brightness": 0.05
+  },
+  {
     "name": "BLACK",
     "parent": "NONE",
     "brightness": 0

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -31388,14 +31388,21 @@
   },
   {
     "description": "Falling rocks at Grotesque Guardians",
+    "baseMaterial": "GRAY_05",
     "hideVanillaShadows": true,
     "retainVanillaShadowsInPvm": true,
     "hideHdShadowsInPvm": true,
     "graphicsObjectIds": [
+      "GARGBOSS_DEBRIS_SHADOW_60",
+      "GARGBOSS_DEBRIS_SHADOW_60_SMALL",
+      "GARGBOSS_DEBRIS_SHADOW_90",
+      "GARGBOSS_DEBRIS_SHADOW_120",
+      "GARGBOSS_DEBRIS_SHADOW_150",
       "GARGBOSS_DEBRIS_SHADOW_180",
       "GARGBOSS_DEBRIS_SHADOW_210",
       "GARGBOSS_DEBRIS_SHADOW_240",
-      "GARGBOSS_DEBRIS_SHADOW_270"
+      "GARGBOSS_DEBRIS_SHADOW_270",
+      "GARGBOSS_DEBRIS_SHADOW_300"
     ],
     "projectileIds": [ "GG_FALLING_PROJECTILE" ]
   },
@@ -44228,7 +44235,7 @@
   },
   {
     "description": "Grotesque Guardians Tiled Floor",
-    "baseMaterial": "STONE_NORMALED",
+    "baseMaterial": "STONE_NORMALED_LIGHT",
     "objectIds": [
       "SLAYER_TOWER_ROOF_TOP_FLOOR_1A",
       "SLAYER_TOWER_ROOF_TOP_FLOOR_1B",
@@ -44248,7 +44255,8 @@
       "SLAYER_TOWER_ROOF_TOP_FLOOR_4D"
     ],
     "uvType": "MODEL_XZ",
-    "uvOrientation": 156
+    "uvOrientation": 156,
+    "uvScale": 1.2
   },
   {
     "description": "Grotesque Guardians Low Wall",


### PR DESCRIPTION
It is rather slight but hopefully it makes all the difference for people struggling to see the falling shadow locations when using 117hd

Before:
<img width="2286" height="1416" alt="java_BKjOe9GMGD" src="https://github.com/user-attachments/assets/f65705a1-03db-488f-bf9d-30a884185e0a" />
After:
<img width="2286" height="1416" alt="java_5aUIetrbnw" src="https://github.com/user-attachments/assets/a6cf6d47-6f68-4c7e-a54a-6f817113bcc3" />
