### PR TITLE
Zone Invalidation Improvements

### DIFF
--- a/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
@@ -606,6 +606,8 @@ public class SceneUploader {
 		} else if (r instanceof DynamicObject) {
 			var dynamic = (DynamicObject) r;
 			m = dynamic.getModelZbuf();
+			if (dynamic.getAnimation() != null)
+				z.numAnimatedDynamicObjects++;
 			if (dynamic.getRecordedObjectComposition() != null)
 				mightHaveTransparency = true;
 		}

--- a/src/main/java/rs117/hd/renderer/zone/WorldViewContext.java
+++ b/src/main/java/rs117/hd/renderer/zone/WorldViewContext.java
@@ -1,6 +1,5 @@
 package rs117.hd.renderer.zone;
 
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingDeque;
 import javax.annotation.Nullable;
@@ -10,7 +9,6 @@ import rs117.hd.opengl.uniforms.UBOWorldViews;
 import rs117.hd.opengl.uniforms.UBOWorldViews.WorldViewStruct;
 import rs117.hd.utils.jobs.JobGroup;
 
-import static net.runelite.api.Constants.*;
 import static org.lwjgl.opengl.GL33C.*;
 import static rs117.hd.renderer.zone.SceneManager.NUM_ZONES;
 
@@ -33,7 +31,6 @@ public class WorldViewContext {
 	public long uploadTime;
 	public long sceneSwapTime;
 
-	final HashSet<Integer> drawnDynamicGameObjects = new HashSet<>();
 	final LinkedBlockingDeque<Zone> pendingCull = new LinkedBlockingDeque<>();
 	final JobGroup<ZoneUploadJob> sceneLoadGroup = new JobGroup<>(true, true);
 	final JobGroup<ZoneUploadJob> streamingGroup = new JobGroup<>(false, false);
@@ -216,27 +213,5 @@ public class WorldViewContext {
 		curZone.uploadJob.delay = prevUploadDelay;
 		if (curZone.uploadJob.delay < 0.0f)
 			curZone.uploadJob.queue(shouldBlock ? blockingInvalidationGroup : streamingGroup, sceneManager.getGenerateSceneDataTask());
-	}
-
-	boolean doesZoneContainPreviouslyDynamicGameObject(int mzx, int mzz) {
-		if (drawnDynamicGameObjects.isEmpty())
-			return false;
-
-		final Tile[][][] tiles = sceneContext.scene.getExtendedTiles();
-		for (int z = 0; z < MAX_Z; ++z) {
-			for (int xoff = 0; xoff < 8; ++xoff) {
-				for (int zoff = 0; zoff < 8; ++zoff) {
-					Tile t = tiles[z][(mzx << 3) + xoff][(mzz << 3) + zoff];
-					if (t != null) {
-						for (GameObject gameObject : t.getGameObjects()) {
-							if (gameObject != null && drawnDynamicGameObjects.contains(gameObject.getId())) {
-								return true; // A dynamic object is present in this zone
-							}
-						}
-					}
-				}
-			}
-		}
-		return false;
 	}
 }

--- a/src/main/java/rs117/hd/renderer/zone/Zone.java
+++ b/src/main/java/rs117/hd/renderer/zone/Zone.java
@@ -77,6 +77,8 @@ public class Zone {
 
 	ZoneUploadJob uploadJob;
 
+	public int numAnimatedDynamicObjects;
+
 	int[] levelOffsets = new int[5]; // buffer pos in ints for the end of the level
 
 	int[][] rids;

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -274,7 +274,6 @@ public class ZoneRenderer implements Renderer {
 		ctx.level = level;
 		ctx.maxLevel = maxLevel;
 		ctx.hideRoofIds = hideRoofIds;
-		ctx.drawnDynamicGameObjects.clear();
 
 		if (ctx.uboWorldViewStruct != null)
 			ctx.uboWorldViewStruct.update();
@@ -1096,9 +1095,6 @@ public class ZoneRenderer implements Renderer {
 		} else {
 			sceneUploader.uploadTempModel(m, modelOverride, preOrientation, orient, x, y, z, o.vbo.vb, o.vbo.vb);
 		}
-
-		if (r instanceof GameObject)
-			ctx.drawnDynamicGameObjects.add(((GameObject) r).getId());
 	}
 
 	@Override

--- a/src/main/java/rs117/hd/renderer/zone/ZoneSceneContext.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneSceneContext.java
@@ -1,8 +1,11 @@
 package rs117.hd.renderer.zone;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import net.runelite.api.*;
 import rs117.hd.scene.SceneContext;
+
+import static net.runelite.api.Constants.*;
 
 public class ZoneSceneContext extends SceneContext {
 	public int totalReused;
@@ -22,5 +25,34 @@ public class ZoneSceneContext extends SceneContext {
 			sizeX = worldView.getSizeX();
 			sizeZ = worldView.getSizeY();
 		}
+	}
+
+	public int countAnimatedDynamicObjectsInZone(int zx, int zz) {
+		int count = 0;
+		final Tile[][][] tiles = scene.getExtendedTiles();
+		for (int z = 0; z < MAX_Z; ++z) {
+			for (int x = 0; x < 8; ++x) {
+				for (int y = 0; y < 8; ++y) {
+					Tile t = tiles[z][(zx << 3) + x][(zz << 3) + y];
+					if (t != null)
+						count += countAnimatedObjects(t);
+				}
+			}
+		}
+		return count;
+	}
+
+	private int countAnimatedObjects(@Nonnull Tile t) {
+		int count = 0;
+		for (var gameObject : t.getGameObjects()) {
+			if (gameObject == null)
+				continue;
+			var r = gameObject.getRenderable();
+			if (r instanceof DynamicObject && ((DynamicObject) r).getAnimation() != null)
+				count++;
+		}
+		if (t.getBridge() != null)
+			count += countAnimatedObjects(t.getBridge());
+		return count;
 	}
 }


### PR DESCRIPTION
 * Zone Invalidation is triggered as soon as the API is invoked
 * Wait for all queued invalidation to complete before the next update is triggered
 * Moved JobGroup removal to release, not completion since we still want to loop through JobGroup work in some cases
 * Added FrameCounter to allow tracking of when ZoneUploads we're queued