### PR TITLE
Remove Unneeded path fix

### DIFF
--- a/src/main/resources/rs117/hd/scene/areas.json
+++ b/src/main/resources/rs117/hd/scene/areas.json
@@ -189,18 +189,6 @@
     ]
   },
   {
-    "name": "LUMBRIDGE_DRAYNOR_PATH_BLEND_1",
-    "aabbs": [
-      [ 3135, 3293, 3135, 3295 ]
-    ]
-  },
-  {
-    "name": "LUMBRIDGE_DRAYNOR_PATH_BLEND_2",
-    "aabbs": [
-      [ 3136, 3293, 3136, 3296 ]
-    ]
-  },
-  {
     "name": "LUMBRIDGE_SWAMP_PATH_FIX",
     "aabbs": [
       [ 3242, 3184, 3244, 3186 ]

--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -747,38 +747,6 @@
     }
   },
   {
-    "name": "BLEND_IMPROVEMENT_1",
-    "area": "LUMBRIDGE_DRAYNOR_PATH_BLEND_1",
-    "overlayIds": [
-      10
-    ],
-    "groundMaterial": "GRAVEL",
-    "minHue": 7,
-    "maxHue": 7,
-    "minSaturation": 1,
-    "maxSaturation": 1,
-    "shiftLightness": 6,
-    "replacements": {
-      "NONE": "!textures"
-    }
-  },
-  {
-    "name": "BLEND_IMPROVEMENT_2",
-    "area": "LUMBRIDGE_DRAYNOR_PATH_BLEND_2",
-    "overlayIds": [
-      10
-    ],
-    "groundMaterial": "GRAVEL",
-    "minHue": 7,
-    "maxHue": 7,
-    "minSaturation": 1,
-    "maxSaturation": 1,
-    "shiftLightness": 9,
-    "replacements": {
-      "NONE": "!textures"
-    }
-  },
-  {
     "name": "SWAMP_PATH_FIX_1",
     "area": "LUMBRIDGE_SWAMP_PATH_FIX",
     "overlayIds": [


### PR DESCRIPTION
There used to be a blending fix that was needed over in this area. the Lumbridge Path has since been moved so this is just a weird patch in the path.

<img width="801" height="698" alt="image" src="https://github.com/user-attachments/assets/4c590b79-6414-4296-a235-ad076dc7f9fa" />
<img width="801" height="698" alt="image" src="https://github.com/user-attachments/assets/ade37127-ceec-4621-8881-f6396940613c" />
