### PR TITLE
Swap `HashSet` out for `IntHashSet` to reduce garbage generation

### DIFF
--- a/src/main/java/rs117/hd/opengl/GLState.java
+++ b/src/main/java/rs117/hd/opengl/GLState.java
@@ -1,10 +1,9 @@
 package rs117.hd.opengl;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 import lombok.Getter;
+import rs117.hd.utils.collections.IntHashSet;
 
 public abstract class GLState {
 	protected boolean hasValue;
@@ -145,7 +144,7 @@ public abstract class GLState {
 	}
 
 	public abstract static class IntSet extends GLState {
-		private final Set<Integer> targets = new HashSet<>();
+		private final IntHashSet targets = new IntHashSet();
 
 		public void add(int target) {
 			hasValue = true;


### PR DESCRIPTION
Does what is says on the tin!

Removes the following allocations due to Integer boxing
<img width="884" height="628" alt="image" src="https://github.com/user-attachments/assets/9f94027c-d1b5-4037-af7c-cfae76f7825b" />
