### PR TITLE
Improve JobSystem Shutdown

### DIFF
--- a/src/main/java/rs117/hd/renderer/zone/SceneManager.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneManager.java
@@ -278,7 +278,8 @@ public class SceneManager {
 	public void completeAllStreaming() {
 		root.sceneLoadGroup.complete();
 		root.streamingGroup.complete();
-		root.invalidationGroup.complete();
+
+		root.completeInvalidation();
 
 		WorldView wv = client.getTopLevelWorldView();
 		if (wv != null) {
@@ -287,7 +288,8 @@ public class SceneManager {
 				if (ctx != null) {
 					ctx.sceneLoadGroup.complete();
 					ctx.streamingGroup.complete();
-					ctx.invalidationGroup.complete();
+
+					ctx.completeInvalidation();
 				}
 			}
 		}


### PR DESCRIPTION
Instead of clearing queues, pop all pending work & cancel them to ensure all other threads which might be waiting for completion pick up on the job system shutdown

Also call completeInvalidation() in completeAllStreaming() to prevent leaks from not swapping in zones