### PR TITLE
More Tile Brightness Fixes

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -1372,7 +1372,10 @@
     "maxHue": 7,
     "minSaturation": 1,
     "maxSaturation": 1,
-    "shiftLightness": 20
+    "shiftLightness": 20,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_EAST_BANK_PATH_FIX_1",
@@ -1386,7 +1389,10 @@
     "maxHue": 7,
     "minSaturation": 1,
     "maxSaturation": 1,
-    "shiftLightness": 16
+    "shiftLightness": 16,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_TRIANGLE_DIRT_PATH_FIX_1",
@@ -1395,7 +1401,10 @@
       2
     ],
     "groundMaterial": "GRAVEL",
-    "shiftLightness": 3
+    "shiftLightness": 3,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_TRIANGLE_DIRT_PATH_FIX_2",
@@ -1406,7 +1415,10 @@
     "groundMaterial": "GRAVEL",
     "shiftHue": -4,
     "shiftSaturation": -1,
-    "shiftLightness": 5
+    "shiftLightness": 5,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_TRIANGLE_PATH_PATH_FIX_1",
@@ -1417,7 +1429,10 @@
     "groundMaterial": "GRAVEL",
     "shiftHue": -4,
     "shiftSaturation": -1,
-    "shiftLightness": 2
+    "shiftLightness": 2,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_SOUTH_PATH_FIX_1",
@@ -1430,7 +1445,10 @@
     "maxHue": 7,
     "minSaturation": 1,
     "maxSaturation": 1,
-    "shiftLightness": 19
+    "shiftLightness": 19,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_SOUTH_PATH_FIX_2",
@@ -1441,7 +1459,10 @@
     "groundMaterial": "GRAVEL",
     "shiftHue": -4,
     "shiftSaturation": -1,
-    "shiftLightness": 2
+    "shiftLightness": 2,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_PATHS",
@@ -1454,7 +1475,10 @@
     "maxHue": 7,
     "minSaturation": 1,
     "maxSaturation": 1,
-    "shiftLightness": 15
+    "shiftLightness": 15,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "FALADOR_HAIRDRESSER_TILE_1",

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -3718,7 +3718,10 @@
     ],
     "groundMaterial": "SAND_BRICK",
     "shiftSaturation": -2,
-    "shiftLightness": 12
+    "shiftLightness": 12,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "LLETYA_WOOD_FLOORS",
@@ -3735,7 +3738,10 @@
     "overlayIds": [ 42, 106 ],
     "groundMaterial": "HD_WOOD_PLANKS_2",
     "blended": false,
-    "shiftLightness": 10
+    "shiftLightness": 10,
+    "replacements": {
+      "NONE": "!textures"
+    }
   },
   {
     "name": "PRIFDDINAS_INTERIORS_RAISED",


### PR DESCRIPTION
Falador Paths, Master/PR/GPU:
<img width="2286" height="1416" alt="java_iPEkODov6e" src="https://github.com/user-attachments/assets/96e38c81-36e9-4680-81fc-580f6d77ff32" />

<img width="2286" height="1416" alt="java_rVya3kEs5B" src="https://github.com/user-attachments/assets/51813dc4-00b4-46b2-a34e-2966581431bb" />

<img width="2286" height="1416" alt="java_4kWXJ0tWfi" src="https://github.com/user-attachments/assets/a949cd61-fc1a-43bb-9c59-6b1fb1bbc6cd" />


Prifddinas Buildings: Master/PR/GPU:
<img width="2286" height="1416" alt="java_elFSzw6TCK" src="https://github.com/user-attachments/assets/e465e02d-16eb-469f-9630-962e973a1793" />

<img width="2286" height="1416" alt="java_xHl4XkIO5s" src="https://github.com/user-attachments/assets/c87dd4fa-26c6-4799-b95b-969a55be62ec" />

<img width="2286" height="1416" alt="java_MSnrQQ9XLW" src="https://github.com/user-attachments/assets/ed3e6b51-0388-444b-83a6-89f168aa61ef" />


Arandar Pass, Master/PR:
<img width="2286" height="1416" alt="java_q8gAsRyR1l" src="https://github.com/user-attachments/assets/a0c91d50-69aa-483c-affd-a6ee204daf53" />

<img width="2286" height="1416" alt="java_TfzbbRintd" src="https://github.com/user-attachments/assets/7f60168f-48da-4b9f-8c34-f9340e727956" />

