### PR TITLE
Slight adjustment to the Farming Guilds path

### DIFF
--- a/src/main/resources/rs117/hd/scene/tile_overrides.json
+++ b/src/main/resources/rs117/hd/scene/tile_overrides.json
@@ -9039,7 +9039,8 @@
       174
     ],
     "groundMaterial": "WORN_TILES",
-    "shiftLightness": -30,
+    "shiftLightness": -35,
+    "minLightness": 20,
     "replacements": {
       "NONE": "!textures"
     }


### PR DESCRIPTION
Slightly darken the path so it doesn't pop out as much against the grass

<img width="2560" height="1416" alt="java_nYaBRICi7C" src="https://github.com/user-attachments/assets/bfee3174-88b3-4dbf-ad42-77d410dd86d3" />

<img width="2560" height="1416" alt="java_9whj1J2dhj" src="https://github.com/user-attachments/assets/9120ee67-dfb1-4d87-9637-68836272c6e9" />
