### PR TITLE
Void Knight Outpost Roof fix

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -66202,15 +66202,18 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
+    "flatNormals": true,
     "objectIds": [
       "PEST_FARM_BARN_ROOF",
       "PEST_FARM_BARN_ROOF1",
       "PEST_FARM_BARN_ROOF2",
       "PEST_FARM_BARN_ROOF_EDGE",
       "FARM_BARN_ROOF_MID_EDGE",
+      "FARM_BARN_ROOF_MID_EDGE2",
       "PEST_FARM_BARN_ROOF_EDGE_MIRROR",
       "PEST_FARM_BARN_ROOF_EDGE_2",
-      "PEST_FARM_BARN_ROOF_EDGE_2_MIRROR"
+      "PEST_FARM_BARN_ROOF_EDGE_2_MIRROR",
+      "FARM_BARN_ROOF_MID2"
     ]
   },
   {


### PR DESCRIPTION
Add missing roof, use flat normals
<img width="1181" height="796" alt="image" src="https://github.com/user-attachments/assets/177f03b7-c903-4b0c-9764-236e3c0dfac1" />
