### PR TITLE
Winter Sand improvement

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -108,9 +108,9 @@
   },
   {
     "name": "WINTER_SAND",
-    "groundMaterial": "SNOW_2",
-    "maxHue": 0,
-    "maxSaturation": 0,
+    "groundMaterial": "SAND",
+    "maxHue": 6,
+    "maxSaturation": 1,
     "shiftLightness": 40,
     "maxLightness": 70
   },
@@ -9629,7 +9629,7 @@
     ],
     "replacements": {
       "SEASONAL_GRUNGE": "s == 0 || h <= 10 && s < 2",
-      "DEFAULT_SAND": "h == 8 && s == 4 && l >= 71 || h == 8 && s == 3 && l >= 48",
+      "SEASONAL_SAND": "h == 8 && s == 4 && l >= 71 || h == 8 && s == 3 && l >= 48",
       "SEASONAL_GRASS": [
         "h >= 11 && s == 1",
         "h == 9 && s == 2",


### PR DESCRIPTION
uses already defined WINTER_SAND to add perimeters to de saturate and brighten the sand as if it had snow on it
Only affects areas winter theme applies

Master/Pr:
<img width="332" height="406" alt="image" src="https://github.com/user-attachments/assets/4970548a-bc25-4367-a745-304a139c0183" />
<img width="332" height="406" alt="image" src="https://github.com/user-attachments/assets/80e35458-c0b5-4988-adc6-b684df6182b1" />
