### PR TITLE
Fix Zone Leak caused by Invalidate being triggered before ZoneSwap

### DIFF
--- a/src/main/java/rs117/hd/renderer/zone/WorldViewContext.java
+++ b/src/main/java/rs117/hd/renderer/zone/WorldViewContext.java
@@ -314,17 +314,21 @@ public class WorldViewContext {
 		Zone curZone = zones[zx][zz];
 		long revealAfterTimestampMs = 0;
 		if (curZone.uploadJob != null) {
+			Zone pendingZone = curZone.uploadJob.zone;
 			log.trace(
 				"Invalidate Zone({}) - Cancelled upload task: [{}-{},{}] task zone({})",
 				curZone.hashCode(),
 				worldViewId,
 				zx,
 				zz,
-				curZone.uploadJob.zone.hashCode()
+				pendingZone.hashCode()
 			);
 			revealAfterTimestampMs = curZone.uploadJob.revealAfterTimestampMs;
 			curZone.uploadJob.cancel();
 			curZone.uploadJob.release();
+
+			if (pendingZone != curZone)
+				DestructibleHandler.destroy(pendingZone);
 		}
 
 		Zone newZone = injector.getInstance(Zone.class);

--- a/src/main/java/rs117/hd/renderer/zone/Zone.java
+++ b/src/main/java/rs117/hd/renderer/zone/Zone.java
@@ -172,6 +172,7 @@ public class Zone implements Destructible {
 
 		if (uploadJob != null) {
 			uploadJob.cancel();
+			DestructibleHandler.destroy(uploadJob.zone);
 			uploadJob = null;
 		}
 

--- a/src/main/java/rs117/hd/utils/DestructibleHandler.java
+++ b/src/main/java/rs117/hd/utils/DestructibleHandler.java
@@ -20,6 +20,13 @@ public final class DestructibleHandler {
 		PENDING_DESTRUCTION.add(destructible);
 	}
 
+	public static void destroy(Destructible destructible) {
+		PENDING_DESTRUCTION.remove(destructible);
+		LEAKED_DESTRUCTIBLE.remove(destructible);
+
+		destructible.destroy();
+	}
+
 	public static void queueLeakedDestruction(Destructible destructible) {
 		LEAKED_DESTRUCTIBLE.add(destructible);
 	}


### PR DESCRIPTION
Fix Zone Leak caused by Invalidate being triggered before ZoneSwap
Destroy Previous UploadJob Zone if requeuing

Fixes the following logs at boot:
```
13:30:29.737 [Client    ] WARN  r.h.u.DestructibleHandler      - Leaked Destructible detected, count: 5
 * GLTextureBuffer | Name: Zone::TBO, Capacity: 1048576
 * GLBuffer | Name: ZoneMetadata, Capacity: 16
 * GLBuffer | Name: Zone::VBO::Opaque, Capacity: 2097152
 * GLBuffer | Name: Zone::VBO::Alpha, Capacity: 1048576
 * Zone | Zone Initialized: true, culled: false hasUploadJob: false opaqueSize: 16897 alphaSize: 6417
Total leaked by Type:
 * class rs117.hd.utils.buffer.GLTextureBuffer: 1
 * class rs117.hd.renderer.zone.Zone: 1
 * class rs117.hd.utils.buffer.GLBuffer: 3
```