### PR TITLE
Fix some path tiles in Edgeville not respecting the winter theme

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -1628,7 +1628,10 @@
     "overlayIds": [
       10
     ],
-    "groundMaterial": "VARROCK_PATHS"
+    "groundMaterial": "VARROCK_PATHS",
+    "replacements": {
+      "WINTER_JAGGED_STONE_TILE_LIGHT": "season == SeasonalTheme.WINTER"
+    }
   },
   {
     "name": "EDGEVILLE_BANK_PERIMETER_FIX",
@@ -1652,6 +1655,7 @@
     ],
     "groundMaterial": "VARROCK_PATHS",
     "replacements": {
+      "WINTER_JAGGED_STONE_TILE_LIGHT": "season == SeasonalTheme.WINTER",
       "EDGEVILLE_BANK_WINDOW_FIX_UNBLEND": "!blending"
     },
     "blended": false,


### PR DESCRIPTION
Fixes path tiles in front of the window not being snowy

<img width="2286" height="1416" alt="java_hRNcUL4KJM" src="https://github.com/user-attachments/assets/d2fa5fb5-987b-4732-bea2-2b885eb068e0" />

<img width="2286" height="1416" alt="java_TRWhZVjlSO" src="https://github.com/user-attachments/assets/ae919826-56fd-4003-bca7-8ae4db93e563" />
