### PR TITLE
Troll Cave Fix

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -7886,7 +7886,6 @@
     "baseMaterial": "GRUNGE_1",
     "objectIds": [
       "SLAYER_DUNGEON_ENTRANCE",
-      "VIKING_TROLLCAVE_ENTRANCE",
       "TROLLROMANCE_STRONGHOLD_EXIT_TUNNEL",
       "ROUTE_CAVEWALLTUNNEL",
       "MDAUGHTER_CAVEEXIT",
@@ -7898,6 +7897,16 @@
       "FOSSIL_SHORTCUT_BASECAMP_A",
       "FOSSIL_SHORTCUT_BASECAMP_B",
       "MYQ5_WALL_CAVE_SHORTCUT_5"
+    ],
+    "uvType": "BOX",
+    "uvScale": 0.5
+  },
+  {
+    "description": "Grunge Caves",
+    "baseMaterial": "GRUNGE_1",
+    "terrainVertexSnap": true,
+    "objectIds": [
+      "VIKING_TROLLCAVE_ENTRANCE"
     ],
     "uvType": "BOX",
     "uvScale": 0.5


### PR DESCRIPTION
Enables vertex snap on a floating cave near the Frem slayer dungeon:

<img width="599" height="509" alt="image" src="https://github.com/user-attachments/assets/1b797514-0535-4520-b46a-0767e29b0146" />
<img width="599" height="509" alt="image" src="https://github.com/user-attachments/assets/fe599cab-72d8-4523-aa45-96000b9e09df" />
