### PR TITLE
Fix potential crash caused by unmap being called on none client thread

### DIFF
--- a/src/main/java/rs117/hd/renderer/zone/SceneManager.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneManager.java
@@ -1,6 +1,7 @@
 package rs117.hd.renderer.zone;
 
 import com.google.common.base.Stopwatch;
+import com.google.inject.Injector;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,10 +47,13 @@ public class SceneManager {
 	private static final int ZONE_DEFER_DIST_START = 3;
 
 	@Inject
-	protected Client client;
+	private Injector injector;
 
 	@Inject
-	protected ClientThread clientThread;
+	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private HdPlugin plugin;
@@ -80,13 +84,14 @@ public class SceneManager {
 
 	private UBOWorldViews uboWorldViews;
 
-	private final Map<Integer, Integer> nextRoofChanges = new HashMap<>();
 	@Getter
-	private final WorldViewContext root = new WorldViewContext(this, null, null, null);
+	private final WorldViewContext root = new WorldViewContext(null, null, null);
 	private final WorldViewContext[] subs = new WorldViewContext[MAX_WORLDVIEWS];
-	private final List<SortedZone> sortedZones = new ArrayList<>();
+
+	private final Map<Integer, Integer> nextRoofChanges = new HashMap<>();
 	private ZoneSceneContext nextSceneContext;
 	private Zone[][] nextZones;
+	private final List<SortedZone> sortedZones = new ArrayList<>();
 	private boolean reloadRequested;
 
 	public boolean isZoneStreamingEnabled() {
@@ -125,6 +130,7 @@ public class SceneManager {
 
 	public void initialize(UBOWorldViews uboWorldViews) {
 		this.uboWorldViews = uboWorldViews;
+		injector.injectMembers(root);
 	}
 
 	public void destroy() {
@@ -710,7 +716,8 @@ public class SceneManager {
 		var sceneContext = new ZoneSceneContext(client, worldView, scene, plugin.getExpandedMapLoadingChunks(), null);
 		proceduralGenerator.generateSceneData(sceneContext);
 
-		final WorldViewContext ctx = new WorldViewContext(this, worldView, sceneContext, uboWorldViews);
+		final WorldViewContext ctx = new WorldViewContext(worldView, sceneContext, uboWorldViews);
+		injector.injectMembers(ctx);
 		subs[worldViewId] = ctx;
 
 		for (int x = 0; x < ctx.sizeX; ++x)


### PR DESCRIPTION
Fix Edgecase where handleZoneSwap is called on map loader thread resulting in unmap being called on the none client thread