### PR TITLE
Remove grunge from overworld complex tiles when ground blending is disabled

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -9560,7 +9560,7 @@
       144
     ],
     "replacements": {
-      "SEASONAL_GRUNGE": "s == 0 && blending || h <= 10 && s < 2 && blending",
+      "SEASONAL_GRUNGE": "blending && (s == 0 || h <= 10 && s < 2)",
       "SEASONAL_SAND": "h == 8 && s == 4 && l >= 71 || h == 8 && s == 3 && l >= 48",
       "SEASONAL_GRASS": [
         "h >= 11 && s == 1",


### PR DESCRIPTION
Disables the usage of grunge in overworld complex tiles when ground blending is disabled, resulting in much nicer looking transitions between materials, does not have any effect when ground blending is enabled since it already smoothly blends between materials

<img width="2560" height="1416" alt="image" src="https://github.com/user-attachments/assets/4629b776-aae2-4b24-ba21-ea1ae21c034c" />
<img width="2560" height="1416" alt="image" src="https://github.com/user-attachments/assets/f1e36509-7359-493d-8ad6-37da273a425c" />
