### PR TITLE
Define Red Rock

### DIFF
--- a/src/main/resources/rs117/hd/scene/areas.json
+++ b/src/main/resources/rs117/hd/scene/areas.json
@@ -9463,7 +9463,9 @@
   },
   {
     "name": "RED_ROCK",
-    "regions": [ 11046, 11047 ]
+    "regionBoxes": [
+      [ 11046, 11047 ]
+    ]
   },
   {
     "name": "ISLE_OF_BONES",


### PR DESCRIPTION
Defines the Red Rock area and adds it to the warm region

* Fixes incorrect tiles on the island