### PR TITLE
Remove view blockers from Doom of Mokhaiotl lobby

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -43728,6 +43728,9 @@
       "ROR_TEMPLE_TALL_TOP",
       "ROR_TEMPLE_TALL_PILLAR"
     ],
+    "hideInAreas": [
+      [ 1280, 9536, 1343, 9538, 1 ]
+    ],
     "baseMaterial": "PURE_BLACK",
     "castShadows": false,
     "receiveShadows": false


### PR DESCRIPTION
Upon entering the lobby for Doom of Mokhaiotl, the camera is often facing straight onto a wall of black objects Jagex have seemingly placed there to hide the rest of the dungeon when standing within the lobby, but we of course have area hiding for this.