### PR TITLE
add missing tile definition in warm region

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -7483,6 +7483,7 @@
     "minSaturation": 3,
     "maxSaturation": 3,
     "underlayIds": [
+      48,
       61,
       62,
       64,
@@ -9339,6 +9340,7 @@
       26,
       33,
       38,
+      48,
       49,
       50,
       51,


### PR DESCRIPTION
I forgot a tile South of the Ruins of Unkah

* Fixes incorrect theme on 1 tile