### PR TITLE
Draw Zone Alpha in two Passes Color & Depth

### DIFF
--- a/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
@@ -1519,6 +1519,9 @@ public class SceneUploader implements AutoCloseable {
 			ModelOverride faceOverride = modelOverride;
 
 			int transparency = readFaceTransparency(modelTransparency, transparencies, face);
+			if (transparency == 255)
+				continue;
+
 			int textureId = isVanillaTextured ? faceTextures[face] : -1;
 			boolean isTextured = textureId != -1;
 			if (isTextured) {
@@ -2606,10 +2609,16 @@ public class SceneUploader implements AutoCloseable {
 
 		int t = modelTransparency & 255;
 		int faceTransparency = transparencies != null ? transparencies[f] & 0xFF : 0;
-		if (t > 0 && faceTransparency < 253) {
-			int a = (253 - faceTransparency) * t >> 8;
-			assert (faceTransparency & 255) == faceTransparency;
-			return faceTransparency + a;
+		if(faceTransparency < 253) {
+			if (t > 0) {
+				int a = (253 - faceTransparency) * t >> 8;
+				assert (faceTransparency & 255) == faceTransparency;
+				return faceTransparency + a;
+			}
+		} else {
+			// 253 & 254 are special faces like clickboxes which we don't want to render
+			// So force it to be 255 so that the face is completely skipped
+			return 255;
 		}
 
 		return faceTransparency;

--- a/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
@@ -2607,18 +2607,18 @@ public class SceneUploader implements AutoCloseable {
 		if (modelTransparency == -1)
 			return 255;
 
-		int t = modelTransparency & 255;
 		int faceTransparency = transparencies != null ? transparencies[f] & 0xFF : 0;
-		if(faceTransparency < 253) {
-			if (t > 0) {
-				int a = (253 - faceTransparency) * t >> 8;
-				assert (faceTransparency & 255) == faceTransparency;
-				return faceTransparency + a;
-			}
-		} else {
-			// 253 & 254 are special faces like clickboxes which we don't want to render
-			// So force it to be 255 so that the face is completely skipped
+		if (faceTransparency >= 253) {
+			// 253 & 254 are special faces like clickboxes which we don't want to render,
+			// so force them to be 255 so that they are completely skipped
 			return 255;
+		}
+
+		if (modelTransparency != 0) {
+			assert (faceTransparency & 255) == faceTransparency;
+			int t = modelTransparency & 255;
+			int a = (253 - faceTransparency) * t >> 8;
+			return faceTransparency + a;
 		}
 
 		return faceTransparency;

--- a/src/main/java/rs117/hd/renderer/zone/Zone.java
+++ b/src/main/java/rs117/hd/renderer/zone/Zone.java
@@ -736,8 +736,6 @@ public class Zone implements Destructible {
 
 		drawIdx = 0;
 
-		cmd.DepthMask(false);
-
 		if (!isShadowPass)
 			sortedAlphaFacesUpload.waitForCompletion();
 
@@ -801,8 +799,6 @@ public class Zone implements Destructible {
 		}
 
 		flush(cmd);
-
-		cmd.DepthMask(true);
 	}
 
 	private void flush(CommandBuffer cmd) {

--- a/src/main/java/rs117/hd/renderer/zone/Zone.java
+++ b/src/main/java/rs117/hd/renderer/zone/Zone.java
@@ -719,7 +719,7 @@ public class Zone implements Destructible {
 		int zz,
 		int level,
 		WorldViewContext ctx,
-		boolean isShadowPass,
+		boolean depthOnly,
 		boolean includeRoof
 	) {
 		if (alphaModels.isEmpty())
@@ -736,7 +736,7 @@ public class Zone implements Destructible {
 
 		drawIdx = 0;
 
-		if (!isShadowPass)
+		if (!depthOnly)
 			sortedAlphaFacesUpload.waitForCompletion();
 
 		int eboAlphaStart = eboAlphaOffset = ZoneRenderer.eboAlphaWriter.getWrittenInts();
@@ -753,7 +753,7 @@ public class Zone implements Destructible {
 			if (m.isTemp()) {
 				// these are already sorted and so just requires a glMultiDrawArrays() from the active vao
 				drawMode = TEMP;
-			} else if (isShadowPass || m.asyncSortIdx < 0) {
+			} else if (depthOnly || m.asyncSortIdx < 0) {
 				drawMode = STATIC_UNSORTED;
 			}
 

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -769,10 +769,7 @@ public class ZoneRenderer implements Renderer {
 		renderState.disable.set(GL_CULL_FACE);
 		renderState.depthFunc.set(GL_LEQUAL);
 		renderState.ido.set(indirectDrawCmds.id);
-
-		CommandBuffer.SKIP_DEPTH_MASKING = true;
 		directionalCmd.execute(renderState);
-		CommandBuffer.SKIP_DEPTH_MASKING = false;
 
 		glBindVertexArray(0);
 
@@ -979,8 +976,22 @@ public class ZoneRenderer implements Renderer {
 					z.renderAlpha(directionalCmd, zx - offset, zz - offset, level, ctx, true, shouldDrawRoofShadows);
 				}
 
-				if (!sceneManager.isRoot(ctx) || z.inSceneFrustum)
+				if (!sceneManager.isRoot(ctx) || z.inSceneFrustum) {
+					// Write Color without Depth Writes
+					sceneCmd.DepthMask(false);
+					sceneCmd.ColorMask(true, true, true, true);
+
 					z.renderAlpha(sceneCmd, zx - offset, zz - offset, level, ctx, false, false);
+
+					// Write Depth without Color
+					sceneCmd.DepthMask(true);
+					sceneCmd.ColorMask(false, false, false, false);
+
+					z.renderAlpha(sceneCmd, zx - offset, zz - offset, level, ctx, false, false);
+
+					// Restore Color Writes
+					sceneCmd.ColorMask(true, true, true, true);
+				}
 			}
 			frameTimer.end(Timer.DRAW_ZONE_ALPHA);
 

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -977,19 +977,19 @@ public class ZoneRenderer implements Renderer {
 				}
 
 				if (!sceneManager.isRoot(ctx) || z.inSceneFrustum) {
-					// Write Color without Depth Writes
+					// Write color without depth writes
 					sceneCmd.DepthMask(false);
 					sceneCmd.ColorMask(true, true, true, true);
 
 					z.renderAlpha(sceneCmd, zx - offset, zz - offset, level, ctx, false, false);
 
-					// Write Depth without Color
+					// Write depth without color
 					sceneCmd.DepthMask(true);
 					sceneCmd.ColorMask(false, false, false, false);
 
 					z.renderAlpha(sceneCmd, zx - offset, zz - offset, level, ctx, true, false);
 
-					// Restore Color Writes
+					// Restore color writes
 					sceneCmd.ColorMask(true, true, true, true);
 				}
 			}

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -987,7 +987,7 @@ public class ZoneRenderer implements Renderer {
 					sceneCmd.DepthMask(true);
 					sceneCmd.ColorMask(false, false, false, false);
 
-					z.renderAlpha(sceneCmd, zx - offset, zz - offset, level, ctx, false, false);
+					z.renderAlpha(sceneCmd, zx - offset, zz - offset, level, ctx, true, false);
 
 					// Restore Color Writes
 					sceneCmd.ColorMask(true, true, true, true);

--- a/src/main/java/rs117/hd/utils/CommandBuffer.java
+++ b/src/main/java/rs117/hd/utils/CommandBuffer.java
@@ -22,8 +22,6 @@ import static rs117.hd.utils.MathUtils.*;
 
 @Slf4j
 public class CommandBuffer {
-	public static boolean SKIP_DEPTH_MASKING;
-
 	private static final int GL_MULTI_DRAW_ARRAYS_TYPE = 0;
 	private static final int GL_MULTI_DRAW_ARRAYS_INDIRECT_TYPE = 1;
 	private static final int GL_DRAW_ARRAYS_TYPE = 2;
@@ -294,8 +292,6 @@ public class CommandBuffer {
 				switch (type) {
 					case GL_DEPTH_MASK_TYPE: {
 						int state = (int) (data >> 8) & 1;
-						if (SKIP_DEPTH_MASKING)
-							continue;
 						renderState.depthMask.set(state == 1);
 						break;
 					}


### PR DESCRIPTION
Prevent Alpha being drawn over due to higher planes drawing after lower planes

Main:
<img width="1096" height="581" alt="image" src="https://github.com/user-attachments/assets/3dc6f507-fddd-4a2f-a73a-b6627039dde4" />

PR:
<img width="1427" height="632" alt="image" src="https://github.com/user-attachments/assets/573b1ad6-6dfa-48a1-8272-3680ae435cfa" />

Main:
<img width="2527" height="1377" alt="image" src="https://github.com/user-attachments/assets/a0a167f3-9d2a-4776-8a9e-0136b95cb8a0" />

PR:
<img width="2527" height="1375" alt="image" src="https://github.com/user-attachments/assets/e2996870-abc7-488f-b6aa-550e017ad0c0" />

