### PR TITLE
Magic Light Improvements

### DIFF
--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -41217,10 +41217,11 @@
     "graphicsObjectIds": [ "ABYSSAL_DAGGER_SPECIAL_SPOTANIM" ]
   },
   {
-    "description": "Scythe of Vitur - Swing - Red",
+    "description": "Scythe of Vitur swing & Dragon Halberd special attack - Red",
     "offset": [ 0, 0, 0 ],
     "radius": 275,
-    "spawnDelay": 650,
+    "waitForAnimation": true,
+    "spawnDelay": 250,
     "fixedDespawnTime": true,
     "despawnDelay": 890,
     "strength": 12,
@@ -41240,10 +41241,11 @@
     ]
   },
   {
-    "description": "Scythe of Vitur - Swing - White",
+    "description": "Scythe of Vitur swing & Dragon Halberd special attack - White",
     "offset": [ 0, 0, 0 ],
     "radius": 250,
-    "spawnDelay": 650,
+    "waitForAnimation": true,
+    "spawnDelay": 250,
     "fixedDespawnTime": true,
     "despawnDelay": 890,
     "strength": 10,


### PR DESCRIPTION
Some adjustments to elemental spell lights and the telegrab cast animation

My initial implementation and adjustments were a bit too dim, this brightens the lights a little and adds an orange highlight to the fire spells while keeping the original red light they had as the main light


Some examples below
Fire Bolt:

https://github.com/user-attachments/assets/bfefd5bf-0f6d-4c78-8a12-9ec8ee6c2f18

https://github.com/user-attachments/assets/2e97701e-8618-457f-aa3d-a13e012c38b1

Fire Wave:

https://github.com/user-attachments/assets/1b733bfd-44bc-49fe-8439-8e31915f2e3e

https://github.com/user-attachments/assets/b4d03a8c-7b3c-48ce-93ee-4dceb74fa83a

Telegrab:

https://github.com/user-attachments/assets/32792475-7db6-47fc-a980-056cbf92bc21

https://github.com/user-attachments/assets/1ae0b515-3d8f-4d75-ab57-247e1dde9ff6

Scythe:

https://github.com/user-attachments/assets/92a1cfcb-6980-406b-94b2-e88bed85db5a

