### PR TITLE
Fix seasonal snow

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -7873,8 +7873,7 @@
   },
   {
     "name": "FREM_COLONIES_SEASONAL_SNOW",
-    "minHue": 3,
-    "maxHue": 7,
+    "maxHue": 0,
     "maxLightness": 63,
     "replacements": {
       "WINTER_ICY_SNOW": "season == SeasonalTheme.WINTER",


### PR DESCRIPTION
Sets the hue to 0 for all seasonal snow when not in winter; cause Jagex uses colors wrong

Master/PR
<img width="678" height="535" alt="image" src="https://github.com/user-attachments/assets/dbade66d-809b-4514-b92d-9349aee12a1d" />
<img width="678" height="535" alt="image" src="https://github.com/user-attachments/assets/1fe9f721-93cf-4606-b6cd-3607702ebdeb" />
<img width="930" height="613" alt="image" src="https://github.com/user-attachments/assets/d2cf2162-2e1d-4a91-980f-1bca62917381" />
<img width="930" height="613" alt="image" src="https://github.com/user-attachments/assets/e7fb4626-5b7b-4b21-a917-250039961785" />
