### PR TITLE
Add Support for Skybox Models to 117 for Upcoming Content for New Renderer

### DIFF
--- a/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
+++ b/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
@@ -18,6 +18,7 @@ import rs117.hd.HdPluginConfig;
 import rs117.hd.config.ShadowMode;
 import rs117.hd.overlays.FrameTimer;
 import rs117.hd.overlays.Timer;
+import rs117.hd.scene.MaterialManager;
 import rs117.hd.scene.ModelOverrideManager;
 import rs117.hd.scene.model_overrides.ModelOverride;
 import rs117.hd.utils.HDUtils;
@@ -66,6 +67,9 @@ public class ModelStreamingManager {
 
 	@Inject
 	private ModelOverrideManager modelOverrideManager;
+
+	@Inject
+	private MaterialManager materialManager;
 
 	@Inject
 	private FrameTimer frameTimer;
@@ -147,7 +151,20 @@ public class ModelStreamingManager {
 	}
 
 
-	private boolean skyboxFacesLogged; // DEV-ONLY diagnostic, remove once skybox is confirmed working
+	// Reusable override for the skybox: an unlit material so the model's authored vertex colors are shown
+	// directly (e.g. the sky's color banding and white moon), without 117HD's lighting or vanilla-shading
+	// adjustments. Built lazily because the material manager isn't loaded when this class is constructed.
+	private ModelOverride skyboxOverride;
+
+	private ModelOverride getSkyboxOverride() {
+		if (skyboxOverride == null) {
+			skyboxOverride = new ModelOverride();
+			skyboxOverride.baseMaterial = materialManager.getMaterial("UNLIT");
+			skyboxOverride.undoVanillaShading = false;
+			skyboxOverride.castShadows = false;
+		}
+		return skyboxOverride;
+	}
 
 	public boolean drawSkybox(Scene scene) {
 		Model skybox = scene.getSkybox();
@@ -157,6 +174,8 @@ public class ModelStreamingManager {
 		WorldViewContext ctx = sceneManager.getContext(scene);
 		if (ctx == null || ctx.isLoading)
 			return false;
+
+		final ModelOverride override = getSkyboxOverride();
 
 		final int camX = (int) plugin.cameraPosition[0];
 		final int camY = (int) plugin.cameraPosition[1];
@@ -178,7 +197,7 @@ public class ModelStreamingManager {
 					visibleFaces,
 					culledFaces,
 					false,
-					ModelOverride.NONE,
+					override,
 					skybox,
 					false,
 					0,
@@ -186,11 +205,6 @@ public class ModelStreamingManager {
 				);
 			} finally {
 				sceneUploader.skipBackfaceCull = false;
-			}
-
-			if (!skyboxFacesLogged) {
-				log.warn("DEBUG skybox faces={} visible={} culled={}", skybox.getFaceCount(), visibleFaces.length, culledFaces.length);
-				skyboxFacesLogged = true;
 			}
 
 			if (visibleFaces.length == 0)
@@ -202,7 +216,7 @@ public class ModelStreamingManager {
 				sceneUploader.uploadTempModel(
 					visibleFaces,
 					skybox,
-					ModelOverride.NONE,
+					override,
 					0,
 					0,
 					false,

--- a/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
+++ b/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
@@ -21,6 +21,7 @@ import rs117.hd.overlays.Timer;
 import rs117.hd.scene.ModelOverrideManager;
 import rs117.hd.scene.model_overrides.ModelOverride;
 import rs117.hd.utils.HDUtils;
+import rs117.hd.utils.Mat4;
 import rs117.hd.utils.ModelHash;
 import rs117.hd.utils.collections.ConcurrentPool;
 import rs117.hd.utils.collections.PooledArrayType;
@@ -33,6 +34,7 @@ import static rs117.hd.renderer.zone.WorldViewContext.VAO_ALPHA;
 import static rs117.hd.renderer.zone.WorldViewContext.VAO_OPAQUE;
 import static rs117.hd.renderer.zone.WorldViewContext.VAO_PLAYER;
 import static rs117.hd.renderer.zone.WorldViewContext.VAO_SHADOW;
+import static rs117.hd.renderer.zone.WorldViewContext.VAO_SKYBOX;
 import static rs117.hd.utils.MathUtils.*;
 
 @Slf4j
@@ -143,6 +145,87 @@ public class ModelStreamingManager {
 			count += streamingContexts[i].renderableCount;
 		return count;
 	}
+
+
+	public boolean drawSkybox(Scene scene) {
+		Model skybox = scene.getSkybox();
+		if (skybox == null)
+			return false;
+
+		WorldViewContext ctx = sceneManager.getContext(scene);
+		if (ctx == null || ctx.isLoading)
+			return false;
+
+		final int camX = (int) plugin.cameraPosition[0];
+		final int camY = (int) plugin.cameraPosition[1];
+		final int camZ = (int) plugin.cameraPosition[2];
+
+		final PrimitiveCharArray visibleFaces = FACE_INDICES.acquire();
+		final PrimitiveCharArray culledFaces = FACE_INDICES.acquire();
+		try (SceneUploader sceneUploader = SceneUploader.POOL.acquire()) {
+			skybox.calculateBoundsCylinder();
+
+			sceneUploader.preprocessTempModel(
+				skyboxProjection,
+				plugin.cameraFrustum,
+				null,
+				visibleFaces,
+				culledFaces,
+				false,
+				ModelOverride.NONE,
+				skybox,
+				false,
+				0,
+				camX, camY, camZ
+			);
+
+			if (visibleFaces.length == 0)
+				return true;
+
+			final DynamicModelVAO.View view = ctx.beginDraw(VAO_SKYBOX, visibleFaces.length);
+			sceneUploader.uploadAsSkybox = true;
+			try {
+				sceneUploader.uploadTempModel(
+					visibleFaces,
+					skybox,
+					ModelOverride.NONE,
+					0,
+					0,
+					false,
+					view,
+					view
+				);
+			} finally {
+				sceneUploader.uploadAsSkybox = false;
+			}
+			view.end();
+		} catch (Exception ex) {
+			log.error("Error uploading skybox", ex);
+		} finally {
+			FACE_INDICES.recycle(visibleFaces);
+			FACE_INDICES.recycle(culledFaces);
+		}
+		return true;
+	}
+
+
+	private final float[] skyboxProjectionVec = new float[4];
+	private final Projection skyboxProjection = new Projection() {
+		@Override
+		public float[] project(float x, float y, float z) {
+			return project(x, y, z, new float[4]);
+		}
+
+		@Override
+		public float[] project(float x, float y, float z, float[] out) {
+			skyboxProjectionVec[0] = x;
+			skyboxProjectionVec[1] = y;
+			skyboxProjectionVec[2] = z;
+			skyboxProjectionVec[3] = 1;
+			Mat4.mulVec(out, plugin.viewProjMatrix, skyboxProjectionVec);
+			return out;
+		}
+	};
 
 	public void drawTemp(Projection worldProjection, Scene scene, GameObject gameObject, Model m, int orientation, int x, int y, int z) {
 		WorldViewContext ctx = sceneManager.getContext(scene);

--- a/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
+++ b/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
@@ -153,16 +153,18 @@ public class ModelStreamingManager {
 
 	// Reusable override for the skybox: an unlit material so the model's authored vertex colors are shown
 	// directly (e.g. the sky's color banding and white moon), without 117HD's lighting or vanilla-shading
-	// adjustments. Built lazily because the material manager isn't loaded when this class is constructed.
+	// adjustments. The override shell is reused, but the UNLIT material is re-fetched each call: a cached
+	// Material reference is invalidated when materials reload (its UBO index can change), which would throw
+	// "Material UNLIT used after invalidation".
 	private ModelOverride skyboxOverride;
 
 	private ModelOverride getSkyboxOverride() {
 		if (skyboxOverride == null) {
 			skyboxOverride = new ModelOverride();
-			skyboxOverride.baseMaterial = materialManager.getMaterial("UNLIT");
 			skyboxOverride.undoVanillaShading = false;
 			skyboxOverride.castShadows = false;
 		}
+		skyboxOverride.baseMaterial = materialManager.getMaterial("UNLIT");
 		return skyboxOverride;
 	}
 

--- a/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
+++ b/src/main/java/rs117/hd/renderer/zone/ModelStreamingManager.java
@@ -147,6 +147,8 @@ public class ModelStreamingManager {
 	}
 
 
+	private boolean skyboxFacesLogged; // DEV-ONLY diagnostic, remove once skybox is confirmed working
+
 	public boolean drawSkybox(Scene scene) {
 		Model skybox = scene.getSkybox();
 		if (skybox == null)
@@ -165,19 +167,31 @@ public class ModelStreamingManager {
 		try (SceneUploader sceneUploader = SceneUploader.POOL.acquire()) {
 			skybox.calculateBoundsCylinder();
 
-			sceneUploader.preprocessTempModel(
-				skyboxProjection,
-				plugin.cameraFrustum,
-				null,
-				visibleFaces,
-				culledFaces,
-				false,
-				ModelOverride.NONE,
-				skybox,
-				false,
-				0,
-				camX, camY, camZ
-			);
+			// The skybox is viewed from inside, so its faces are "back-facing" by the usual winding test;
+			// disable back-face culling so they aren't all rejected.
+			sceneUploader.skipBackfaceCull = true;
+			try {
+				sceneUploader.preprocessTempModel(
+					skyboxProjection,
+					plugin.cameraFrustum,
+					null,
+					visibleFaces,
+					culledFaces,
+					false,
+					ModelOverride.NONE,
+					skybox,
+					false,
+					0,
+					camX, camY, camZ
+				);
+			} finally {
+				sceneUploader.skipBackfaceCull = false;
+			}
+
+			if (!skyboxFacesLogged) {
+				log.warn("DEBUG skybox faces={} visible={} culled={}", skybox.getFaceCount(), visibleFaces.length, culledFaces.length);
+				skyboxFacesLogged = true;
+			}
 
 			if (visibleFaces.length == 0)
 				return true;

--- a/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
@@ -136,6 +136,8 @@ public class SceneUploader implements AutoCloseable {
 
 	private int[] modelVertices;
 	public int tempModelAlphaFaces = 0;
+	// When set, faces uploaded by uploadTempModel are tagged as skybox so the shader skips fogging them.
+	public boolean uploadAsSkybox = false;
 
 	private final PooledObjectArray<ModelOverride> faceOverrides = new PooledObjectArray<>();
 	private final PooledObjectArray<Material> faceMaterials = new PooledObjectArray<>();
@@ -2131,10 +2133,11 @@ public class SceneUploader implements AutoCloseable {
 			final VertexWriteCache vb = writeCache.getVertexBuffer(hasAlpha);
 			final VertexWriteCache tb = writeCache.getTextureBuffer(hasAlpha);
 
+			final int terrainData = uploadAsSkybox ? HDUtils.SKYBOX_TERRAIN_FLAG : 0;
 			final int texturedFaceIdx = tb.putFace(
 				color1, color2, color3,
 				materialData, materialData, materialData,
-				0, 0, 0
+				terrainData, terrainData, terrainData
 			);
 
 			vb.putDynamicVertex(

--- a/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
@@ -138,6 +138,9 @@ public class SceneUploader implements AutoCloseable {
 	public int tempModelAlphaFaces = 0;
 	// When set, faces uploaded by uploadTempModel are tagged as skybox so the shader skips fogging them.
 	public boolean uploadAsSkybox = false;
+	// When set, preprocessTempModel skips back-face culling. The skybox surrounds the camera and is viewed
+	// from the inside, so its faces are "back-facing" by the usual test and would otherwise all be culled.
+	public boolean skipBackfaceCull = false;
 
 	private final PooledObjectArray<ModelOverride> faceOverrides = new PooledObjectArray<>();
 	private final PooledObjectArray<Material> faceMaterials = new PooledObjectArray<>();
@@ -1941,7 +1944,7 @@ public class SceneUploader implements AutoCloseable {
 			final float cY = modelProjected[offsetC + 1];
 
 			// back face culling
-			if ((aX - bX) * (cY - bY) - (cX - bX) * (aY - bY) <= 0) {
+			if (!skipBackfaceCull && (aX - bX) * (cY - bY) - (cX - bX) * (aY - bY) <= 0) {
 				culledFaces.put(f);
 				continue;
 			}

--- a/src/main/java/rs117/hd/renderer/zone/WorldViewContext.java
+++ b/src/main/java/rs117/hd/renderer/zone/WorldViewContext.java
@@ -34,7 +34,8 @@ public class WorldViewContext {
 	public static final int VAO_ALPHA = 1;
 	public static final int VAO_PLAYER = 2;
 	public static final int VAO_SHADOW = 3;
-	public static final int VAO_COUNT = 4;
+	public static final int VAO_SKYBOX = 4;
+	public static final int VAO_COUNT = 5;
 
 	public static final ConcurrentPool<DynamicModelVAO> DYNAMIC_MODEL_VAO_STAGING_POOL =
 		new ConcurrentPool<>(() -> new DynamicModelVAO("DynamicModelVAO::Staging", true));
@@ -121,7 +122,7 @@ public class WorldViewContext {
 
 		long start = System.nanoTime();
 		for (int i = 0; i < VAO_COUNT; i++) {
-			final boolean needsStaging = i == VAO_OPAQUE || i == VAO_PLAYER || i == VAO_SHADOW;
+			final boolean needsStaging = i == VAO_OPAQUE || i == VAO_PLAYER || i == VAO_SHADOW || i == VAO_SKYBOX;
 			final var POOL = needsStaging ? DYNAMIC_MODEL_VAO_STAGING_POOL : DYNAMIC_MODEL_VAO_POOL;
 			for (int k = 0; k < FRAMES_IN_FLIGHT; k++) {
 				DynamicModelVAO dynamicModelVao = dynamicModelVaos[k][i] = POOL.acquire();
@@ -156,7 +157,7 @@ public class WorldViewContext {
 
 	void unmap() {
 		for (int i = 0; i < VAO_COUNT; i++) {
-			final boolean shouldCoalesce = i == VAO_OPAQUE || i == VAO_PLAYER || i == VAO_SHADOW;
+			final boolean shouldCoalesce = i == VAO_OPAQUE || i == VAO_PLAYER || i == VAO_SHADOW || i == VAO_SKYBOX;
 			dynamicModelVaos[plugin.frame % FRAMES_IN_FLIGHT][i].unmap(shouldCoalesce);
 		}
 	}

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -998,10 +998,13 @@ public class ZoneRenderer implements Renderer {
 						frameTimer.end(Timer.UNMAP_ROOT_CTX);
 
 					// Draw the camera-anchored skybox first as the background, without writing depth so
-					// all scene geometry overdraws it. Only the root scene supplies a skybox.
+					// all scene geometry overdraws it. Back-face culling is disabled because the skybox is
+					// viewed from the inside. Only the root scene supplies a skybox.
 					if (skyboxVisible && sceneManager.isRoot(ctx)) {
 						ctx.vaoSceneCmd.DepthMask(false);
+						ctx.vaoSceneCmd.Disable(GL_CULL_FACE);
 						ctx.drawAll(VAO_SKYBOX, ctx.vaoSceneCmd);
+						ctx.vaoSceneCmd.Enable(GL_CULL_FACE);
 						ctx.vaoSceneCmd.DepthMask(true);
 					}
 

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -550,6 +550,11 @@ public class ZoneRenderer implements Renderer {
 				break;
 		}
 		fogDepth *= min(plugin.getDrawDistance(), 90) / 10.f;
+		// Disable fog while a skybox is present: fog fades distant geometry to the sky/fog color, which
+		// clashes with the skybox's colors. Zeroing fogDepth short-circuits all distance fog in the shader.
+		// (A proper fix would fade to transparency instead of a color.)
+		if (scene.getSkybox() != null)
+			fogDepth = 0;
 		plugin.uboGlobal.useFog.set(fogDepth > 0 ? 1 : 0);
 		plugin.uboGlobal.fogDepth.set(fogDepth);
 		plugin.uboGlobal.fogColor.set(ColorUtils.linearToSrgb(environmentManager.currentFogColor));

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -152,6 +152,8 @@ public class ZoneRenderer implements Renderer {
 	public final CommandBuffer sceneCmd = new CommandBuffer("Scene");
 	public final CommandBuffer directionalCmd = new CommandBuffer("Directional");
 	public final CommandBuffer gapFillerCmd = new CommandBuffer("GapFiller");
+	// The skybox is recorded separately and executed before the scene so it acts as the background.
+	public final CommandBuffer skyboxCmd = new CommandBuffer("Skybox");
 
 	private GLBuffer indirectDrawCmds;
 	public static GpuIntBuffer indirectDrawCmdsStaging;
@@ -191,6 +193,7 @@ public class ZoneRenderer implements Renderer {
 		sceneCmd.setFrameTimer(frameTimer);
 		directionalCmd.setFrameTimer(frameTimer);
 		gapFillerCmd.setFrameTimer(frameTimer);
+		skyboxCmd.setFrameTimer(frameTimer);
 
 		jobSystem.startUp(config.cpuUsageLimit());
 		uboWorldViews.initialize(UNIFORM_BLOCK_WORLD_VIEWS);
@@ -323,7 +326,8 @@ public class ZoneRenderer implements Renderer {
 			ctx.map();
 
 			// Upload the camera-anchored skybox (if the scene has one) into VAO_SKYBOX now that the
-			// dynamic model buffers are mapped. It is drawn first, before opaque geometry, in drawPass.
+			// dynamic model buffers are mapped. It is recorded into skyboxCmd in the alpha pass (after
+			// unmap) and executed before the scene in scenePass() so it acts as the background.
 			if (scene.getWorldViewId() == WorldView.TOPLEVEL)
 				skyboxVisible = modelStreamingManager.drawSkybox(scene);
 
@@ -624,6 +628,7 @@ public class ZoneRenderer implements Renderer {
 		sceneCmd.reset();
 		directionalCmd.reset();
 		gapFillerCmd.reset();
+		skyboxCmd.reset();
 		renderState.reset();
 
 		eboAlpha.orphan();
@@ -798,6 +803,10 @@ public class ZoneRenderer implements Renderer {
 			gapFillerCmd.execute(renderState);
 			renderState.depthMask.set(true);
 		}
+
+		// Draw the skybox as the background, before the scene, so all scene geometry overdraws it.
+		if (!skyboxCmd.isEmpty())
+			skyboxCmd.execute(renderState);
 
 		sceneCmd.execute(renderState);
 
@@ -997,18 +1006,15 @@ public class ZoneRenderer implements Renderer {
 					if (sceneManager.isRoot(ctx))
 						frameTimer.end(Timer.UNMAP_ROOT_CTX);
 
-					// Draw the camera-anchored skybox first as the pure background. Depth testing AND writing
-					// are disabled so it never occludes scene geometry and never writes depth; everything
-					// else is drawn afterwards with depth testing and paints over it. Back-face culling is
-					// disabled because the skybox is viewed from the inside. Only the root scene has a skybox.
+					// Record the camera-anchored skybox into its own command buffer, executed before the
+					// scene in scenePass() so it acts as the background. Depth writes and back-face culling
+					// are disabled (it's viewed from inside and must not occlude); the scene draws over it.
 					if (skyboxVisible && sceneManager.isRoot(ctx)) {
-						ctx.vaoSceneCmd.Disable(GL_DEPTH_TEST);
-						ctx.vaoSceneCmd.DepthMask(false);
-						ctx.vaoSceneCmd.Disable(GL_CULL_FACE);
-						ctx.drawAll(VAO_SKYBOX, ctx.vaoSceneCmd);
-						ctx.vaoSceneCmd.Enable(GL_CULL_FACE);
-						ctx.vaoSceneCmd.DepthMask(true);
-						ctx.vaoSceneCmd.Enable(GL_DEPTH_TEST);
+						skyboxCmd.DepthMask(false);
+						skyboxCmd.Disable(GL_CULL_FACE);
+						ctx.drawAll(VAO_SKYBOX, skyboxCmd);
+						skyboxCmd.Enable(GL_CULL_FACE);
+						skyboxCmd.DepthMask(true);
 					}
 
 					// Draw opaque

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -775,17 +775,22 @@ public class ZoneRenderer implements Renderer {
 		renderState.ido.set(indirectDrawCmds.id);
 		renderState.apply();
 
-		// Clear scene
+		// Clear scene. When a skybox is present, clear to black so the sky color doesn't bleed through any
+		// pixels the skybox model doesn't cover; otherwise clear to the environment's fog/sky color.
 		frameTimer.begin(Timer.CLEAR_SCENE);
 
-		float[] fogColor = ColorUtils.linearToSrgb(environmentManager.currentFogColor);
-		float[] gammaCorrectedFogColor = pow(fogColor, plugin.getGammaCorrection());
-		glClearColor(
-			gammaCorrectedFogColor[0],
-			gammaCorrectedFogColor[1],
-			gammaCorrectedFogColor[2],
-			1f
-		);
+		if (skyboxVisible) {
+			glClearColor(0, 0, 0, 1f);
+		} else {
+			float[] fogColor = ColorUtils.linearToSrgb(environmentManager.currentFogColor);
+			float[] gammaCorrectedFogColor = pow(fogColor, plugin.getGammaCorrection());
+			glClearColor(
+				gammaCorrectedFogColor[0],
+				gammaCorrectedFogColor[1],
+				gammaCorrectedFogColor[2],
+				1f
+			);
+		}
 		glClearDepth(0);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		frameTimer.end(Timer.CLEAR_SCENE);

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -82,6 +82,7 @@ import static rs117.hd.HdPluginConfig.*;
 import static rs117.hd.renderer.zone.WorldViewContext.VAO_OPAQUE;
 import static rs117.hd.renderer.zone.WorldViewContext.VAO_PLAYER;
 import static rs117.hd.renderer.zone.WorldViewContext.VAO_SHADOW;
+import static rs117.hd.renderer.zone.WorldViewContext.VAO_SKYBOX;
 import static rs117.hd.utils.MathUtils.*;
 
 @Slf4j
@@ -160,6 +161,7 @@ public class ZoneRenderer implements Renderer {
 
 	private boolean sceneFboValid;
 	private boolean shouldRenderScene;
+	private boolean skyboxVisible;
 	private boolean shouldClearShadowFbo;
 	private boolean shouldDrawRoofShadows;
 
@@ -319,6 +321,12 @@ public class ZoneRenderer implements Renderer {
 			ctx.sortStaticAlphaModels(sceneCamera);
 
 			ctx.map();
+
+			// Upload the camera-anchored skybox (if the scene has one) into VAO_SKYBOX now that the
+			// dynamic model buffers are mapped. It is drawn first, before opaque geometry, in drawPass.
+			if (scene.getWorldViewId() == WorldView.TOPLEVEL)
+				skyboxVisible = modelStreamingManager.drawSkybox(scene);
+
 			frameTimer.end(Timer.DRAW_PRESCENE);
 		} catch (Throwable ex) {
 			log.error("Error in preSceneDraw({}):", scene != null ? scene.getWorldViewId() : null, ex);
@@ -988,6 +996,14 @@ public class ZoneRenderer implements Renderer {
 
 					if (sceneManager.isRoot(ctx))
 						frameTimer.end(Timer.UNMAP_ROOT_CTX);
+
+					// Draw the camera-anchored skybox first as the background, without writing depth so
+					// all scene geometry overdraws it. Only the root scene supplies a skybox.
+					if (skyboxVisible && sceneManager.isRoot(ctx)) {
+						ctx.vaoSceneCmd.DepthMask(false);
+						ctx.drawAll(VAO_SKYBOX, ctx.vaoSceneCmd);
+						ctx.vaoSceneCmd.DepthMask(true);
+					}
 
 					// Draw opaque
 					ctx.drawAll(VAO_OPAQUE, ctx.vaoSceneCmd);

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -997,15 +997,18 @@ public class ZoneRenderer implements Renderer {
 					if (sceneManager.isRoot(ctx))
 						frameTimer.end(Timer.UNMAP_ROOT_CTX);
 
-					// Draw the camera-anchored skybox first as the background, without writing depth so
-					// all scene geometry overdraws it. Back-face culling is disabled because the skybox is
-					// viewed from the inside. Only the root scene supplies a skybox.
+					// Draw the camera-anchored skybox first as the pure background. Depth testing AND writing
+					// are disabled so it never occludes scene geometry and never writes depth; everything
+					// else is drawn afterwards with depth testing and paints over it. Back-face culling is
+					// disabled because the skybox is viewed from the inside. Only the root scene has a skybox.
 					if (skyboxVisible && sceneManager.isRoot(ctx)) {
+						ctx.vaoSceneCmd.Disable(GL_DEPTH_TEST);
 						ctx.vaoSceneCmd.DepthMask(false);
 						ctx.vaoSceneCmd.Disable(GL_CULL_FACE);
 						ctx.drawAll(VAO_SKYBOX, ctx.vaoSceneCmd);
 						ctx.vaoSceneCmd.Enable(GL_CULL_FACE);
 						ctx.vaoSceneCmd.DepthMask(true);
+						ctx.vaoSceneCmd.Enable(GL_DEPTH_TEST);
 					}
 
 					// Draw opaque

--- a/src/main/java/rs117/hd/utils/HDUtils.java
+++ b/src/main/java/rs117/hd/utils/HDUtils.java
@@ -467,6 +467,8 @@ public final class HDUtils {
 		return true;
 	}
 
+	public static final int SKYBOX_TERRAIN_FLAG = 1 << 23;
+
 	public static int packTerrainData(boolean isTerrain, int waterDepth, WaterType waterType, int plane) {
 		// Up to 12-bit water depth | 8-bit water type | 2-bit plane | terrain flag
 		assert waterType.index < 1 << 7 : "Too many water types";

--- a/src/main/resources/rs117/hd/scene_frag.glsl
+++ b/src/main/resources/rs117/hd/scene_frag.glsl
@@ -93,6 +93,8 @@ void main() {
 
     // Water data
     bool isTerrain = (fTerrainData[0] & 1) != 0; // 1 = 0b1
+    // Skybox faces are anchored to the camera and act as the background; they must not be fogged.
+    bool isSkybox = (fTerrainData[0] & (1 << 23)) != 0;
     int waterDepth1 = fTerrainData[0] >> 11 & 0xFFF;
     int waterDepth2 = fTerrainData[1] >> 11 & 0xFFF;
     int waterDepth3 = fTerrainData[2] >> 11 & 0xFFF;
@@ -511,7 +513,7 @@ void main() {
     #endif
 
     // apply fog
-    if (!isUnderwater) {
+    if (!isUnderwater && !isSkybox) {
         // ground fog
         float distance = distance(IN.position, cameraPos);
         float closeFadeDistance = 1500;


### PR DESCRIPTION
Currently only supports the new renderer, with no support for legacy add in this branch

Adds support for the client's new Scene.getSkybox() model (introduced for an upcoming quest), mirroring the base GPU plugin's skybox feature but adapted to 117HD's zone renderer. The skybox is rendered as actual camera-anchored geometry through the existing dynamic model pipeline.

Added a flag (bit 23 of the face terrain data) that tags skybox faces so scene_frag.glsl skips fog on them — the skybox is the background, but distant scene geometry still gets normal distance haze

When getSkybox() returns null (i.e. everywhere until the quest ships), behavior is unchanged — it falls back to the existing environment sky-color rendering