### PR TITLE
Motherlode Mine - Ore wall UV improvements

### DIFF
--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -11796,9 +11796,9 @@
       {
         "description": "Ore",
         "colors": "h == 0",
-        "baseMaterial": "GRAVEL_SHINY",
+        "baseMaterial": "ROCK_4_ORE",
         "uvType": "BOX",
-        "uvScale": 0.711
+        "uvOrientation": 187
       }
     ],
     "objectIds": [
@@ -11845,7 +11845,7 @@
       {
         "description": "Ore",
         "colors": "h == 0",
-        "baseMaterial": "GRAVEL_SHINY",
+        "baseMaterial": "ROCK_4_ORE",
         "uvType": "BOX",
         "uvScale": 0.711
       }

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -11768,14 +11768,15 @@
     ]
   },
   {
-    "description": "Motherlode Mine Walls",
+    "description": "Motherlode Mine - Walls",
     "baseMaterial": "DIRT_2",
+    "uvType": "BOX",
+    "uvScale": 0.7,
     "objectIds": [
       "MOTHERLODE_WALL",
       "MOTHERLODE_SUPPORT_LEFT",
       "MOTHERLODE_SUPPORT_MIDDLE",
       "MOTHERLODE_SUPPORT_RIGHT",
-      "MOTHERLODE_ORE_SINGLE",
       "MOTHERLODE_DEPLETED_SINGLE",
       "MOTHERLODE_DEPLETED_LEFT",
       "MOTHERLODE_DEPLETED_MIDDLE",
@@ -11783,13 +11784,29 @@
       "MGUILD_WALL",
       "MGUILD_WALL_LEFT",
       "MGUILD_WALL_RIGHT",
+      "MOTHERLODE_WATER_TUNNEL"
+    ]
+  },
+  {
+    "description": "Motherlode Mine - Ore Walls",
+    "baseMaterial": "DIRT_2",
+    "uvType": "BOX",
+    "uvScale": 0.7,
+    "colorOverrides": [
+      {
+        "description": "Ore",
+        "colors": "h == 0",
+        "baseMaterial": "GRAVEL_SHINY",
+        "uvType": "BOX",
+        "uvScale": 0.711
+      }
+    ],
+    "objectIds": [
+      "MOTHERLODE_ORE_SINGLE",
       "MOTHERLODE_ORE_LEFT",
       "MOTHERLODE_ORE_MIDDLE",
-      "MOTHERLODE_ORE_RIGHT",
-      "MOTHERLODE_WATER_TUNNEL"
-    ],
-    "uvType": "BOX",
-    "uvScale": 0.7
+      "MOTHERLODE_ORE_RIGHT"
+    ]
   },
   {
     "areas": [
@@ -11810,10 +11827,6 @@
     "areas": [ "Motherlode Mine Dark Wall Fix" ],
     "objectIds": [
       "MOTHERLODE_WALL",
-      "MOTHERLODE_ORE_SINGLE",
-      "MOTHERLODE_ORE_LEFT",
-      "MOTHERLODE_ORE_MIDDLE",
-      "MOTHERLODE_ORE_RIGHT",
       "MOTHERLODE_DEPLETED_SINGLE",
       "MOTHERLODE_DEPLETED_LEFT",
       "MOTHERLODE_DEPLETED_MIDDLE",
@@ -11821,6 +11834,28 @@
     ],
     "uvType": "BOX",
     "uvScale": 0.7
+  },
+  {
+    "description": "Motherlode Mine - Ore Walls Lighten",
+    "areas": [ "Motherlode Mine Dark Wall Fix" ],
+    "baseMaterial": "DIRT_2_LIGHT",
+    "uvType": "BOX",
+    "uvScale": 0.7,
+    "colorOverrides": [
+      {
+        "description": "Ore",
+        "colors": "h == 0",
+        "baseMaterial": "GRAVEL_SHINY",
+        "uvType": "BOX",
+        "uvScale": 0.711
+      }
+    ],
+    "objectIds": [
+      "MOTHERLODE_ORE_SINGLE",
+      "MOTHERLODE_ORE_LEFT",
+      "MOTHERLODE_ORE_MIDDLE",
+      "MOTHERLODE_ORE_RIGHT"
+    ]
   },
   {
     "description": "Motherlode Mine Walls Lighten & Darken Caves",


### PR DESCRIPTION
Sets these unique overrides to apply color overrides to the ore portions of the wall.
master/PR:
<img width="850" height="414" alt="image" src="https://github.com/user-attachments/assets/c9f59d43-3b3c-44ca-a7b3-3f086fd30a6b" />
<img width="850" height="414" alt="image" src="https://github.com/user-attachments/assets/799fb325-fd38-4a95-a441-5fc33336b010" />
