### PR TITLE
Fix light flicker on loading/reloading

### DIFF
--- a/src/main/java/rs117/hd/scene/lights/LightDefinition.java
+++ b/src/main/java/rs117/hd/scene/lights/LightDefinition.java
@@ -22,8 +22,8 @@ public class LightDefinition {
 	public LightType type = LightType.STATIC;
 	public float duration;
 	public float range;
-	public int fadeInDuration = 50;
-	public int fadeOutDuration = 50;
+	public int fadeInDuration = 0;
+	public int fadeOutDuration = 0;
 	public int spawnDelay;
 	public int despawnDelay;
 	public boolean fixedDespawnTime;


### PR DESCRIPTION

The way I was making the game load was changing the extended map loading setting, first video has lights flickering without the fix and the second with the fix its solved

https://github.com/user-attachments/assets/10de232e-23a2-43ac-94d3-8100d51c94c2

https://github.com/user-attachments/assets/31c271fd-2a48-4c03-9e4c-9d62c6807d28

The default fade in duration was sort of a bandaid, imo, for when we had a much lower light limit and places with lots of torches would have extremely obvious light pop