### PR TITLE
First draft of magic tree lights

### DIFF
--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -24238,22 +24238,23 @@
     "description": "ELVEN_LAMP",
     "height": 160,
     "alignment": "CENTER",
-    "radius": 350,
+    "radius": 275,
     "strength": 10,
+    "visibleFromOtherPlanes": true,
     "color": [
       255,
       255,
       255
     ],
-    "type": "PULSE",
-    "duration": 2000,
-    "range": 7,
+    "type": "FLICKER",
+    "range": 10,
     "objectIds": [
       "SOTE_HUNTING_LAMP_OP",
       "SOTE_HUNTING_LAMP_NOOP",
       "REGICIDE_CRYSTAL_LAMP",
       "REGICIDE_CRYSTAL_LAMP_BLOCKWALK_ONLY",
-      "ELF_VILLAGE_RAIL_LAMP"
+      "ELF_VILLAGE_RAIL_LAMP",
+      "PRIF_CRYSTAL_LAMP"
     ]
   },
   {
@@ -37373,8 +37374,8 @@
   {
     "description": "GNOME_LAMP",
     "offset": [ -60, 120, 0 ],
-    "radius": 400,
-    "strength": 7,
+    "radius": 550,
+    "strength": 4,
     "color": [
       255,
       255,

--- a/src/main/resources/rs117/hd/scene/lights.json
+++ b/src/main/resources/rs117/hd/scene/lights.json
@@ -47868,5 +47868,195 @@
     "projectileIds": [
       "SNAKEBOSS_FIREBALL"
     ]
+  },
+  {
+    "description": "Magic Tree Top",
+    "offset": [ 10, 600, -10 ],
+    "radius": 300,
+    "strength": 5,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 19,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree North",
+    "offset": [ 120, 480, -10 ],
+    "radius": 300,
+    "strength": 3,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 17,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree South",
+    "offset": [ -170, 500, -10 ],
+    "radius": 300,
+    "strength": 3,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 15,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree West",
+    "offset": [ 10, 500, 170 ],
+    "radius": 300,
+    "strength": 3,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 10,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree East",
+    "offset": [ 10, 500, -170 ],
+    "radius": 300,
+    "strength": 3,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 10,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree Under North",
+    "offset": [ 170, 280, -10 ],
+    "radius": 280,
+    "strength": 7,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 25,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree Under South",
+    "offset": [ -110, 250, -10 ],
+    "radius": 300,
+    "strength": 2,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 35,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree Under West",
+    "offset": [ 10, 250, 100 ],
+    "radius": 300,
+    "strength": 2,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 25,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree Under East",
+    "offset": [ 50, 290, -150 ],
+    "radius": 300,
+    "strength": 2,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 30,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
+  },
+  {
+    "description": "Magic Tree Main",
+    "offset": [ 10, 150, -10 ],
+    "radius": 300,
+    "strength": 7,
+    "fadeInDuration": 200,
+    "color": [
+      255,
+      255,
+      255
+    ],
+    "type": "FLICKER",
+    "duration": 0,
+    "range": 20,
+    "objectIds": [
+      "MAGIC_TREE_FULLYGROWN_2",
+      "MAGICTREE"
+    ]
   }
 ]


### PR DESCRIPTION
Adds flickering lights to magic trees, they are mostly unnoticeable during the day unless they are in shadow as in the videos below:

https://github.com/user-attachments/assets/bb4d8541-45f4-4d1f-ae75-7e1b2f84ee98

https://github.com/user-attachments/assets/4e08faeb-5a09-4c99-aced-29609c34325d

This is primary for the day/night cycle PR though and looks like this:
<img width="1744" height="988" alt="image" src="https://github.com/user-attachments/assets/7b43e934-d939-43fc-a5cf-a2ce9bfcb15c" />

Needs fine tuning still.