### PR TITLE
Expression Parser Rewrite

### DIFF
--- a/src/main/java/rs117/hd/renderer/legacy/LegacyModelPusher.java
+++ b/src/main/java/rs117/hd/renderer/legacy/LegacyModelPusher.java
@@ -337,12 +337,10 @@ public class LegacyModelPusher {
 				} else if (modelOverride.colorOverrides != null && (cacheUvData || !needsCaching)) {
 					// Color overrides are heavy. Only apply them if the UVs will be cached or don't need caching
 					int ahsl = (faceTransparencies == null ? 0xFF : 0xFF - (faceTransparencies[face] & 0xFF)) << 16 | faceColors[face];
-					for (var override : modelOverride.colorOverrides) {
-						if (override.ahslCondition.test(ahsl)) {
-							faceOverride = override;
-							material = faceOverride.baseMaterial;
-							break;
-						}
+					final var override = modelOverride.testColorOverrides(ahsl);
+					if (override != null) {
+						faceOverride = override;
+						material = faceOverride.baseMaterial;
 					}
 				}
 

--- a/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
@@ -37,6 +37,7 @@ import rs117.hd.scene.ProceduralGenerator;
 import rs117.hd.scene.SceneContext;
 import rs117.hd.scene.ground_materials.GroundMaterial;
 import rs117.hd.scene.materials.Material;
+import rs117.hd.scene.model_overrides.AHSLSupplier;
 import rs117.hd.scene.model_overrides.InheritTileColorType;
 import rs117.hd.scene.model_overrides.ModelOverride;
 import rs117.hd.scene.model_overrides.TzHaarRecolorType;
@@ -146,6 +147,8 @@ public class SceneUploader implements AutoCloseable {
 	private final GpuIntBuffer zoneVboO = new GpuIntBuffer(false);
 	private final GpuIntBuffer zoneVboA = new GpuIntBuffer(false);
 	private final GpuIntBuffer zoneTboF = new GpuIntBuffer(false);
+
+	private final AHSLSupplier ahslSupplier = new AHSLSupplier();
 
 	// Lazily initialized staging buffers
 	public VertexWriteCache.Collection writeCache;
@@ -1634,8 +1637,7 @@ public class SceneUploader implements AutoCloseable {
 					}
 				}
 			} else if (modelOverride.colorOverrides != null) {
-				final int ahsl = (0xFF - transparency) << 16 | color1;
-				final var override = modelOverride.testColorOverrides(ahsl);
+				final var override = modelOverride.testColorOverrides(ahslSupplier.ahsl(transparency, color1));
 				if (override != null) {
 					faceOverride = override;
 					material = faceOverride.baseMaterial;
@@ -1974,6 +1976,7 @@ public class SceneUploader implements AutoCloseable {
 		visibleFaces.ensureCapacity(triangleCount);
 		culledFaces.ensureCapacity(triangleCount);
 
+		final int[] color1s = model.getFaceColors1();
 		final int[] color3s = model.getFaceColors3();
 		final int[] indices1 = model.getFaceIndices1();
 		final int[] indices2 = model.getFaceIndices2();
@@ -2042,10 +2045,10 @@ public class SceneUploader implements AutoCloseable {
 					}
 				}
 			} else if (modelOverride.colorOverrides != null) {
-				final int ahsl = (0xFF - transparency) << 16 | model.getFaceColors1()[f];
+				final int ahsl = (0xFF - transparency) << 16 | color1s[f];
 				final var override = cachedAhsl == ahsl ?
 					cachedAhslOverride :
-					modelOverride.testColorOverrides(ahsl);
+					modelOverride.testColorOverrides(ahslSupplier.ahsl(ahsl));
 				cachedAhsl = ahsl;
 				cachedAhslOverride = override;
 

--- a/src/main/java/rs117/hd/scene/ProceduralGenerator.java
+++ b/src/main/java/rs117/hd/scene/ProceduralGenerator.java
@@ -34,6 +34,7 @@ import rs117.hd.scene.materials.Material;
 import rs117.hd.scene.model_overrides.ModelOverride;
 import rs117.hd.scene.model_overrides.TzHaarRecolorType;
 import rs117.hd.scene.tile_overrides.TileOverride;
+import rs117.hd.scene.tile_overrides.TileOverrideVariables;
 import rs117.hd.scene.water_types.WaterType;
 import rs117.hd.utils.ColorUtils;
 import rs117.hd.utils.collections.ConcurrentPool;
@@ -84,6 +85,7 @@ public class ProceduralGenerator {
 	@Inject
 	private WaterTypeManager waterTypeManager;
 
+	private final TileOverrideVariables tileVar = new TileOverrideVariables();
 	private final ConcurrentPool<GeneratorContext> GENERATOR_POOL = new ConcurrentPool<>(GeneratorContext::new);
 
 	final class GeneratorContext implements AutoCloseable {
@@ -555,9 +557,13 @@ public class ProceduralGenerator {
 
 			sceneContext.extendedSceneToWorld(tileExX, tileExY, tileZ, worldPos);
 
-			overrides[0] = tileOverrideManager.getOverride(sceneContext, tile, worldPos, ids);
-			overrides[1] = tileOverrideManager.getOverride(sceneContext, tile, worldPos, ids[1]);
-			overrides[2] = tileOverrideManager.getOverride(sceneContext, tile, worldPos, ids[0]);
+			try {
+				overrides[0] = tileOverrideManager.getOverride(sceneContext, tileVar, worldPos, ids);
+				overrides[1] = tileOverrideManager.getOverride(sceneContext, tileVar, worldPos, ids[1]);
+				overrides[2] = tileOverrideManager.getOverride(sceneContext, tileVar, worldPos, ids[0]);
+			} finally {
+				tileVar.setTile(null);
+			}
 
 			sceneContext.setTileOverride(tileZ, tileExX, tileExY, overrides);
 		}

--- a/src/main/java/rs117/hd/scene/TileOverrideManager.java
+++ b/src/main/java/rs117/hd/scene/TileOverrideManager.java
@@ -20,6 +20,7 @@ import rs117.hd.renderer.zone.SceneManager;
 import rs117.hd.scene.areas.Area;
 import rs117.hd.scene.ground_materials.GroundMaterial;
 import rs117.hd.scene.tile_overrides.TileOverride;
+import rs117.hd.scene.tile_overrides.TileOverrideVariables;
 import rs117.hd.utils.FileWatcher;
 import rs117.hd.utils.Props;
 import rs117.hd.utils.ResourcePath;
@@ -228,6 +229,18 @@ public class TileOverrideManager {
 
 	@Nonnull
 	public TileOverride getOverride(SceneContext sceneContext, @Nonnull Tile tile, @Nonnull int[] worldPos, int... ids) {
+		final var vars = SceneContext.TILE_OVERRIDE_VARIABLES.get();
+		try {
+			return getOverride(sceneContext, vars.setTile(tile), worldPos, ids);
+		}
+		finally {
+			vars.setTile(null); // Avoid accidentally keeping the old scene in memory
+		}
+	}
+
+	@Nonnull
+	public TileOverride getOverride(SceneContext sceneContext, TileOverrideVariables vars, @Nonnull int[] worldPos, int... ids) {
+		final Tile tile = vars.getTile();
 		if (ids.length == 0) {
 			var pos = tile.getSceneLocation();
 			int x = pos.getX() + sceneContext.sceneOffset;
@@ -244,11 +257,7 @@ public class TileOverrideManager {
 		if (override.isConstant())
 			return override;
 
-		final var vars = SceneContext.TILE_OVERRIDE_VARIABLES.get();
-		vars.setTile(tile);
-		TileOverride replacement = override.resolveReplacements(vars);
-		vars.setTile(null); // Avoid accidentally keeping the old scene in memory
-		return replacement;
+		return override.resolveReplacements(vars);
 	}
 
 	@Nonnull

--- a/src/main/java/rs117/hd/scene/model_overrides/AHSLSupplier.java
+++ b/src/main/java/rs117/hd/scene/model_overrides/AHSLSupplier.java
@@ -1,0 +1,37 @@
+package rs117.hd.scene.model_overrides;
+
+import rs117.hd.utils.Props;
+import rs117.hd.utils.VariableSupplier;
+
+public final class AHSLSupplier implements VariableSupplier {
+	public enum Var { a, h, s, l, ahsl, hsl }
+
+	private final int[] values = new int[Var.values().length];
+
+	public AHSLSupplier ahsl(int ahsl) {
+		values[Var.hsl.ordinal()] = ahsl & 0xFFFF;
+		values[Var.a.ordinal()]   = (ahsl >>> 16) & 0xFF;
+		values[Var.h.ordinal()]   = (ahsl >>> 10) & 0x3F;
+		values[Var.s.ordinal()]   = (ahsl >>> 7) & 0x7;
+		values[Var.l.ordinal()]   = ahsl & 0x7F;
+		values[Var.ahsl.ordinal()] = ahsl;
+		return this;
+	}
+
+	public AHSLSupplier ahsl(int transparency, int color) {
+		return ahsl(((0xFF - transparency) << 16) | (color & 0xFFFF));
+	}
+
+	@Override
+	public int getInt(Enum<?> key) {
+		if(Props.DEVELOPMENT && !(key instanceof Var))
+			throw new IllegalArgumentException("Undefined variable '" + key + "'");
+		return values[key.ordinal()];
+	}
+
+	@Override
+	public float getFloat(Enum<?> key) { return getInt(key); }
+
+	@Override
+	public Object get(String name) { return getInt(Var.valueOf(name)); }
+}

--- a/src/main/java/rs117/hd/scene/model_overrides/HSLComparison.java
+++ b/src/main/java/rs117/hd/scene/model_overrides/HSLComparison.java
@@ -1,0 +1,11 @@
+package rs117.hd.scene.model_overrides;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public final class HSLComparison implements ModelOverride.AhslPredicate {
+	public final int targetHsl;
+
+	@Override
+	public boolean test(AHSLSupplier vars) { return vars.getInt("hsl") == targetHsl; }
+}

--- a/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
+++ b/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
@@ -3,13 +3,17 @@ package rs117.hd.scene.model_overrides;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.annotations.JsonAdapter;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
@@ -24,7 +28,7 @@ import rs117.hd.utils.Props;
 
 import static net.runelite.api.Perspective.*;
 import static rs117.hd.utils.ExpressionParser.asExpression;
-import static rs117.hd.utils.ExpressionParser.parseExpression;
+import static rs117.hd.utils.ExpressionParser.parseExpressionEnum;
 import static rs117.hd.utils.MathUtils.*;
 
 @Slf4j
@@ -34,10 +38,21 @@ import static rs117.hd.utils.MathUtils.*;
 @AllArgsConstructor
 public class ModelOverride
 {
+	private static final ThreadLocal<AHSLSupplier> LOCAL_AHSLSupplier = ThreadLocal.withInitial(AHSLSupplier::new);
+
 	public static final ModelOverride NONE = new ModelOverride(true);
 	public static final ModelOverride UNLIT = new ModelOverride(true).baseMaterial(Material.UNLIT).undoVanillaShading(false);
 
 	private static final Set<Integer> EMPTY = new HashSet<>();
+
+	private static final Comparator<WeightedPredicate> WEIGHTED_PREDICATE_COMPARATOR = Comparator.comparingInt((val) -> val.weight);
+	private static final List<WeightedPredicate> PREDICATES = new ArrayList<>();
+
+	@RequiredArgsConstructor
+	private static class WeightedPredicate {
+		public final AhslPredicate condition;
+		public final int weight;
+	}
 
 	public String description = "UNKNOWN";
 
@@ -123,12 +138,9 @@ public class ModelOverride
 	public transient boolean mightBeDoubleSided;
 	public transient boolean modifiesVanillaTexture;
 
-	// Transient not volatile, since access order can be random as it'll mean we'll just fall back to the full lookup
-	private transient long cachedColorOverrideAhsl = -1;
-
 	@FunctionalInterface
 	public interface AhslPredicate {
-		boolean test(int ahsl);
+		boolean test(AHSLSupplier vars);
 	}
 
 	public void normalize(HdPlugin plugin) {
@@ -349,9 +361,7 @@ public class ModelOverride
 			ahslCondition,
 			mightHaveTransparency,
 			mightBeDoubleSided,
-			modifiesVanillaTexture,
-			// Runtime caching fields
-			-1
+			modifiesVanillaTexture
 		);
 	}
 
@@ -372,8 +382,7 @@ public class ModelOverride
 			arr.add(element);
 		}
 
-		AhslPredicate combinedPredicate = null;
-
+		PREDICATES.clear();
 		for (var el : arr) {
 			if (el.isJsonNull())
 				continue;
@@ -382,68 +391,67 @@ public class ModelOverride
 				continue;
 			}
 
-			AhslPredicate condition;
+			AhslPredicate condition = null;
+			int weight = 1;
 			var prim = el.getAsJsonPrimitive();
 			if (prim.isBoolean()) {
-				boolean bool = prim.getAsBoolean();
-				condition = ahsl -> bool;
+				if(prim.getAsBoolean())
+					condition = ahsl -> true;
 			} else if (prim.isNumber()) {
 				try {
-					int targetHsl = prim.getAsInt();
-					condition = ahsl -> (ahsl & 0xFFFF) == targetHsl;
+					condition = new HSLComparison(prim.getAsInt());
 				} catch (Exception ex) {
 					log.warn("Expected integer, but got {} in override '{}'", el, description);
 					continue;
 				}
 			} else if (prim.isString()) {
-				var expr = asExpression(parseExpression(prim.getAsString()));
+				final var expr = asExpression(parseExpressionEnum(prim.getAsString(), AHSLSupplier.Var::valueOf));
 
 				if (Props.DEVELOPMENT) {
 					// Ensure all variables are defined
-					final Set<String> knownVariables = Set.of("a", "h", "s", "l", "hsl", "ahsl");
+					final Set<String> knownVariables = new HashSet<>();
+					for(var val : AHSLSupplier.Var.values())
+						knownVariables.add(val.name());
+					
 					for (var variable : expr.variables)
 						if (!knownVariables.contains(variable))
 							throw new IllegalStateException(
 								"Expression '" + prim.getAsString() + "' contains unknown variable '" + variable + "'");
 				}
 
-				var predicate = expr.toPredicate();
-				condition = ahsl -> predicate.test(key -> {
-					switch (key) {
-						case "a":
-							return ahsl >>> 16 & 0xFF;
-						case "h":
-							return ahsl >>> 10 & 0x3F;
-						case "s":
-							return ahsl >>> 7 & 0x7;
-						case "l":
-							return ahsl & 0x7F;
-						case "ahsl":
-							return ahsl;
-						case "hsl":
-							return ahsl & 0xFFFF;
-						default:
-							assert false : "Unexpected variable: " + key;
-							return 0;
-					}
-				});
+				final var predicate = expr.toPredicate();
+				condition = predicate::test;
+				weight = expr.variables.size();
 			} else {
 				log.warn("Skipping unexpected HSL condition primitive '{}' in override '{}'", el, description);
 				continue;
 			}
 
-			if (combinedPredicate == null) {
-				combinedPredicate = condition;
-			} else {
-				var prev = combinedPredicate;
-				combinedPredicate = ahsl -> prev.test(ahsl) || condition.test(ahsl);
-			}
+			if(condition != null)
+				PREDICATES.add(new WeightedPredicate(condition, weight));
 		}
 
-		if (combinedPredicate == null)
+		if (PREDICATES.isEmpty())
 			return ahsl -> false;
 
-		return combinedPredicate;
+		final int conditionCount = PREDICATES.size();
+		if(conditionCount == 1)
+			return PREDICATES.get(0).condition;
+
+		// Sort based on weight to push cheaper conditions first
+		PREDICATES.sort(WEIGHTED_PREDICATE_COMPARATOR);
+
+		final AhslPredicate[] conditions = new AhslPredicate[conditionCount];
+		for(int i = 0; i < conditionCount; i++)
+			conditions[i] = PREDICATES.get(i).condition;
+
+		return ahsl -> {
+			for (int i = 0; i < conditionCount; i++) {
+				if (conditions[i].test(ahsl))
+					return true;
+			}
+			return false;
+		};
 	}
 
 	public void computeModelUvw(float[] out, int i, float x, float y, float z, int orientation) {
@@ -734,23 +742,20 @@ public class ModelOverride
 
 	@Nullable
 	public final ModelOverride testColorOverrides(int ahsl) {
-		ModelOverride override = null;
-		final long packedAhl = cachedColorOverrideAhsl;
-		if (packedAhl != -1 && ahsl == (int) packedAhl)
-			override = colorOverrides[(int) (packedAhl >> 32)];
+		if(colorOverrides.length == 0)
+			return null;
 
-		if (override == null) {
-			final int len = colorOverrides.length;
-			for (int i = 0; i < len; ++i) {
-				final var inner = colorOverrides[i];
-				if (inner.ahslCondition.test(ahsl)) {
-					cachedColorOverrideAhsl = ahsl | (long) i << 32;
-					override = inner;
-					break;
-				}
-			}
+		return testColorOverrides(LOCAL_AHSLSupplier.get().ahsl(ahsl));
+	}
+
+	@Nullable
+	public final ModelOverride testColorOverrides(AHSLSupplier vars) {
+		final int len = colorOverrides.length;
+		for (int i = 0; i < len; ++i) {
+			final var override = colorOverrides[i];
+			if (override.ahslCondition.test(vars))
+				return override;
 		}
-
-		return override;
+		return null;
 	}
 }

--- a/src/main/java/rs117/hd/scene/tile_overrides/TileOverride.java
+++ b/src/main/java/rs117/hd/scene/tile_overrides/TileOverride.java
@@ -175,7 +175,7 @@ public class TileOverride {
 					}
 				}
 
-				var result = parseExpression(ExpressionParser.mergeJsonExpressions("||", entry.getValue()), constants);
+				var result = parseExpression(ExpressionParser.mergeJsonExpressions("||", entry.getValue()), constants, TileOverrideVariables.Var::valueOf);
 				if (Props.DEVELOPMENT && result instanceof ExpressionParser.Expression) {
 					var expr = (ExpressionParser.Expression) result;
 					// Ensure all variables are defined

--- a/src/main/java/rs117/hd/scene/tile_overrides/TileOverrideVariables.java
+++ b/src/main/java/rs117/hd/scene/tile_overrides/TileOverrideVariables.java
@@ -1,35 +1,40 @@
 package rs117.hd.scene.tile_overrides;
 
+import lombok.Getter;
 import net.runelite.api.*;
 import rs117.hd.utils.HDUtils;
+import rs117.hd.utils.Props;
 import rs117.hd.utils.VariableSupplier;
 
 public class TileOverrideVariables implements VariableSupplier {
-	private final String[] HSL_VARS = { "h", "s", "l" };
-	private final int[] hsl = new int[3];
+	public enum Var {h, s, l}
 
+	private final int[] hsl = new int[Var.values().length];
+
+	@Getter
 	private Tile tile;
 	private boolean requiresHslUpdate;
 
-	public void setTile(Tile tile) {
+	public TileOverrideVariables setTile(Tile tile) {
 		if (tile == this.tile)
-			return;
+			return this;
 		this.tile = tile;
 		requiresHslUpdate = true;
+		return this;
 	}
 
 	@Override
-	public Object get(String name) {
-		for (int i = 0; i < HSL_VARS.length; i++) {
-			if (HSL_VARS[i].equals(name)) {
-				if (requiresHslUpdate) {
-					HDUtils.getSouthWesternMostTileColor(hsl, tile);
-					requiresHslUpdate = false;
-				}
-				return hsl[i];
-			}
-		}
+	public Object get(String name) { return getInt(Var.valueOf(name)); }
 
-		throw new IllegalArgumentException("Undefined variable '" + name + "'");
+	@Override
+	public int getInt(Enum<?> key) {
+		if(Props.DEVELOPMENT && !(key instanceof Var))
+			throw new IllegalArgumentException("Undefined variable '" + key + "'");
+
+		if (requiresHslUpdate) {
+			HDUtils.getSouthWesternMostTileColor(hsl, tile);
+			requiresHslUpdate = false;
+		}
+		return hsl[key.ordinal()];
 	}
 }

--- a/src/main/java/rs117/hd/utils/ExpressionParser.java
+++ b/src/main/java/rs117/hd/utils/ExpressionParser.java
@@ -7,38 +7,121 @@ import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanComparisons;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanConstant;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanEnumVariable;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanEvalPredicate;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanNot;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanStringVariable;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanTernary;
+import rs117.hd.utils.ExpressionParserEvaluators.BooleanToObjectFunction;
+import rs117.hd.utils.ExpressionParserEvaluators.ConstantFunction;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatAdd;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatComparisons;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatConstant;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatDiv;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatEnumVariable;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatMod;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatMul;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatStringVariable;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatSub;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatTernary;
+import rs117.hd.utils.ExpressionParserEvaluators.FloatToObjectFunction;
+import rs117.hd.utils.ExpressionParserEvaluators.IntAdd;
+import rs117.hd.utils.ExpressionParserEvaluators.IntComparisons;
+import rs117.hd.utils.ExpressionParserEvaluators.IntConstant;
+import rs117.hd.utils.ExpressionParserEvaluators.IntDiv;
+import rs117.hd.utils.ExpressionParserEvaluators.IntEnumVariable;
+import rs117.hd.utils.ExpressionParserEvaluators.IntMod;
+import rs117.hd.utils.ExpressionParserEvaluators.IntMul;
+import rs117.hd.utils.ExpressionParserEvaluators.IntStringVariable;
+import rs117.hd.utils.ExpressionParserEvaluators.IntSub;
+import rs117.hd.utils.ExpressionParserEvaluators.IntTernary;
+import rs117.hd.utils.ExpressionParserEvaluators.IntToObjectFunction;
+import rs117.hd.utils.ExpressionParserEvaluators.ObjectTernaryFunction;
+import rs117.hd.utils.ExpressionParserEvaluators.ObjectVariableFunction;
 
+import static rs117.hd.utils.ExpressionParser.Operator.NOT;
+import static rs117.hd.utils.ExpressionParser.Operator.TERNARY;
 import static rs117.hd.utils.MathUtils.*;
 
 public class ExpressionParser {
+	private static final LinkedHashMap<ExpressionKey, Expression> EXPRESSION_CACHE = new LinkedHashMap<>();
+	private static final LinkedHashMap<Object, IntEval> INT_VARIABLE_CACHE = new LinkedHashMap<>();
+	private static final LinkedHashMap<Object, FloatEval> FLOAT_VARIABLE_CACHE = new LinkedHashMap<>();
+	private static final LinkedHashMap<Object, BooleanEval> BOOLEAN_VARIABLE_CACHE = new LinkedHashMap<>();
+
 	public static ExpressionPredicate parsePredicate(String expression) {
-		return parsePredicate(expression, null);
+		return parsePredicate(expression, null, null);
 	}
 
 	public static ExpressionPredicate parsePredicate(String expression, @Nullable VariableSupplier constants) {
-		return asExpression(parseExpression(expression, constants)).toPredicate();
+		return parsePredicate(expression, constants, null);
+	}
+
+	public static ExpressionPredicate parsePredicateEnum(String expression, @Nullable VariableKeyResolver resolver) {
+		return parsePredicate(expression, null, resolver);
+	}
+
+	public static ExpressionPredicate parsePredicate(
+		String expression, @Nullable VariableSupplier constants, @Nullable VariableKeyResolver resolver
+	) {
+		return asExpression(parseExpression(expression, constants, resolver)).toPredicate();
 	}
 
 	public static Function<VariableSupplier, Object> parseFunction(String expression) {
-		return parseFunction(expression, null);
+		return parseFunction(expression, null, null);
 	}
 
 	public static Function<VariableSupplier, Object> parseFunction(String expression, @Nullable VariableSupplier constants) {
-		return asFunction(parseExpression(expression, constants));
+		return parseFunction(expression, constants, null);
+	}
+
+	public static Function<VariableSupplier, Object> parseFunctionEnum(String expression, @Nullable VariableKeyResolver resolver) {
+		return parseFunction(expression, null, resolver);
+	}
+
+	public static Function<VariableSupplier, Object> parseFunction(
+		String expression, @Nullable VariableSupplier constants, @Nullable VariableKeyResolver resolver
+	) {
+		return asFunction(parseExpression(expression, constants, resolver));
 	}
 
 	public static Object parseExpression(String expression) {
-		return parseExpression(expression, null);
+		return parseExpression(expression, null, null);
 	}
 
 	public static Object parseExpression(String expression, @Nullable VariableSupplier constants) {
-		return asExpression(parseExpression(expression, 0, expression.length())).simplify(constants);
+		return parseExpression(expression, constants, null);
+	}
+
+	public static Object parseExpressionEnum(String expression, @Nullable VariableKeyResolver resolver) {
+		return parseExpression(expression, null, resolver);
+	}
+
+	public static Object parseExpression(
+		String expression, @Nullable VariableSupplier constants, @Nullable VariableKeyResolver resolver
+	) {
+		final ExpressionKey key = new ExpressionKey(expression, constants, resolver);
+		final Expression cached = EXPRESSION_CACHE.get(key);
+		if(cached != null)
+			return cached;
+
+		final Object parsed = asExpression(parseExpression(expression, 0, expression.length(), constants, resolver)).simplify(constants);
+		if(parsed instanceof Expression)
+			EXPRESSION_CACHE.put(key, (Expression) parsed);
+
+		return parsed;
 	}
 
 	public static String mergeJsonExpressions(String delimiter, JsonElement jsonExpressions) {
@@ -81,11 +164,73 @@ public class ExpressionParser {
 	public static Function<VariableSupplier, Object> asFunction(Object object) {
 		if (object instanceof Expression)
 			return ((Expression) object).toFunction();
-		if (object instanceof String)
-			return vars -> vars.get((String) object);
-		return vars -> object;
+		if (object instanceof String || object instanceof Enum)
+			return new ObjectVariableFunction(object);
+		return new ConstantFunction(object);
 	}
 
+
+	private static IntEval toIntEval(Object operand) {
+		if (operand instanceof Expression)
+			return ((Expression) operand).compileInt();
+		if (operand instanceof Number)
+			return new IntConstant(((Number) operand).intValue());
+
+		IntEval evalVar = INT_VARIABLE_CACHE.get(operand);
+		if (evalVar == null) {
+			if (operand instanceof String)
+				evalVar = new IntStringVariable((String) operand);
+			else if (operand instanceof Enum)
+				evalVar = new IntEnumVariable((Enum<?>) operand);
+			else
+				throw new IllegalArgumentException("Cannot evaluate '" + operand + "' as a int");
+			INT_VARIABLE_CACHE.put(operand, evalVar);
+		}
+
+		return evalVar;
+	}
+
+	private static FloatEval toFloatEval(Object operand) {
+		if (operand instanceof Expression)
+			return  ((Expression) operand).compileFloat();
+		if (operand instanceof Number)
+			return new FloatConstant(((Number) operand).floatValue());
+
+		FloatEval evalVar = FLOAT_VARIABLE_CACHE.get(operand);
+		if (evalVar == null) {
+			if (operand instanceof String)
+				evalVar = new FloatStringVariable((String) operand);
+			else if (operand instanceof Enum)
+				evalVar = new FloatEnumVariable((Enum<?>) operand);
+			else
+				throw new IllegalArgumentException("Cannot evaluate '" + operand + "' as a float");
+			FLOAT_VARIABLE_CACHE.put(operand, evalVar);
+		}
+
+		return evalVar;
+	}
+
+	private static BooleanEval toBooleanEval(Object operand) {
+		if (operand instanceof Expression)
+			return  ((Expression) operand).compileBoolean();
+		if (operand instanceof Boolean)
+			return new BooleanConstant((Boolean) operand);
+
+		BooleanEval evalVar = BOOLEAN_VARIABLE_CACHE.get(operand);
+		if (evalVar == null) {
+			if (operand instanceof String)
+				evalVar = new BooleanStringVariable((String) operand);
+			else if (operand instanceof Enum)
+				evalVar = new BooleanEnumVariable((Enum<?>) operand);
+			else
+				throw new IllegalArgumentException("Cannot evaluate '" + operand + "' as a boolean");
+			BOOLEAN_VARIABLE_CACHE.put(operand, evalVar);
+		}
+
+		return evalVar;
+	}
+
+	@RequiredArgsConstructor
 	public static class SerializableExpressionPredicate implements ExpressionPredicate {
 		public final Expression expression;
 		public final ExpressionPredicate predicate;
@@ -169,7 +314,7 @@ public class ExpressionParser {
 	}
 
 	@RequiredArgsConstructor
-	private enum Operator {
+	public enum Operator {
 		MOD("%", 6, 2),
 		MUL("*", 6, 2),
 		DIV("/", 6, 2),
@@ -200,6 +345,9 @@ public class ExpressionParser {
 
 	@AllArgsConstructor
 	public static class ParserContext {
+		static final StringBuilder TRUE_SB = new StringBuilder("true");
+		static final StringBuilder FALSE_SB = new StringBuilder("false");
+		final StringBuilder sb = new StringBuilder();
 		final String expr;
 		int index, endIndex;
 		char c;
@@ -207,14 +355,23 @@ public class ExpressionParser {
 		Object[] operands = new Object[2];
 		boolean isInParentheses;
 		boolean isTopLevelParser;
+		boolean hasDecimal;
 		int minPrecedence;
+		@Nullable VariableSupplier constants;
+		@Nullable VariableKeyResolver keyResolver;
 
-		ParserContext(String expression, int startIndex, int endIndex, boolean isTopLevelParser, int minPrecedence) {
+		ParserContext(
+			String expression, int startIndex, int endIndex,
+			boolean isTopLevelParser, int minPrecedence,
+			@Nullable VariableSupplier constants, @Nullable VariableKeyResolver keyResolver
+		) {
 			this.expr = expression;
 			this.index = startIndex;
 			this.endIndex = endIndex;
 			this.isTopLevelParser = isTopLevelParser;
 			this.minPrecedence = minPrecedence;
+			this.constants = constants;
+			this.keyResolver = keyResolver;
 		}
 
 		boolean done() {
@@ -329,7 +486,7 @@ public class ExpressionParser {
 				// Always parse parentheses in a new parsing context
 				if (c == '(') {
 					int end = indexOfClosingParenthesis(index);
-					var exprInParentheses = parseExpression(expr, index, end + 1);
+					var exprInParentheses = parseExpression(expr, index, end + 1, constants, keyResolver);
 					index = end + 1;
 					readSafe();
 					return exprInParentheses;
@@ -337,7 +494,7 @@ public class ExpressionParser {
 
 				// Parse all following operations with higher precedence than the current, and return that as the operand
 				if (op != null) {
-					var higherPrecedenceParser = new ParserContext(expr, index, endIndex, false, op.precedence + 1);
+					var higherPrecedenceParser = new ParserContext(expr, index, endIndex, false, op.precedence + 1, constants, keyResolver);
 					var expr = parseExpression(higherPrecedenceParser);
 					if (expr != null) {
 						index = higherPrecedenceParser.index;
@@ -346,8 +503,14 @@ public class ExpressionParser {
 					}
 				}
 
-				if (c == '+' || c == '-' || c == '.' || ('0' <= c && c <= '9'))
-					return readNumber();
+				if (c == '+' || c == '-' || c == '.' || ('0' <= c && c <= '9')) {
+					final float floatVal = readNumber();
+					final int intVal = (int) floatVal;
+					hasDecimal = floatVal != intVal;
+					if(hasDecimal)
+						return floatVal;
+					return intVal;
+				}
 				if ('A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || c == '_')
 					return readIdentifier();
 			}
@@ -406,7 +569,7 @@ public class ExpressionParser {
 		}
 
 		Object readIdentifier() {
-			StringBuilder sb = new StringBuilder();
+			sb.setLength(0);
 			while (!done()) {
 				if ('A' <= c && c <= 'Z' ||
 					'a' <= c && c <= 'z' ||
@@ -422,28 +585,35 @@ public class ExpressionParser {
 			}
 
 			assert sb.length() > 0;
-			var str = sb.toString();
-
-			// Convert string constants
-			if (str.equalsIgnoreCase("true"))
+			if(sb.compareTo(TRUE_SB) == 0)
 				return true;
-			if (str.equalsIgnoreCase("false"))
+
+			if(sb.compareTo(FALSE_SB) == 0)
 				return false;
 
-			return str;
+			final String name = sb.toString().intern();
+			final boolean isKnownConstant = constants != null && constants.get(name) != null;
+
+			if (keyResolver != null && !isKnownConstant) {
+				var resolved = keyResolver.resolve(name);
+				if (resolved != null)
+					return resolved;
+			}
+
+			return name;
 		}
 
 		Expression createExpression(Object leftOperand, Operator op, Object rightOperand) {
 			if (!(leftOperand instanceof Expression)) {
 				// Simple combination of left & right operands
-				return new Expression(op, leftOperand, rightOperand, null, false);
+				return new Expression(op, leftOperand, rightOperand, null, false, false);
 			}
 
 			Expression left = (Expression) leftOperand;
 			// If the left expression is in parentheses, or has the same or higher operator precedence,
 			// it should be evaluated first, so use it as the left operand in a new expression
 			if (left.isInParentheses || left.op.precedence >= op.precedence)
-				return new Expression(op, left, rightOperand, null, false);
+				return new Expression(op, left, rightOperand, null, false, false);
 
 			// The new operator should act on the left expression's right-most operand,
 			// and should replace the right-most operand with the resulting expression
@@ -452,23 +622,54 @@ public class ExpressionParser {
 		}
 	}
 
-	public static class Expression {
+	@RequiredArgsConstructor
+	private static class ExpressionKey {
+		@NonNull final String expression;
+		@Nullable final VariableSupplier constants;
+		@Nullable final VariableKeyResolver keyResolver;
+
+		@Override
+		public int hashCode() {
+			int result = expression.hashCode();
+			result = 31 * result + System.identityHashCode(constants);
+			result = 31 * result + System.identityHashCode(keyResolver);
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (this == other)
+				return true;
+			if (!(other instanceof ExpressionKey))
+				return false;
+
+			ExpressionKey otherKey = (ExpressionKey) other;
+			return expression.equals(otherKey.expression)
+			       && constants == otherKey.constants
+			       && keyResolver == otherKey.keyResolver;
+		}
+	}
+
+	public static final class Expression {
 		Operator op;
 		Object left, right;
 		Object ternary;
 		boolean isInParentheses;
+		boolean hasDecimal;
+
 		public final HashSet<String> variables = new HashSet<>();
 
 		Expression(Object value) {
-			this(null, value, null, null, false);
+			this(null, value, null, null, false, false);
 		}
 
-		Expression(Operator op, Object left, Object right, Object ternary, boolean isInParentheses) {
+		Expression(Operator op, Object left, Object right, Object ternary, boolean isInParentheses, boolean hasDecimal) {
 			this.op = op;
 			this.left = left;
 			this.right = right;
 			this.ternary = ternary;
 			this.isInParentheses = isInParentheses;
+			this.hasDecimal = hasDecimal;
 			registerVariables(left);
 			registerVariables(right);
 			registerVariables(ternary);
@@ -482,38 +683,48 @@ public class ExpressionParser {
 				if (l instanceof String) {
 					var value = constants.get((String) l);
 					if (value != null)
-						l = sanitizeValue(value);
+						l = value;
+				} else if (l instanceof Enum) {
+					var value = constants.get((Enum<?>) l);
+					if (value != null)
+						l = value;
 				}
 				if (r instanceof String) {
 					var value = constants.get((String) r);
 					if (value != null)
-						r = sanitizeValue(value);
+						r = value;
+				} else if (r instanceof Enum) {
+					var value = constants.get((Enum<?>) r);
+					if (value != null)
+						r = value;
 				}
 			}
 
-			if (op == Operator.TERNARY) {
+			if (op == TERNARY) {
 				Object t = asExpression(ternary).simplify(constants);
 				if (t instanceof Boolean)
 					return (boolean) t ? l : r;
-				return new Expression(op, l, r, asExpression(t), isInParentheses);
+				return new Expression(op, l, r, asExpression(t), isInParentheses, hasDecimal);
 			}
 
 			var expr = this;
 			if (l != left || r != right)
-				expr = new Expression(op, l, r, null, isInParentheses);
+				expr = new Expression(op, l, r, null, isInParentheses, hasDecimal);
 
 			if (isPrimitive(l) && isPrimitive(r))
-				return expr.toFunctionInternal().apply(null);
+				return expr.toFunction().apply(null);
 
 			return expr;
 		}
 
 		private String formatOperand(Object operand) {
-			if (operand instanceof Number) {
+			if (operand instanceof Float) {
 				int nearest = round((float) operand);
 				if (abs((float) operand - nearest) < 1e-10)
 					operand = nearest;
 			}
+			if (operand instanceof Enum)
+				return ((Enum<?>) operand).name();
 			return operand.toString();
 		}
 
@@ -531,93 +742,102 @@ public class ExpressionParser {
 		}
 
 		public Function<VariableSupplier, Object> toFunction() {
-			var func = toFunctionInternal();
-			return vars -> func.apply(key -> sanitizeValue(vars.get(key)));
-		}
-
-		static Object sanitizeValue(Object value) {
-			// This is kind of stupid, but it's necessary to convert
-			// ints to floats here to avoid messy code later
-			if (value instanceof Integer)
-				return ((Integer) value).floatValue();
-			return value;
-		}
-
-		private Function<VariableSupplier, Object> toFunctionInternal() {
 			if (op == null)
 				return asFunction(left);
+			if (op == TERNARY)
+				return compileObjectTernary();
+			return isBoolean() ?
+				new BooleanToObjectFunction(compileBoolean()) :
+				hasDecimal ? new FloatToObjectFunction(compileFloat()) : new IntToObjectFunction(compileInt());
+		}
 
-			if (op == Operator.TERNARY) {
-				var condition = asExpression(ternary).toPredicate();
-				if (left instanceof Expression) {
-					var ifTrue = ((Expression) left).toFunction();
-					if (right instanceof Expression) {
-						var ifFalse = ((Expression) right).toFunction();
-						return vars -> condition.test(vars) ? ifTrue.apply(vars) : ifFalse.apply(vars);
-					}
-					return vars -> condition.test(vars) ? ifTrue.apply(vars) : right;
-				} else if (right instanceof Expression) {
-					var ifFalse = ((Expression) right).toFunction();
-					return vars -> condition.test(vars) ? left : ifFalse.apply(vars);
-				} else {
-					return vars -> condition.test(vars) ? left : right;
-				}
-			}
+		private Function<VariableSupplier, Object> compileObjectTernary() {
+			BooleanEval condition = toBooleanEval(ternary);
+			Function<VariableSupplier, Object> ifTrue = asFunction(left);
+			Function<VariableSupplier, Object> ifFalse = asFunction(right);
+			return new ObjectTernaryFunction(condition, ifTrue, ifFalse);
+		}
 
-			// Convert variables and constants into functions
-			var l = asFunction(left);
-			var r = asFunction(right);
+		private IntEval compileInt() {
+			if (op == null)
+				return toIntEval(left);
+
+			if(op == TERNARY)
+				return new IntTernary(toBooleanEval(ternary), toIntEval(left), toIntEval(right));
 
 			switch (op) {
-				case AND:
-					return vars -> (boolean) l.apply(vars) && (boolean) r.apply(vars);
-				case OR:
-					return vars -> (boolean) l.apply(vars) || (boolean) r.apply(vars);
-				case NOTEQUAL:
-				case EQUAL:
-					boolean isBoolean =
-						left instanceof Boolean || left instanceof Expression && ((Expression) left).isBoolean() ||
-						right instanceof Boolean || right instanceof Expression && ((Expression) right).isBoolean();
-					if (isBoolean) {
-						return op == Operator.EQUAL ?
-							vars -> (boolean) l.apply(vars) == (boolean) r.apply(vars) :
-							vars -> (boolean) l.apply(vars) != (boolean) r.apply(vars);
-					} else {
-						return op == Operator.EQUAL ?
-							vars -> (float) l.apply(vars) == (float) r.apply(vars) :
-							vars -> (float) l.apply(vars) != (float) r.apply(vars);
-					}
-				case GEQUAL:
-					return vars -> (float) l.apply(vars) >= (float) r.apply(vars);
-				case GREATER:
-					return vars -> (float) l.apply(vars) > (float) r.apply(vars);
-				case LEQUAL:
-					return vars -> (float) l.apply(vars) <= (float) r.apply(vars);
-				case LESS:
-					return vars -> (float) l.apply(vars) < (float) r.apply(vars);
 				case ADD:
-					return vars -> (float) l.apply(vars) + (float) r.apply(vars);
+					return new IntAdd(toIntEval(left), toIntEval(right));
 				case SUB:
-					return vars -> (float) l.apply(vars) - (float) r.apply(vars);
+					return new IntSub(toIntEval(left), toIntEval(right));
 				case MUL:
-					return vars -> (float) l.apply(vars) * (float) r.apply(vars);
+					return new IntMul(toIntEval(left), toIntEval(right));
 				case DIV:
-					return vars -> (float) l.apply(vars) / (float) r.apply(vars);
+					return new IntDiv(toIntEval(left), toIntEval(right));
 				case MOD:
-					return vars -> (float) l.apply(vars) % (float) r.apply(vars);
-				case NOT:
-					return vars -> !(boolean) r.apply(vars);
+					return new IntMod(toIntEval(left), toIntEval(right));
 			}
 
-			throw new UnsupportedOperationException("Unsupported operands: " + l + " " + op + " " + r);
+			throw new UnsupportedOperationException("Operator '" + op + "' is not a math operator");
+		}
+
+		private FloatEval compileFloat() {
+			if (op == null)
+				return toFloatEval(left);
+
+			if(op == TERNARY)
+				return new FloatTernary(toBooleanEval(ternary), toFloatEval(left), toFloatEval(right));
+
+			switch (op) {
+				case ADD:
+					return new FloatAdd(toFloatEval(left), toFloatEval(right));
+				case SUB:
+					return new FloatSub(toFloatEval(left), toFloatEval(right));
+				case MUL:
+					return new FloatMul(toFloatEval(left), toFloatEval(right));
+				case DIV:
+					return new FloatDiv(toFloatEval(left), toFloatEval(right));
+				case MOD:
+					return new FloatMod(toFloatEval(left), toFloatEval(right));
+			}
+
+			throw new UnsupportedOperationException("Operator '" + op + "' is not a math operator");
+		}
+
+		private BooleanEval compileBoolean() {
+			if (op == null)
+				return toBooleanEval(left);
+
+			if (op == NOT)
+				return new BooleanNot(toBooleanEval(right));
+
+			final boolean isFloatCompare =
+				left instanceof Float || left instanceof Expression && ((Expression) left).hasDecimal ||
+				right instanceof Float || right instanceof Expression && ((Expression)right).hasDecimal;
+
+			final boolean isBooleanCompare =
+				op == Operator.AND || op == Operator.OR ||
+				left instanceof Boolean || left instanceof Expression && ((Expression) left).isBoolean() ||
+				right instanceof Boolean || right instanceof Expression && ((Expression) right).isBoolean();
+
+			if(isBooleanCompare) {
+				if(op == TERNARY)
+					return new BooleanTernary(toBooleanEval(ternary), toBooleanEval(left), toBooleanEval(right));
+
+				return new BooleanComparisons(op, toBooleanEval(left), toBooleanEval(right));
+			}
+
+			if(isFloatCompare)
+				return new FloatComparisons(op, toFloatEval(left), toFloatEval(right));
+
+			return new IntComparisons(op, toIntEval(left), toIntEval(right));
 		}
 
 		public ExpressionPredicate toPredicate() {
 			if (!isBoolean())
 				throw new IllegalArgumentException("Expression does not result in a boolean");
 
-			var func = toFunction();
-			return vars -> (boolean) func.apply(vars);
+			return new BooleanEvalPredicate(compileBoolean());
 		}
 
 		boolean isBoolean() {
@@ -644,24 +864,30 @@ public class ExpressionParser {
 			return
 				obj instanceof Boolean ||
 				obj instanceof String ||
+				obj instanceof Enum ||
 				obj instanceof Expression && ((Expression) obj).isBoolean();
 		}
 
 		private boolean isPrimitive(Object obj) {
-			return obj == null || obj instanceof Float || obj instanceof Boolean;
+			return obj == null || obj instanceof Integer || obj instanceof Float || obj instanceof Boolean;
 		}
 
 		private void registerVariables(@Nullable Object dependency) {
 			if (dependency instanceof String) {
 				variables.add((String) dependency);
+			} else if (dependency instanceof Enum) {
+				variables.add(((Enum<?>) dependency).name());
 			} else if (dependency instanceof Expression) {
 				variables.addAll(((Expression) dependency).variables);
 			}
 		}
 	}
 
-	private static Object parseExpression(String expression, int startIndex, int endIndex) {
-		return parseExpression(new ParserContext(expression, startIndex, endIndex, true, 0));
+	private static Object parseExpression(
+		String expression, int startIndex, int endIndex,
+		@Nullable VariableSupplier constants, @Nullable VariableKeyResolver resolver
+	) {
+		return parseExpression(new ParserContext(expression, startIndex, endIndex, true, 0, constants, resolver));
 	}
 
 	private static Object parseExpression(ParserContext ctx) {
@@ -672,8 +898,10 @@ public class ExpressionParser {
 		ctx.trimParentheses();
 		boolean wasInParentheses = ctx.isInParentheses;
 		boolean wasTopLevelParser = ctx.isTopLevelParser;
+		boolean didHaveDecimal = ctx.hasDecimal;
 		// Since we'll be reusing the same parser context for parsing sub-expressions, mark it as not top-level
 		ctx.isTopLevelParser = false;
+		ctx.hasDecimal = false;
 
 		// The general gist:
 		// 1. Begin parsing from left to right until any operator is reached
@@ -691,7 +919,7 @@ public class ExpressionParser {
 			for (var op : Operator.OPERATORS) {
 				// Skip lower precedence operators
 				if (op.precedence >= ctx.minPrecedence && ctx.expr.startsWith(op.symbol, ctx.index)) {
-					if (op == Operator.TERNARY) {
+					if (op == TERNARY) {
 						// Parse the ternary into an expression to be the new left operand, and keep parsing
 						var condition = ctx.operands[0];
 						if (condition == null)
@@ -703,7 +931,7 @@ public class ExpressionParser {
 							throw new SyntaxError(ctx, "Expected ':' in ternary expression");
 						ctx.advance();
 						var ifFalse = parseExpression(ctx);
-						ctx.operands[0] = new Expression(op, ifTrue, ifFalse, condition, wasInParentheses);
+						ctx.operands[0] = new Expression(op, ifTrue, ifFalse, condition, wasInParentheses, didHaveDecimal);
 						continue parsing;
 					}
 
@@ -737,9 +965,43 @@ public class ExpressionParser {
 		if (wasTopLevelParser && !ctx.done())
 			throw new SyntaxError(ctx, "Unexpected character '" + ctx.c + "'");
 
-		if (ctx.operands[0] instanceof Expression)
-			((Expression) ctx.operands[0]).isInParentheses = wasInParentheses;
+		if (ctx.operands[0] instanceof Expression) {
+			Expression expression = (Expression) ctx.operands[0];
+			expression.isInParentheses = wasInParentheses;
+			expression.hasDecimal = didHaveDecimal;
+		}
 
 		return ctx.operands[0];
+	}
+
+	@FunctionalInterface
+	public interface IntEval {
+		int apply(VariableSupplier vars);
+	}
+
+	@FunctionalInterface
+	public interface FloatEval {
+		float apply(VariableSupplier vars);
+	}
+
+	@FunctionalInterface
+	public interface BooleanEval {
+		boolean apply(VariableSupplier vars);
+	}
+
+	@FunctionalInterface
+	public interface VariableKeyResolver {
+		Object resolve(String name);
+
+		static <E extends Enum<E>> VariableKeyResolver forEnum(Class<E> enumType) {
+			var values = enumType.getEnumConstants();
+			Map<String, E> lookup = new HashMap<>(values.length * 2);
+			for (var e : values)
+				lookup.put(e.name(), e);
+			return name -> {
+				E resolved = lookup.get(name);
+				return resolved != null ? resolved : name;
+			};
+		}
 	}
 }

--- a/src/main/java/rs117/hd/utils/ExpressionParserEvaluators.java
+++ b/src/main/java/rs117/hd/utils/ExpressionParserEvaluators.java
@@ -1,0 +1,347 @@
+package rs117.hd.utils;
+
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import rs117.hd.utils.ExpressionParser.BooleanEval;
+import rs117.hd.utils.ExpressionParser.FloatEval;
+import rs117.hd.utils.ExpressionParser.IntEval;
+import rs117.hd.utils.ExpressionParser.Operator;
+
+public class ExpressionParserEvaluators {
+	@RequiredArgsConstructor
+	public static final class ConstantFunction implements Function<VariableSupplier, Object> {
+		private final Object value;
+
+		@Override
+		public Object apply(VariableSupplier vars) { return value; }
+	}
+
+	@RequiredArgsConstructor
+	public static final class ObjectVariableFunction implements Function<VariableSupplier, Object> {
+		private final Object key;
+
+		@Override
+		public Object apply(VariableSupplier vars) {
+			return key instanceof Enum<?> ? vars.get((Enum<?>) key) : vars.get((String) key);
+		}
+	}
+
+	@RequiredArgsConstructor
+	public static final class IntToObjectFunction implements Function<VariableSupplier, Object> {
+		private final IntEval eval;
+
+		@Override
+		public Object apply(VariableSupplier vars) { return eval.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class FloatToObjectFunction implements Function<VariableSupplier, Object> {
+		private final FloatEval eval;
+
+		@Override
+		public Object apply(VariableSupplier vars) { return eval.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanToObjectFunction implements Function<VariableSupplier, Object> {
+		private final BooleanEval eval;
+
+		@Override
+		public Object apply(VariableSupplier vars) { return eval.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanEvalPredicate implements ExpressionPredicate {
+		private final BooleanEval eval;
+
+		@Override
+		public boolean test(VariableSupplier vars) { return eval.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class ObjectTernaryFunction implements Function<VariableSupplier, Object> {
+		private final BooleanEval condition;
+		private final Function<VariableSupplier, Object> ifTrue, ifFalse;
+
+		@Override
+		public Object apply(VariableSupplier vars) { return condition.apply(vars) ? ifTrue.apply(vars) : ifFalse.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class IntConstant implements IntEval {
+		private final int value;
+
+		@Override
+		public int apply(VariableSupplier vars) { return value; }
+	}
+
+	@RequiredArgsConstructor
+	public static final class IntStringVariable implements IntEval {
+		private final String key;
+
+		@Override
+		public int apply(VariableSupplier vars) { return vars.getInt(key); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class IntEnumVariable implements IntEval {
+		private final Enum<?> key;
+
+		@Override
+		public int apply(VariableSupplier vars) { return vars.getInt(key); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class FloatConstant implements FloatEval {
+		private final float value;
+
+		@Override
+		public float apply(VariableSupplier vars) { return value; }
+	}
+
+	@RequiredArgsConstructor
+	public static final class FloatStringVariable implements FloatEval {
+		private final String key;
+
+		@Override
+		public float apply(VariableSupplier vars) { return vars.getFloat(key); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class FloatEnumVariable implements FloatEval {
+		private final Enum<?> key;
+
+		@Override
+		public float apply(VariableSupplier vars) { return vars.getFloat(key); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanConstant implements BooleanEval {
+		private final boolean value;
+
+		@Override
+		public boolean apply(VariableSupplier vars) { return value; }
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanStringVariable implements BooleanEval {
+		private final String key;
+
+		@Override
+		public boolean apply(VariableSupplier vars) { return vars.getBoolean(key); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanEnumVariable implements BooleanEval {
+		private final Enum<?> key;
+
+		@Override
+		public boolean apply(VariableSupplier vars) { return vars.getBoolean(key); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class IntTernary implements IntEval {
+		private final BooleanEval condition;
+		private final IntEval ifTrue, ifFalse;
+
+		@Override
+		public int apply(VariableSupplier vars) { return condition.apply(vars) ? ifTrue.apply(vars) : ifFalse.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class FloatTernary implements FloatEval {
+		private final BooleanEval condition;
+		private final FloatEval ifTrue, ifFalse;
+
+		@Override
+		public float apply(VariableSupplier vars) { return condition.apply(vars) ? ifTrue.apply(vars) : ifFalse.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanTernary implements BooleanEval {
+		private final BooleanEval condition, ifTrue, ifFalse;
+
+		@Override
+		public boolean apply(VariableSupplier vars) { return condition.apply(vars) ? ifTrue.apply(vars) : ifFalse.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public abstract static class IntMathOperation implements IntEval {
+		protected final IntEval left;
+		protected final IntEval right;
+
+		@Override
+		public final int apply(VariableSupplier vars) { return apply(left.apply(vars), right.apply(vars)); }
+
+		protected abstract int apply(int left, int right);
+	}
+
+	public static final class IntAdd extends IntMathOperation {
+		public IntAdd(IntEval left, IntEval right) { super(left, right); }
+
+		@Override
+		protected int apply(int left, int right) { return left + right; }
+	}
+
+	public static final class IntSub extends IntMathOperation {
+		public IntSub(IntEval left, IntEval right) { super(left, right); }
+
+		@Override
+		protected int apply(int left, int right) { return left - right; }
+	}
+
+	public static final class IntMul extends IntMathOperation {
+		public IntMul(IntEval left, IntEval right) { super(left, right); }
+
+		@Override
+		protected int apply(int left, int right) { return left * right; }
+	}
+
+	public static final class IntDiv extends IntMathOperation {
+		public IntDiv(IntEval left, IntEval right) { super(left, right); }
+
+		@Override
+		protected int apply(int left, int right) { return left / right; }
+	}
+
+	public static final class IntMod extends IntMathOperation {
+		public IntMod(IntEval left, IntEval right) { super(left, right); }
+
+		@Override
+		protected int apply(int left, int right) { return left % right; }
+	}
+
+	@RequiredArgsConstructor
+	public abstract static class FloatMathOperation implements FloatEval {
+		protected final FloatEval left;
+		protected final FloatEval right;
+
+		@Override
+		public final float apply(VariableSupplier vars) { return apply(left.apply(vars), right.apply(vars)); }
+
+		protected abstract float apply(float left, float right);
+	}
+
+	public static final class FloatAdd extends FloatMathOperation {
+		public FloatAdd(FloatEval left, FloatEval right) { super(left, right); }
+
+		@Override
+		protected float apply(float left, float right) { return left + right; }
+	}
+
+	public static final class FloatSub extends FloatMathOperation {
+		public FloatSub(FloatEval left, FloatEval right) { super(left, right); }
+
+		@Override
+		protected float apply(float left, float right) { return left - right; }
+	}
+
+	public static final class FloatMul extends FloatMathOperation {
+		public FloatMul(FloatEval left, FloatEval right) { super(left, right); }
+
+		@Override
+		protected float apply(float left, float right) { return left * right; }
+	}
+
+	public static final class FloatDiv extends FloatMathOperation {
+		public FloatDiv(FloatEval left, FloatEval right) { super(left, right); }
+
+		@Override
+		protected float apply(float left, float right) { return left / right; }
+	}
+
+	public static final class FloatMod extends FloatMathOperation {
+		public FloatMod(FloatEval left, FloatEval right) { super(left, right); }
+
+		@Override
+		protected float apply(float left, float right) { return left % right; }
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanComparisons implements BooleanEval {
+		private final Operator op;
+		private final BooleanEval l, r;
+
+		@Override
+		public boolean apply(VariableSupplier vars) {
+			// AND/OR both can short circuit based on lVal value, so rVal is being sampled as part of the check
+			final boolean lVal = l.apply(vars);
+			switch (op) {
+				case AND:
+					return lVal && r.apply(vars);
+				case OR:
+					return lVal || r.apply(vars);
+				case EQUAL:
+					return lVal == r.apply(vars);
+				case NOTEQUAL:
+					return lVal != r.apply(vars);
+			}
+
+			throw new UnsupportedOperationException("Operator '" + op + "' is not a boolean comparison operator");
+		}
+	}
+
+	@RequiredArgsConstructor
+	public static final class BooleanNot implements BooleanEval {
+		private final BooleanEval operand;
+
+		@Override
+		public boolean apply(VariableSupplier vars) { return !operand.apply(vars); }
+	}
+
+	@RequiredArgsConstructor
+	public static final class IntComparisons implements BooleanEval {
+		private final Operator op;
+		private final IntEval l, r;
+
+		@Override
+		public boolean apply(VariableSupplier vars) {
+			final int lVal = l.apply(vars);
+			final int rVal = r.apply(vars);
+			switch (op) {
+				case LESS:
+					return lVal < rVal;
+				case LEQUAL:
+					return lVal <= rVal;
+				case GREATER:
+					return lVal > rVal;
+				case GEQUAL:
+					return lVal >= rVal;
+				case EQUAL:
+					return lVal == rVal;
+				case NOTEQUAL:
+					return lVal != rVal;
+			}
+
+			throw new UnsupportedOperationException("Operator '" + op + "' is not a int comparison operator");
+		}
+	}
+
+	@RequiredArgsConstructor
+	public static final class FloatComparisons implements BooleanEval {
+		private final Operator op;
+		private final FloatEval l, r;
+
+		@Override
+		public boolean apply(VariableSupplier vars) {
+			final float lVal = l.apply(vars);
+			final float rVal = r.apply(vars);
+			switch (op) {
+				case LESS:
+					return lVal < rVal;
+				case LEQUAL:
+					return lVal <= rVal;
+				case GREATER:
+					return lVal > rVal;
+				case GEQUAL:
+					return lVal >= rVal;
+				case EQUAL:
+					return lVal == rVal;
+				case NOTEQUAL:
+					return lVal != rVal;
+			}
+
+			throw new UnsupportedOperationException("Operator '" + op + "' is not a int comparison operator");
+		}
+	}
+}

--- a/src/main/java/rs117/hd/utils/VariableSupplier.java
+++ b/src/main/java/rs117/hd/utils/VariableSupplier.java
@@ -6,18 +6,84 @@ import java.util.Map;
 public interface VariableSupplier {
 	Object get(String name);
 
+	default float getFloat(String name) {
+		Object var = get(name);
+		if(var instanceof Integer)
+			return ((Integer)var).floatValue();
+		return (int) var;
+	}
+
+	default int getInt(String name) {
+		Object var = get(name);
+		if(var instanceof Float)
+			return ((Float)var).intValue();
+		return (int) var;
+	}
+
+	default boolean getBoolean(String name) {
+		return (Boolean) get(name);
+	}
+
+	default Object get(Enum<?> key) { return get(key.name()); }
+	default int getInt(Enum<?> key) { return getInt(key.name()); }
+	default float getFloat(Enum<?> key) { return getFloat(key.name()); }
+	default boolean getBoolean(Enum<?> key) { return getBoolean(key.name()); }
+
 	default VariableSupplier proxy(VariableSupplier proxy) {
-		return name -> {
-			var value = proxy.get(name);
-			if (value == null)
-				return get(name);
-			if (value instanceof String)
-				return get((String) value);
-			return value;
-		};
+		return new ProxyVariableSupplier(this, proxy);
 	}
 
 	default VariableSupplier aliases(Map<String, Object> aliases) {
 		return proxy(aliases::get);
+	}
+
+	final class ProxyVariableSupplier implements VariableSupplier {
+		private final VariableSupplier base;
+		private final VariableSupplier proxy;
+
+		ProxyVariableSupplier(VariableSupplier base, VariableSupplier proxy) {
+			this.base = base;
+			this.proxy = proxy;
+		}
+
+		@Override
+		public Object get(String name) {
+			var value = proxy.get(name);
+			if (value == null)
+				return base.get(name);
+			if (value instanceof String)
+				return base.get((String) value);
+			return value;
+		}
+
+		@Override
+		public float getFloat(String name) {
+			var value = proxy.get(name);
+			if (value == null)
+				return base.getFloat(name);
+			if (value instanceof String)
+				return base.getFloat((String) value);
+			return (Float) value;
+		}
+
+		@Override
+		public int getInt(String name) {
+			var value = proxy.get(name);
+			if (value == null)
+				return base.getInt(name);
+			if (value instanceof String)
+				return base.getInt((String) value);
+			return (Integer) value;
+		}
+
+		@Override
+		public boolean getBoolean(String name) {
+			var value = proxy.get(name);
+			if (value == null)
+				return base.getBoolean(name);
+			if (value instanceof String)
+				return base.getBoolean((String) value);
+			return (Boolean) value;
+		}
 	}
 }

--- a/src/test/java/rs117/hd/tests/ExpressionParserTest.java
+++ b/src/test/java/rs117/hd/tests/ExpressionParserTest.java
@@ -9,45 +9,87 @@ import rs117.hd.utils.VariableSupplier;
 import static rs117.hd.utils.ExpressionParser.parseExpression;
 import static rs117.hd.utils.ExpressionParser.parseFunction;
 import static rs117.hd.utils.ExpressionParser.parsePredicate;
+import static rs117.hd.utils.ExpressionParser.parsePredicateEnum;
 
 public class ExpressionParserTest {
+	enum Var {h, s, l, blending, textures }
+
 	@Test
 	public void testExpressionParser() {
-		VariableSupplier vars = name -> {
-			switch (name) {
-				case "h":
-					return 5;
-				case "s":
-					return 10;
-				case "l":
-					return 5;
-				case "blending":
-					return true;
-				case "textures":
-					return false;
+		final VariableSupplier vars = new VariableSupplier() {
+
+			@Override
+			public Object get(String name) { return null; }
+
+			@Override
+			public int getInt(String name) {
+				switch (name) {
+					case "h":
+						return 5;
+					case "s":
+						return 10;
+					case "l":
+						return 5;
+				}
+				throw new UnsupportedOperationException(name + " is not an int var");
 			}
-			return null;
+
+			@Override
+			public int getInt(Enum<?> name) {
+				switch ((Var)name) {
+					case h:
+						return 5;
+					case s:
+						return 10;
+					case l:
+						return 5;
+				}
+				throw new UnsupportedOperationException(name + " is not an int var");
+			}
+
+			@Override
+			public boolean getBoolean(String name) {
+				switch (name) {
+					case "blending":
+						return true;
+					case "textures":
+						return false;
+				}
+				throw new UnsupportedOperationException(name + " is not an boolean var");
+			}
+
+			@Override
+			public boolean getBoolean(Enum<?> name) {
+				switch ((Var)name) {
+					case blending:
+						return true;
+					case textures:
+						return false;
+				}
+				throw new UnsupportedOperationException(name + " is not an boolean var");
+			}
 		};
 
-		Assert.assertEquals(5.f, parseExpression("5"));
-		Assert.assertEquals(-5.f, parseExpression("-5"));
+		Assert.assertEquals(5, parseExpression("5"));
+		Assert.assertEquals(-5, parseExpression("-5"));
 		Assert.assertEquals(-2.5f, parseExpression("-2.5"));
 		Assert.assertEquals(-.5f, parseExpression("-0.5"));
 		Assert.assertEquals(-.5f, parseExpression("-.5"));
 		Assert.assertEquals(.5f, parseExpression(".5"));
 		Assert.assertEquals(.5f, parseExpression("+.5"));
 		Assert.assertEquals(.5f, parseExpression("++ +.5"));
-		Assert.assertEquals(1f, parseExpression("--1"));
+		Assert.assertEquals(1, parseExpression("--1"));
 		Assert.assertEquals(.5f, parseExpression("+-++-.5"));
-		Assert.assertEquals(17.f, parseFunction("5 + 12").apply(null));
-		Assert.assertEquals(16.f, parseExpression("8 / 2 * (2 + 2)"));
-		Assert.assertEquals(32.f, parseExpression("2 * 8 / 2 * (2 + 2)"));
-		Assert.assertEquals(3.f, parseExpression("2 * 3 / 2"));
-		Assert.assertEquals(0.f, parseExpression("2 * 8 - 4 * 4"));
-		Assert.assertEquals(29.f, parseExpression("2 + 3 * (8 + 5 / 5)"));
-		Assert.assertEquals(40.f, parseExpression("(8 - 1 + 3) * 6 - ((3 + 7) * 2)"));
-		Assert.assertEquals(21.f, parseExpression("(1 + 2) * (3 + 4)"));
+		Assert.assertEquals(17, parseFunction("5 + 12").apply(null));
+		Assert.assertEquals(16, parseExpression("8 / 2 * (2 + 2)"));
+		Assert.assertEquals(32, parseExpression("2 * 8 / 2 * (2 + 2)"));
+		Assert.assertEquals(3, parseExpression("2 * 3 / 2"));
+		Assert.assertEquals(0, parseExpression("2 * 8 - 4 * 4"));
+		Assert.assertEquals(29, parseExpression("2 + 3 * (8 + 5 / 5)"));
+		Assert.assertEquals(40, parseExpression("(8 - 1 + 3) * 6 - ((3 + 7) * 2)"));
+		Assert.assertEquals(21, parseExpression("(1 + 2) * (3 + 4)"));
 		Assert.assertFalse(parsePredicate("!( blending )").test(vars));
+		Assert.assertFalse(parsePredicateEnum("!( blending )", Var::valueOf).test(vars));
 		Assert.assertEquals(false, parseExpression("!true"));
 		Assert.assertEquals(true, parseExpression("SUMMER == 1", name -> SeasonalTheme.valueOf(name).ordinal()));
 
@@ -67,6 +109,15 @@ public class ExpressionParserTest {
 
 		for (var entry : testCases.entrySet()) {
 			var predicate = parsePredicate(entry.getKey());
+			var result = predicate.test(vars);
+			var passed = entry.getValue() == result;
+			System.out.println(
+				(passed ? "\u001B[32m" : "\u001B[31m") +
+				"Case: " + entry.getKey() + " " + (passed ? "passed" : "failed") + ". Expected: " + entry.getValue() + ", got: " + result);
+		}
+
+		for (var entry : testCases.entrySet()) {
+			var predicate = parsePredicateEnum(entry.getKey(), Var::valueOf);
 			var result = predicate.test(vars);
 			var passed = entry.getValue() == result;
 			System.out.println(


### PR DESCRIPTION
 Aims of this rewrite is to eliminate all garbage generation caused by testing the predicate generated by the ExpressionParser, to achieve this tried to remove all Lambdas from within the ExpressionParser, leaving only the `VariableSupplier` as the last potential lambda.

All Operator Lambdas have been replaced with explicit objects which achieve the same, this reduces scope capture ambiguity and instead its now clear where allocations are occurring and should now be a upfront cost to parsing instead of when testing.

`VariableSupplier` now supports:

- `getFloat`
- `getInt`
- `getBoolean`
and the original `get` which will cause boxing and ideally should be removed, its only being left for backwards compatibility.

Profile Capture Before:
<img width="1920" height="296" alt="image" src="https://github.com/user-attachments/assets/75f65806-cc3f-4fca-8086-d4d448e050dd" />

After:
<img width="2402" height="544" alt="image" src="https://github.com/user-attachments/assets/989270da-bbdc-4367-aee5-55f3a38ae680" />

A Garbage reduction of 24 GB down to 27 MB over a 30 second profile capture (On master its view dependent, more dynamic models with color overrides will allocate significantly more, these captures we're taking in port sarim)



### NOTE
Currently a draft since it needs allot of validating to ensure it matches up with the previous version, ideally we'd dump allot of data to test & verify 