### PR TITLE
Fix hiding of projectile & NPC lights when disabled

### DIFF
--- a/src/main/java/rs117/hd/scene/LightManager.java
+++ b/src/main/java/rs117/hd/scene/LightManager.java
@@ -225,7 +225,7 @@ public class LightManager {
 
 			// Whatever the light is attached to is presumed to exist if it's not marked for removal yet
 			boolean parentExists = !light.markedForRemoval;
-			boolean hiddenTemporarily = false;
+			boolean hiddenTemporarily = light.hiddenTemporarily;
 
 			if (light.tileObject != null) {
 				if (!light.markedForRemoval && light.animationSpecific && light.tileObject instanceof GameObject) {
@@ -242,10 +242,10 @@ public class LightManager {
 				light.origin[0] = (int) light.projectile.getX();
 				light.origin[1] = (int) light.projectile.getZ() - light.def.height;
 				light.origin[2] = (int) light.projectile.getY();
+				hiddenTemporarily = !shouldShowProjectileLights();
 				if (light.projectile.getRemainingCycles() <= 0) {
 					light.markedForRemoval = true;
 				} else {
-					hiddenTemporarily = !shouldShowProjectileLights();
 					if (light.animationSpecific) {
 						if (light.def.waitForAnimation && gameCycle < light.projectile.getStartCycle()) {
 							parentExists = false;
@@ -310,6 +310,8 @@ public class LightManager {
 						tileExX < EXTENDED_SCENE_SIZE && tileExY < EXTENDED_SCENE_SIZE &&
 						(tile = tiles[plane][tileExX][tileExY]) != null
 					) {
+						hiddenTemporarily = !isActorLightVisible(light.actor);
+
 						if (!light.def.ignoreActorHiding &&
 							!(light.actor instanceof NPC && ((NPC) light.actor).getComposition().getSize() > 1)
 						) {
@@ -328,9 +330,6 @@ public class LightManager {
 								}
 							}
 						}
-
-						if (!hiddenTemporarily)
-							hiddenTemporarily = !isActorLightVisible(light.actor);
 
 						// Interpolate between tile heights based on specific scene coordinates
 						int tileZ = plane;
@@ -995,6 +994,9 @@ public class LightManager {
 
 	@Subscribe
 	public void onProjectileMoved(ProjectileMoved projectileMoved) {
+		if (!shouldShowProjectileLights())
+			return;
+
 		SceneContext sceneContext = plugin.getSceneContext();
 		if (sceneContext == null)
 			return;

--- a/src/main/java/rs117/hd/scene/LightManager.java
+++ b/src/main/java/rs117/hd/scene/LightManager.java
@@ -994,9 +994,6 @@ public class LightManager {
 
 	@Subscribe
 	public void onProjectileMoved(ProjectileMoved projectileMoved) {
-		if (!shouldShowProjectileLights())
-			return;
-
 		SceneContext sceneContext = plugin.getSceneContext();
 		if (sceneContext == null)
 			return;

--- a/src/main/java/rs117/hd/scene/lights/Light.java
+++ b/src/main/java/rs117/hd/scene/lights/Light.java
@@ -7,7 +7,7 @@ import static rs117.hd.utils.MathUtils.*;
 
 public class Light
 {
-	public static final float VISIBILITY_FADE = 0.1f;
+	public static final float VISIBILITY_FADE = 0.064f;
 
 	public final float randomOffset = RAND.nextFloat();
 	public final LightDefinition def;
@@ -28,7 +28,7 @@ public class Light
 	public boolean visible;
 	public boolean parentExists;
 	public boolean withinViewingDistance = true;
-	public boolean hiddenTemporarily = true;
+	public boolean hiddenTemporarily;
 	public boolean markedForRemoval;
 	public boolean persistent;
 	public boolean replayable;
@@ -105,8 +105,8 @@ public class Light
 
 	public void toggleTemporaryVisibility(boolean changedPlanes) {
 		hiddenTemporarily = !hiddenTemporarily;
-		// If visibility changes due to something other than changing planes, fade in or out
-		if (!changedPlanes) {
+		// If visibility changes due to something other than changing planes, and the light didn't spawn this frame, fade in or out
+		if (!changedPlanes && elapsedTime > 0) {
 			// Begin fading in or out, while accounting for time already spent fading out or in respectively
 			float beginFadeAt = elapsedTime;
 			if (changedVisibilityAt != -1)

--- a/src/main/java/rs117/hd/scene/lights/Light.java
+++ b/src/main/java/rs117/hd/scene/lights/Light.java
@@ -28,7 +28,7 @@ public class Light
 	public boolean visible;
 	public boolean parentExists;
 	public boolean withinViewingDistance = true;
-	public boolean hiddenTemporarily;
+	public boolean hiddenTemporarily = true;
 	public boolean markedForRemoval;
 	public boolean persistent;
 	public boolean replayable;


### PR DESCRIPTION
This aims to fix issues where lights attached to projectiles or NPCs or their spotanims were fading out instead of starting in a hidden state whenever the corresponding config option was disabled. This still needs more testing to ensure it's not accidentally changing the fading behaviour of lights with the options enabled.