### PR TITLE
Fix brick pattern being hidden with ground textures disabled in the blue moon entrance

### DIFF
--- a/src/main/resources/rs117/hd/scene/ground_materials.json
+++ b/src/main/resources/rs117/hd/scene/ground_materials.json
@@ -635,5 +635,11 @@
     "materials": [
       "STONE_NORMALED"
     ]
+  },
+  {
+    "name": "SMOOTH_STONE",
+    "materials": [
+      "SMOOTH_STONE"
+    ]
   }
 ]

--- a/src/main/resources/rs117/hd/scene/materials.json
+++ b/src/main/resources/rs117/hd/scene/materials.json
@@ -2062,7 +2062,7 @@
   },
   {
     "name": "CAM_TORUM_TILES",
-    "parent": "STONE",
+    "parent": "SMOOTH_STONE",
     "normalMap": "LASSAR_UNDERCITY_TILE_N",
     "displacementMap": "LASSAR_UNDERCITY_TILE_D",
     "ambientOcclusionMap": "CAM_TORUM_TILE_AO",

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -27506,8 +27506,7 @@
     "hideInAreas": [
       "LASSAR_UNDERCITY",
       "VARLAMORE_TEMPLE_CRYPT",
-      "CAM_TORUM",
-      "THE_BLUE_MOON_ENTRANCE"
+      "CAM_TORUM"
     ]
   },
   {

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -6388,7 +6388,7 @@
     "name": "THE_BLUE_MOON_ENTRANCE_DIRT",
     "area": "THE_BLUE_MOON_ENTRANCE",
     "underlayIds": [ 56, 73, 205, 206 ],
-    "groundMaterial": "CAM_TORUM_TILES",
+    "groundMaterial": "SMOOTH_STONE",
     "uvOrientation": -512,
     "blended": false
   },


### PR DESCRIPTION
User reported this in the discord:
<img width="1014" height="612" alt="image" src="https://github.com/user-attachments/assets/7d1e6fb7-55f8-4be1-801a-c10c4798f39d" />

Fixed version:
<img width="1208" height="1258" alt="image" src="https://github.com/user-attachments/assets/f9830012-f467-48c6-bd92-fac7d7337306" />
