### PR TITLE
Fix NoClassDefFoundError in getTotalSystemMemory()

### DIFF
--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -535,9 +535,9 @@ public final class HDUtils {
 	public static long getTotalSystemMemory() {
 		try {
 			var bean = ManagementFactory.getOperatingSystemMXBean();
-			return ((com.sun.management.OperatingSystemMXBean) bean).getTotalPhysicalMemorySize();
-		} catch (Exception ignored) {
-			return Long.MAX_VALUE;
-		}
+			if (bean instanceof com.sun.management.OperatingSystemMXBean)
+				return ((com.sun.management.OperatingSystemMXBean) bean).getTotalPhysicalMemorySize();
+		} catch (Throwable ignored){}
+		return Long.MAX_VALUE;
 	}
 }

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -535,9 +535,9 @@ public final class HDUtils {
 	public static long getTotalSystemMemory() {
 		try {
 			var bean = ManagementFactory.getOperatingSystemMXBean();
-			if (bean instanceof com.sun.management.OperatingSystemMXBean)
-				return ((com.sun.management.OperatingSystemMXBean) bean).getTotalPhysicalMemorySize();
-		} catch (Throwable ignored){}
-		return Long.MAX_VALUE;
+			return ((com.sun.management.OperatingSystemMXBean) bean).getTotalPhysicalMemorySize();
+		} catch (Throwable ignored) {
+			return Long.MAX_VALUE;
+		}
 	}
 }


### PR DESCRIPTION
Check if getOperatingSystemMXBean is instance of before casting Switch Catch from Exception to Throwable

Crash this PR is fixing:
```
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - Starting 117 HD... (count: 3)
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - Renderer:          ZoneRenderer
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - rlawt version:     Release
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - LWJGL Version:     3.3.2+13
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - Java version:      OpenJDK 64-Bit Server VM (17)
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - Java memory limit: 768 MiB (free: 386.1 MiB)
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - Operating system:  MacOS 26.4.1 (64-bit aarch64)
2026-04-29 22:03:42 SGT [Client] INFO  rs117.hd.HdPlugin - CPU:               Apple Silicon (10 threads)
2026-04-29 22:03:42 SGT [Client] ERROR rs117.hd.HdPlugin - Error while starting 117 HD
java.lang.NoClassDefFoundError: com/sun/management/OperatingSystemMXBean
	at rs117.hd.utils.HDUtils.getTotalSystemMemory(HDUtils.java:538)
	at rs117.hd.HdPlugin.lambda$startUp$2(HdPlugin.java:588)
	at net.runelite.client.callback.ClientThread.invokeList(ClientThread.java:119)
	at net.runelite.client.callback.ClientThread.invoke(ClientThread.java:101)
	at net.runelite.client.callback.Hooks.tick(Hooks.java:241)
	at client.yc(client.java:19481)
	at client.ir(client.java)
	at sw.agt(sw.java:447)
	at sw.az(sw.java)
	at sw.run(sw.java:58274)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: com.sun.management.OperatingSystemMXBean
	... 11 common frames omitted
```