### PR TITLE
Replace ModelOverride "undoVanillaShading" with "shadingMode"

### DIFF
--- a/schemas/model_overrides.schema.json
+++ b/schemas/model_overrides.schema.json
@@ -165,9 +165,10 @@
         "type": "number",
         "description": "The fraction along the models height defining the region of which vertices blend to the terrain surface. Defaults to 0.125."
       },
-      "undoVanillaShading": {
-        "type": "boolean",
-        "description": "Whether the model should undo the baked phong shading in the vertex colours. Defaults to true."
+      "shadingMode": {
+        "type": "string",
+        "description": "Whether/How the model should undo the baked phong shading in the vertex colours. Defaults to DEFAULT.",
+        "enum": [ "NONE", "DEFAULT", "UNLIT" ]
       },
       "hideAsWaterEffect": {
         "type": "boolean",
@@ -379,9 +380,10 @@
               "type": "number",
               "description": "The fraction along the models height defining the region of which vertices blend to the terrain surface. Defaults to 0.125."
             },
-            "undoVanillaShading": {
-              "type": "boolean",
-              "description": "Whether the model should undo the baked phong shading in the vertex colours. Defaults to true."
+            "shadingMode": {
+              "type": "string",
+              "description": "Whether/How the model should undo the baked phong shading in the vertex colours. Defaults to DEFAULT.",
+              "enum": [ "NONE", "DEFAULT", "UNLIT" ]
             },
             "hideAsWaterEffect": {
               "type": "boolean",

--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -689,11 +689,9 @@ public class HdPlugin extends Plugin {
 				waterTypeManager.startUp();
 				gamevalManager.startUp();
 
-				gpuFlags = DrawCallbacks.GPU | renderer.gpuFlags();
+				gpuFlags = DrawCallbacks.GPU | renderer.gpuFlags() | DrawCallbacks.UNLIT_FACE_COLORS;
 				if (config.removeVertexSnapping())
 					gpuFlags |= DrawCallbacks.NO_VERTEX_SNAPPING;
-				if (configShadingMode.unlitFaceColors)
-					gpuFlags |= DrawCallbacks.UNLIT_FACE_COLORS;
 				client.setGpuFlags(gpuFlags);
 
 				// Initialize the renderer after setting initial GPU flags,

--- a/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
+++ b/src/main/java/rs117/hd/renderer/zone/SceneUploader.java
@@ -1520,7 +1520,7 @@ public class SceneUploader implements AutoCloseable {
 		final int[] indices2 = model.getFaceIndices2();
 		final int[] indices3 = model.getFaceIndices3();
 
-		final short[] unlitFaceColors = plugin.configUnlitFaceColors ? model.getUnlitFaceColors() : null;
+		final short[] unlitFaceColors = model.getUnlitFaceColors();
 		final int[] color1s = model.getFaceColors1();
 		final int[] color2s = model.getFaceColors2();
 		final int[] color3s = model.getFaceColors3();
@@ -1606,9 +1606,6 @@ public class SceneUploader implements AutoCloseable {
 				continue;
 			}
 
-			if (unlitFaceColors != null)
-				color1 = color2 = color3 = unlitFaceColors[face] & 0xFFFF;
-
 			UvType uvType = UvType.GEOMETRY;
 			Material material = baseMaterial;
 			ModelOverride faceOverride = modelOverride;
@@ -1644,6 +1641,9 @@ public class SceneUploader implements AutoCloseable {
 
 			if (faceOverride.hide)
 				continue;
+
+			if (unlitFaceColors != null && (faceOverride.shadingMode.unlitFaceColors || plugin.configUnlitFaceColors))
+				color1 = color2 = color3 = unlitFaceColors[face] & 0xFFFF;
 
 			final int triangleA = indices1[face];
 			final int triangleB = indices2[face];
@@ -1804,7 +1804,7 @@ public class SceneUploader implements AutoCloseable {
 				);
 			}
 
-			if (plugin.configUndoVanillaShading && faceOverride.undoVanillaShading && !keepShading) {
+			if (plugin.configUndoVanillaShading && faceOverride.shadingMode.undoVanillaShading && !keepShading) {
 				color1 = undoVanillaShading(color1, plugin.configLegacyGreyColors, modelNormals[0], modelNormals[1], modelNormals[2]);
 				color2 = undoVanillaShading(color2, plugin.configLegacyGreyColors, modelNormals[3], modelNormals[4], modelNormals[5]);
 				color3 = undoVanillaShading(color3, plugin.configLegacyGreyColors, modelNormals[6], modelNormals[7], modelNormals[8]);
@@ -2155,7 +2155,7 @@ public class SceneUploader implements AutoCloseable {
 		final int[] indices2 = model.getFaceIndices2();
 		final int[] indices3 = model.getFaceIndices3();
 
-		final short[] unlitFaceColors = plugin.configUnlitFaceColors ? model.getUnlitFaceColors() : null;
+		final short[] unlitFaceColors = model.getUnlitFaceColors();
 		final int[] color1s = model.getFaceColors1();
 		final int[] color2s = model.getFaceColors2();
 		final int[] color3s = model.getFaceColors3();
@@ -2198,21 +2198,27 @@ public class SceneUploader implements AutoCloseable {
 			if (face >= faceCount)
 				continue;
 
-			int color1 = color1s[face];
-			int color2 = color2s[face];
-			int color3 = color3s[face];
-
-			if (unlitFaceColors != null)
-				color1 = color2 = color3 = unlitFaceColors[face] & 0xFFFF;
-			else if (color3 == -1)
-				color2 = color3 = color1;
-
 			int transparency = readFaceTransparency(modelTransparency, transparencies, face);
 			final int textureFace = textureFaces != null ? textureFaces[face] : -1;
 			final int textureId = isVanillaTextured ? faceTextures[face] : -1;
 			final UvType uvType = faceUVTypes.get(face);
 			final Material material = faceMaterials.get(face);
 			final ModelOverride faceOverride = faceOverrides.get(face);
+
+			int color1;
+			int color2;
+			int color3;
+
+			if (unlitFaceColors != null && (faceOverride.shadingMode.unlitFaceColors || plugin.configUnlitFaceColors)) {
+				color1 = color2 = color3 = unlitFaceColors[face] & 0xFFFF;
+			} else {
+				color1 = color1s[face];
+				color2 = color2s[face];
+				color3 = color3s[face];
+			}
+
+			if (color3 == -1)
+				color2 = color3 = color1;
 
 			if (textureId != -1)
 				color1 = color2 = color3 = 90;
@@ -2271,7 +2277,7 @@ public class SceneUploader implements AutoCloseable {
 					);
 				}
 
-				if (plugin.configUndoVanillaShading && modelOverride.undoVanillaShading) {
+				if (plugin.configUndoVanillaShading && faceOverride.shadingMode.undoVanillaShading) {
 					color1 = undoVanillaShading(color1, plugin.configLegacyGreyColors, faceNormals[0], faceNormals[1], faceNormals[2]);
 					color2 = undoVanillaShading(color2, plugin.configLegacyGreyColors, faceNormals[3], faceNormals[4], faceNormals[5]);
 					color3 = undoVanillaShading(color3, plugin.configLegacyGreyColors, faceNormals[6], faceNormals[7], faceNormals[8]);

--- a/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
+++ b/src/main/java/rs117/hd/scene/model_overrides/ModelOverride.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.*;
 import rs117.hd.HdPlugin;
 import rs117.hd.config.SeasonalTheme;
+import rs117.hd.config.ShadingMode;
 import rs117.hd.config.VanillaShadowMode;
 import rs117.hd.scene.GamevalManager;
 import rs117.hd.scene.areas.AABB;
@@ -35,7 +36,7 @@ import static rs117.hd.utils.MathUtils.*;
 public class ModelOverride
 {
 	public static final ModelOverride NONE = new ModelOverride(true);
-	public static final ModelOverride UNLIT = new ModelOverride(true).baseMaterial(Material.UNLIT).undoVanillaShading(false);
+	public static final ModelOverride UNLIT = new ModelOverride(true).baseMaterial(Material.UNLIT).shadingMode(ShadingMode.UNLIT);
 
 	private static final Set<Integer> EMPTY = new HashSet<>();
 
@@ -76,13 +77,13 @@ public class ModelOverride
 	public boolean receiveShadows = true;
 	public boolean terrainVertexSnap = false;
 	public boolean doubleSidedFaces = false;
-	public boolean undoVanillaShading = true;
 	private boolean hideAsWaterEffect = false;
 	public float terrainVertexSnapThreshold = 0.125f;
 	public float shadowOpacityThreshold = 0;
 	public TzHaarRecolorType tzHaarRecolorType = TzHaarRecolorType.NONE;
 	public InheritTileColorType inheritTileColorType = InheritTileColorType.NONE;
 	public WindDisplacement windDisplacementMode = WindDisplacement.DISABLED;
+	public ShadingMode shadingMode = ShadingMode.DEFAULT;
 	public int windDisplacementModifier = 0;
 	public boolean invertDisplacementStrength = false;
 	public int depthBias = -1;
@@ -162,6 +163,11 @@ public class ModelOverride
 			if (Props.DEVELOPMENT)
 				throw new IllegalStateException("Invalid windDisplacementMode");
 			windDisplacementMode = ModelOverride.NONE.windDisplacementMode;
+		}
+		if(shadingMode == null) {
+			if (Props.DEVELOPMENT)
+				throw new IllegalStateException("Invalid shadingMode");
+			shadingMode = ModelOverride.NONE.shadingMode;
 		}
 
 		if (windDisplacementModifier < -3 || windDisplacementModifier > 3) {
@@ -310,13 +316,13 @@ public class ModelOverride
 			receiveShadows,
 			terrainVertexSnap,
 			doubleSidedFaces,
-			undoVanillaShading,
 			hideAsWaterEffect,
 			terrainVertexSnapThreshold,
 			shadowOpacityThreshold,
 			tzHaarRecolorType,
 			inheritTileColorType,
 			windDisplacementMode,
+			shadingMode,
 			windDisplacementModifier,
 			invertDisplacementStrength,
 			depthBias,

--- a/src/main/resources/rs117/hd/scene/model_overrides.json
+++ b/src/main/resources/rs117/hd/scene/model_overrides.json
@@ -1299,7 +1299,7 @@
     "baseMaterial": "BARK",
     "shiftLightness": 6,
     "windDisplacementMode": "VERTEX_WITH_HEMISPHERE_BLEND",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "NEWBIETREE",
       "NEWBIETREE2"
@@ -4604,7 +4604,7 @@
     "description": "Varrock Fountain Railing and Statues",
     "baseMaterial": "STONE_NORMALED_LIGHT",
     "uvScale": 0.75,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "FAI_VARROCK_CENTRAL_SQUARE_STATUE01",
       "FAI_VARROCK_CENTRAL_SQUARE_STATUE01",
@@ -4618,7 +4618,7 @@
   {
     "description": "Varrock Fountain Rocks with Water",
     "baseMaterial": "STONE_NORMALED_LIGHT",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.75,
     "objectIds": [
       "FAI_VARROCK_CENTRAL_SQUARE01"
@@ -5474,7 +5474,7 @@
   {
     "description": "Falador - Metallic - White Knight Armor",
     "baseMaterial": "METALLIC_1_LIGHT_SEMIGLOSS",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.2,
     "minLightness": 17,
@@ -5561,6 +5561,7 @@
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
     "uvType": "BOX",
     "uvScale": 0.75,
+    "shadingMode": "UNLIT",
     "objectIds": [
       "FAI_FALADOR_SARADOMIN_STATUE",
       "FAI_FALADOR_SARADOMIN_STATUE_GREY"
@@ -5572,6 +5573,7 @@
     "uvType": "BOX",
     "uvOrientation": 512,
     "uvScale": 0.65,
+    "shadingMode": "UNLIT",
     "objectIds": [
       "FAI_STONE_SIGN_BOTTOM",
       "FAI_STONE_SIGN_TOP"
@@ -13956,7 +13958,7 @@
     "maxLightness": 23,
     "minLightness": 23,
     "flatNormals": true,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [ "TIMBER_OVERHANG" ]
   },
   {
@@ -14105,7 +14107,7 @@
     "uvType": "BOX",
     "uvScale": 0.4,
     "uvOrientation": 512,
-    "undoVanillaShading": false
+    "shadingMode": "NONE"
   },
   {
     "description": "Decorative Armor",
@@ -14189,7 +14191,7 @@
   {
     "description": "MARBLE_STATUE_OF_KING",
     "baseMaterial": "MARBLE_1_SEMIGLOSS",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 2,
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -14811,7 +14813,7 @@
   {
     "description": "Wizard Tower - Bridge Corner Tiles",
     "baseMaterial": "SMOOTH_STONE_VERY_LIGHT",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.7,
     "objectIds": [
@@ -15501,7 +15503,7 @@
         "baseMaterial": "LEAF_VEINS",
         "uvType": "BOX",
         "uvScale": 0.3,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "upwardsNormals": true
       },
       {
@@ -15924,7 +15926,7 @@
         "uvType": "BOX",
         "flatNormals": true,
         "uvOrientation": 512,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.75
       }
     ],
@@ -17471,7 +17473,7 @@
   },
   {
     "description": "Objects - Wooden - Crate - Don't Undo Vanilla Shading",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       "FAI_VARROCK_LARGE_CRATE",
@@ -17485,7 +17487,7 @@
   },
   {
     "description": "Objects - Wooden - Small Crate - Don't Undo Vanilla Shading",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "baseMaterial": "WOOD_GRAIN_3",
     "objectIds": [
       "FAI_VARROCK_SMALL_CRATES"
@@ -23469,7 +23471,7 @@
   {
     "description": "Nardah Walls Rubble",
     "baseMaterial": "STONE_NORMALED_DARK",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "ELID_PILE_BICKS"
     ],
@@ -23704,7 +23706,7 @@
     "baseMaterial": "STONE_NORMALED",
     "uvType": "BOX",
     "uvScale": 0.6,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "ELID_STATUETTE_BASE",
       "ELID_STATUETTE_PLACED"
@@ -30084,7 +30086,7 @@
   {
     "description": "Sangvesti - Blood Fountain",
     "baseMaterial": "WATER_FOUNTAIN_FLAT",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": -2,
     "uvType": "MODEL_XZ",
     "uvScale": 0.75,
@@ -30755,7 +30757,7 @@
     "baseMaterial": "LEAF_VEINS",
     "uvType": "MODEL_XZ",
     "windDisplacementMode": "OBJECT",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.25,
     "objectIds": [
       "SMALLFERN",
@@ -31007,7 +31009,7 @@
     "description": "Generic - Plank - Tables - Picnic Bench",
     "baseMaterial": "WOOD_GRAIN_3",
     "minLightness": 10,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "FAI_VARROCK_POSH_BENCH",
       "FAI_VARROCK_FULL_BENCH"
@@ -34242,7 +34244,7 @@
     "uvType": "BOX",
     "uvScale": 0.35,
     "upwardsNormals": true,
-    "undoVanillaShading": false
+    "shadingMode": "NONE"
   },
   {
     "description": "Lumbridge - Al Kharid Crossroads Signpost",
@@ -34254,21 +34256,21 @@
     "uvType": "BOX",
     "uvScale": 0.35,
     "upwardsNormals": true,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "colors": "h == 10",
         "baseMaterial": "METALLIC_1_LIGHT",
         "uvType": "BOX",
         "uvScale": 0.2,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "colors": "h == 4 || h == 5",
         "baseMaterial": "WOOD_GRAIN_3_LIGHT",
         "uvType": "BOX",
         "uvScale": 0.2,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
@@ -38211,7 +38213,7 @@
   {
     "description": "Oak Tree - Lighter",
     "baseMaterial": "BARK",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 6,
     "windDisplacementMode": "VERTEX_WITH_HEMISPHERE_BLEND",
     "objectIds": [
@@ -41722,7 +41724,7 @@
     "description": "Varrock Sewers - Bryophyta - Mossy Chest",
     "baseMaterial": "METALLIC_1",
     "shiftLightness": 6,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "MOSSYKEY_CHEST_CLOSED",
       "MOSSYKEY_CHEST_OPEN"
@@ -41733,7 +41735,7 @@
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
         "uvOrientation": 512,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.4,
         "shiftLightness": 5
       }
@@ -48643,7 +48645,7 @@
         "description": "Metal",
         "colors": "h == 0 && s == 0 || h == 10",
         "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
@@ -48670,7 +48672,7 @@
         "description": "Metal",
         "colors": "h == 0 && s == 0",
         "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": 3
       }
     ]
@@ -48691,7 +48693,7 @@
         "description": "Metal",
         "colors": "h == 0 && s == 0",
         "baseMaterial": "METALLIC_1_LIGHT_GLOSS",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
@@ -57576,7 +57578,7 @@
     "uvType": "BOX",
     "uvScale": 0.8,
     "flatNormals": true,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 2,
     "objectIds": [
       "WALLKIT_WOODEN01_DEFAULT01",
@@ -57612,7 +57614,7 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.8,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "FORTIS_DOOR_L",
       "FORTIS_DOOR_L_LOCKED",
@@ -61060,7 +61062,7 @@
     "description": "Red Reef Coral",
     "baseMaterial": "ROCK_2",
     "areas": [ "RED_REEF_UNDERWATER" ],
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.4,
     "objectIds": [
@@ -69196,7 +69198,7 @@
         "baseMaterial": "LEAF_VEINS",
         "uvType": "BOX",
         "uvScale": 0.3,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "upwardsNormals": true
       },
       {
@@ -81770,7 +81772,7 @@
         "description": "Rope",
         "colors": "h == 8",
         "baseMaterial": "CARPET_SUPER_LIGHT_SMOOTH",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Metal",
@@ -81910,7 +81912,7 @@
         "description": "Rope",
         "colors": "h == 8",
         "baseMaterial": "CARPET_VERY_LIGHT_SMOOTH",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Metal",
@@ -81935,7 +81937,7 @@
         "description": "Rope",
         "colors": "h == 8",
         "baseMaterial": "CARPET_VERY_LIGHT_SMOOTH",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Metal",
@@ -81968,7 +81970,7 @@
         "description": "Rope",
         "colors": "h == 8",
         "baseMaterial": "CARPET_VERY_LIGHT_SMOOTH",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Metal",
@@ -82032,7 +82034,7 @@
         "description": "Rope",
         "colors": "h == 8",
         "baseMaterial": "CARPET_VERY_LIGHT_SMOOTH",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Metal",
@@ -90319,7 +90321,7 @@
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
         "flatNormals": true,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.7
       },
       {
@@ -90328,7 +90330,7 @@
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
         "flatNormals": true,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvOrientation": 512,
         "uvScale": 0.7
       }
@@ -96479,7 +96481,7 @@
   {
     "description": "Spell Projectile - Trident of the Swamp",
     "baseMaterial": "GRAY_110",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "upwardsNormals": true,
     "flatNormals": true,
     "projectileIds": [
@@ -96489,7 +96491,7 @@
   {
     "description": "Spell Projectile - Normal Spellbook",
     "baseMaterial": "GRAY_90",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "projectileIds": [
       "WATERSURGE_TRAVEL",
       "WATERWAVE_TRAVEL",
@@ -96949,7 +96951,7 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "shiftLightness": 5,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "CRATE_SANGVESTI01_DEFAULT01",
       "CRATE_SANGVESTI01_STACKED01",
@@ -96990,7 +96992,7 @@
         "colors": [ "s == 0 && l > 3" ],
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.5,
         "shiftLightness": 25
       }
@@ -98325,7 +98327,7 @@
     "baseMaterial": "WOOD_GRAIN_3",
     "uvType": "BOX",
     "uvScale": 0.6,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 4,
     "colorOverrides": [
       {
@@ -98341,7 +98343,7 @@
         "description": "Legs",
         "colors": "s == 5",
         "baseMaterial": "BARK",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.4,
         "uvOrientation": 512,
@@ -98486,7 +98488,7 @@
         "description": "Skull",
         "colors": "h == 5 && s == 1",
         "baseMaterial": "BONE",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.6,
         "shiftLightness": -1
@@ -98630,7 +98632,7 @@
     "uvScale": 0.6,
     "uvOrientationY": 512,
     "shiftLightness": 2,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "description": "Metal",
@@ -98653,7 +98655,7 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientationY": 512,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 2,
     "colorOverrides": [
       {
@@ -98844,7 +98846,7 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "uvOrientation": 512,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 9,
     "colorOverrides": [
       {
@@ -98877,14 +98879,14 @@
     "uvScale": 0.7,
     "uvOrientation": 512,
     "shiftLightness": 4,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "flatNormals": true,
     "colorOverrides": [
       {
         "description": "Frame",
         "colors": "s == 5",
         "baseMaterial": "BARK",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.3,
         "uvOrientation": 313,
@@ -98937,7 +98939,7 @@
   {
     "description": "Castle Drakan - Vampyrium Chest",
     "baseMaterial": "WOOD_GRAIN_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "shiftLightness": 7,
     "uvScale": 0.7,
@@ -99052,7 +99054,7 @@
   {
     "description": "Castle Drakan - Vampyrium tables",
     "baseMaterial": "WOOD_GRAIN_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.6,
     "uvOrientation": 512,
@@ -99071,7 +99073,7 @@
         "colors": "s >= 4",
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.4,
         "uvOrientation": 313,
         "shiftLightness": 8
@@ -99207,7 +99209,7 @@
   {
     "description": "Vampyrium - Stymphike Hunting - Trees",
     "baseMaterial": "GRUNGE_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "terrainVertexSnap": true,
     "objectIds": [
       "HUNTING_STYMPHIKE_TREE_LETVEK",
@@ -99218,7 +99220,7 @@
         "colors": "h == 0",
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.85,
         "shiftLightness": 10
       },
@@ -99227,7 +99229,7 @@
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
         "uvScale": 0.7,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "colors": "h == 7",
@@ -99235,7 +99237,7 @@
         "uvType": "BOX",
         "uvScale": 0.2,
         "shiftLightness": -5,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "depthBias": 50
       }
     ]
@@ -99247,7 +99249,7 @@
     "uvType": "BOX",
     "uvScale": 0.2,
     "shiftLightness": -4,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "GHORROCK_BONES03"
     ]
@@ -99255,7 +99257,7 @@
   {
     "description": "Vampyrium - Stymphike Hunting - Grass",
     "baseMaterial": "LEAF_VEINS",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "HUNTING_STYMPHIKE_BUSH_EMPTY",
       "HUNTING_STYMPHIKE_BUSH_SHRUB",
@@ -99266,7 +99268,7 @@
       {
         "colors": "h == 0 || h == 48",
         "baseMaterial": "GRUNGE_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": -2
       }
     ]
@@ -99285,7 +99287,7 @@
     "description": "Vampyrium Blood Wood Trees",
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.7,
     "shiftLightness": 10,
     "objectIds": [
@@ -99303,7 +99305,7 @@
         "uvType": "BOX",
         "uvScale": 0.5,
         "uvOrientation": 900,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
@@ -99311,7 +99313,7 @@
     "description": "Vampyrium Trees",
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.8,
     "shiftLightness": 10,
     "objectIds": [
@@ -99362,7 +99364,7 @@
     "description": "Vampyrium Tree Stump with Axe",
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.7,
     "shiftLightness": 10,
     "objectIds": [
@@ -99373,7 +99375,7 @@
         "colors": "h == 5 || h == 0 && s == 7",
         "baseMaterial": "METALLIC_1",
         "shiftLightness": 15,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "colors": "h == 6",
@@ -99381,7 +99383,7 @@
         "uvType": "BOX",
         "uvOrientation": 512,
         "uvScale": 0.3,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": 5
       }
     ]
@@ -99389,7 +99391,7 @@
   {
     "description": "Vampyrium - Tall Vines",
     "baseMaterial": "PLANT_GRUNGE_1",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 4,
     "windDisplacementMode": "OBJECT_NO_GROUND_DISPLACEMENT",
     "objectIds": [
@@ -99427,7 +99429,7 @@
     "description": "Vampyrium Trees - Snake rope",
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.7,
     "shiftLightness": 10,
     "objectIds": [
@@ -99448,7 +99450,7 @@
     "description": "Vampyrium Trees with webs",
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.7,
     "shiftLightness": 10,
     "objectIds": [
@@ -99492,7 +99494,7 @@
     "description": "Vampyrium Spikey Tree",
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.7,
     "shiftLightness": 10,
     "npcIds": [
@@ -99537,7 +99539,7 @@
         "colors": "h == 60 || s < 3",
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.7,
         "shiftLightness": 3,
         "shiftSaturation": -1
@@ -99570,7 +99572,7 @@
         "colors": "s == 0 && l == 2",
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.7,
         "shiftLightness": 5,
         "shiftSaturation": -1
@@ -99595,7 +99597,7 @@
     "areas": [ "VAMPYRIUM_MAGGOT_KING_TREE_FIX" ],
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.7,
     "objectIds": [
       "DARKWOOD_TREE_TRUNK02_DARK01"
@@ -99617,7 +99619,7 @@
         "colors": "h == 60 || s < 3",
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.7,
         "shiftLightness": 7,
         "shiftSaturation": -1
@@ -99653,7 +99655,7 @@
         "colors": "h == 60 || s < 3",
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.7,
         "shiftLightness": -4,
         "shiftSaturation": -1
@@ -99677,7 +99679,7 @@
     "description": "Vampyrium Trees Doorway",
     "baseMaterial": "BARK",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.7,
     "shiftLightness": 10,
     "objectIds": [
@@ -99702,7 +99704,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 5,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "ROCKS_VOROS02_LARGE01",
       "ROCKS_VOROS02_CHUNK01",
@@ -99734,7 +99736,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 2,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "VAMPYRIUM_STEPPING_STONE_SHORTCUT_PILLAR_OP",
       "VAMPYRIUM_STEPPING_STONE_SHORTCUT_PILLAR_NOOP"
@@ -99747,7 +99749,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 4,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "castShadows": false,
     "objectIds": [
       "VOROS_ROCKSLIDE03",
@@ -99762,7 +99764,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 6,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "VOROS_CAVE01_MOUNTAIN01"
     ],
@@ -99779,7 +99781,7 @@
     "baseMaterial": "STONE_NORMALED",
     "uvType": "BOX",
     "uvScale": 0.75,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvOrientation": 256,
     "objectIds": [
       "BRIDGEKIT_SANGVESTI01_SIDE01"
@@ -99789,7 +99791,7 @@
     "description": "Vampyrium - Sangvesti Buildings - Roof",
     "baseMaterial": "STONE_NORMALED",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "doubleSidedFaces": true,
     "uvScale": 0.75,
     "uvOrientation": -256,
@@ -99801,14 +99803,14 @@
         "uvType": "BOX",
         "uvScale": 0.8,
         "shiftLightness": 7,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvOrientationX": 512
       },
       {
         "description": "Red accents",
         "colors": "h == 0 && s >= 4",
         "baseMaterial": "WOOD_GRAIN_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.4,
         "uvOrientation": 512,
@@ -99841,7 +99843,7 @@
   {
     "description": "Vampyrium - Sangvesti Buildings - Roof Facade - Needs UV",
     "baseMaterial": "STONE_NORMALED",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientation": -256,
@@ -99852,7 +99854,7 @@
         "colors": "h == 0 && s == 2 && l < 14",
         "baseMaterial": "WOOD_GRAIN_3",
         "doubleSidedFaces": true,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.8,
         "shiftLightness": 8,
@@ -99915,7 +99917,7 @@
         "uvScale": 0.4,
         "shiftLightness": 13,
         "uvOrientation": 512,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Spike",
@@ -99925,14 +99927,14 @@
         "uvType": "BOX",
         "uvScale": 0.45,
         "uvOrientation": 512,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
   {
     "description": "Vampyrium - Sangvesti Bridge",
     "baseMaterial": "STONE_NORMALED",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvOrientation": 256,
     "uvScale": 0.8,
@@ -99954,13 +99956,13 @@
         "shiftSaturation": 2,
         "shiftLightness": 1,
         "uvType": "BOX",
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Spike",
         "colors": "h == 0 && s > 3",
         "baseMaterial": "WOOD_GRAIN_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftSaturation": -1,
         "shiftLightness": 2,
         "uvType": "BOX",
@@ -99973,7 +99975,7 @@
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
         "shiftLightness": 6,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ],
     "objectIds": [
@@ -99991,7 +99993,7 @@
   {
     "description": "Vampyrium - Bridge Boardwalk",
     "baseMaterial": "WOOD_GRAIN_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvOrientationY": 512,
     "uvScale": 0.7,
@@ -100046,7 +100048,7 @@
         "uvScale": 0.4,
         "shiftLightness": 13,
         "uvOrientation": 512,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Spike",
@@ -100056,7 +100058,7 @@
         "uvType": "BOX",
         "uvScale": 0.45,
         "uvOrientation": 512,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
@@ -100093,7 +100095,7 @@
   {
     "description": "Vampyrium - Sangvesti Buildings - Bridge",
     "baseMaterial": "STONE_NORMALED",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.75,
     "shiftLightness": 1,
@@ -100111,7 +100113,7 @@
         "baseMaterial": "BARK",
         "uvType": "BOX",
         "uvScale": 0.4,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": 7
       },
       {
@@ -100130,14 +100132,14 @@
         "uvType": "BOX",
         "uvScale": 0.45,
         "uvOrientation": 512,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
   {
     "description": "Vampyrium - Sangvesti Buildings - Bridge Floor",
     "baseMaterial": "SMOOTH_STONE",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.75,
     "shiftLightness": 4,
@@ -100156,7 +100158,7 @@
     "uvScale": 0.75,
     "shiftLightness": 8,
     "uvOrientationY": 512,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "BRIDGEKIT_SANGVESTI01_ARCH01",
       "BRIDGEKIT_SANGVESTI01_ARCH02"
@@ -100168,7 +100170,7 @@
     "uvType": "BOX",
     "uvScale": 0.75,
     "shiftLightness": 1,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "WALLKIT_SANGVESTI01_RUBBLE03",
       "WALLKIT_SANGVESTI01_RUBBLE04",
@@ -100297,7 +100299,7 @@
     "uvType": "BOX",
     "uvScale": 0.3,
     "uvOrientation": 512,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 5,
     "colorOverrides": [
       {
@@ -100312,7 +100314,7 @@
         "colors": "s == 4 || s == 1 || s == 2",
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.6,
         "uvOrientation": 512,
         "shiftLightness": 4
@@ -100329,7 +100331,7 @@
       "MYQ6_STOOL01"
     ],
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.80,
     "shiftLightness": 4
   },
@@ -100715,7 +100717,7 @@
         "description": "Planks",
         "colors": "h == 0 && s == 4",
         "baseMaterial": "BARK",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.3,
         "shiftLightness": 8
@@ -100724,7 +100726,7 @@
         "description": "Planks",
         "colors": "h == 0 && s > 0 && s < 7",
         "baseMaterial": "WOOD_GRAIN_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.58,
         "shiftLightness": 11
@@ -100783,7 +100785,7 @@
     "description": "Vampyrium - Sangvesti House Roof fences on stone",
     "baseMaterial": "SMOOTH_STONE",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.66,
     "uvOrientation": 256,
     "colorOverrides": [
@@ -100791,7 +100793,7 @@
         "description": "Fence",
         "colors": "s == 6",
         "baseMaterial": "METALLIC_1_SEMIGLOSS",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.25,
         "uvOrientation": 187,
@@ -100841,7 +100843,7 @@
   {
     "description": "Vampyrium - Sangvesti Drakan Statue",
     "baseMaterial": "SMOOTH_STONE",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "maxLightness": 27,
     "uvType": "BOX",
     "uvScale": 0.4,
@@ -100866,7 +100868,7 @@
   {
     "description": "Vampyrium - Venator Heart Altar",
     "baseMaterial": "SMOOTH_STONE",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 3,
     "uvType": "BOX",
     "uvScale": 0.7,
@@ -100878,7 +100880,7 @@
       {
         "colors": "s == 5",
         "baseMaterial": "GRUNGE_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "maxLightness": 20
       }
     ]
@@ -100886,7 +100888,7 @@
   {
     "description": "Vampyrium - Sangvesti Wall Stakes",
     "baseMaterial": "BARK",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 8,
     "uvType": "BOX",
     "uvScale": 0.6,
@@ -100899,7 +100901,7 @@
         "description": "Wood",
         "colors": "s > 3",
         "baseMaterial": "WOOD_GRAIN_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.6,
         "shiftLightness": 9
@@ -100926,7 +100928,7 @@
         "description": "Wood grain",
         "colors": "s == 5",
         "baseMaterial": "BARK",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.5,
         "uvOrientation": 512,
@@ -100963,7 +100965,7 @@
   {
     "description": "Vampyrium - Sangvesti Buildings",
     "baseMaterial": "WOOD_GRAIN_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 5,
@@ -100976,7 +100978,7 @@
         "uvType": "BOX",
         "uvScale": 0.5,
         "uvOrientation": 313,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": 8
       }
     ],
@@ -101065,7 +101067,7 @@
         "windDisplacementMode": "OBJECT",
         "shiftLightness": 2,
         "castShadows": false,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Logs",
@@ -101074,7 +101076,7 @@
         "uvType": "BOX",
         "uvScale": 0.5,
         "shiftLightness": 11,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ],
     "objectIds": [
@@ -101087,7 +101089,7 @@
     "uvType": "BOX",
     "uvScale": 0.5,
     "uvOrientation": 512,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 10,
     "colorOverrides": [
       {
@@ -101189,14 +101191,14 @@
     "uvScale": 0.3,
     "uvOrientation": 404,
     "shiftLightness": 2,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "description": "Leaf",
         "colors": "h == 42 && s == 0",
         "baseMaterial": "LEAF_VEINS",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.25,
         "shiftLightness": 20,
         "uvOrientationX": 512
@@ -101214,14 +101216,14 @@
     "uvType": "BOX",
     "uvScale": 0.45,
     "uvOrientation": 404,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 4,
     "colorOverrides": [
       {
         "description": "Leaf",
         "colors": "h == 42 && s == 0",
         "baseMaterial": "LEAF_VEINS",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.25,
         "shiftLightness": 6,
@@ -101252,7 +101254,7 @@
   {
     "description": "Vampyrium - Silver Leafy plant with white stalk",
     "baseMaterial": "PLANT_GRUNGE_2",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.45,
     "uvOrientation": 404,
@@ -101262,7 +101264,7 @@
         "description": "Leaf",
         "colors": "h == 0 && s == 0",
         "baseMaterial": "LEAF_VEINS",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.25,
         "shiftLightness": 5,
@@ -101277,7 +101279,7 @@
   {
     "description": "Vampyrium - Silver Leafy plant with white stalk",
     "baseMaterial": "DIRT_1",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.4,
     "colorOverrides": [
@@ -101289,14 +101291,14 @@
         "uvScale": 0.075,
         "shiftLightness": 2,
         "uvOrientationX": 512,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Trunk",
         "colors": "h == 0 && s == 0 || h == 42",
         "baseMaterial": "BARK",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.35,
         "shiftLightness": 5
       }
@@ -101310,7 +101312,7 @@
   {
     "description": "Vampyrium - Bell flower",
     "baseMaterial": "PLANT_GRUNGE_2",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.2,
     "uvOrientation": 404,
@@ -101323,7 +101325,7 @@
         "uvType": "BOX",
         "uvScale": 0.25,
         "shiftLightness": 18,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvOrientationX": 512
       }
     ],
@@ -101336,7 +101338,7 @@
     "baseMaterial": "GRUNGE_2",
     "uvType": "BOX",
     "uvScale": 0.3,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 6,
     "colorOverrides": [
       {
@@ -101347,7 +101349,7 @@
         "uvScale": 0.45,
         "uvOrientation": 42,
         "shiftLightness": 5,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Stalk",
@@ -101355,7 +101357,7 @@
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
         "uvScale": 0.3,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": 6
       },
       {
@@ -101374,7 +101376,7 @@
   {
     "description": "Vampyrium - Purple grass and webbed plant",
     "baseMaterial": "LEAF_VEINS",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.45,
     "uvOrientation": 404,
@@ -101390,7 +101392,7 @@
     "uvType": "BOX",
     "uvScale": 0.45,
     "uvOrientation": 404,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 4,
     "colorOverrides": [
       {
@@ -101409,7 +101411,7 @@
         "uvType": "BOX",
         "uvScale": 0.45,
         "uvOrientation": 42,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": 6
       },
       {
@@ -101542,7 +101544,7 @@
     "uvScale": 0.7,
     "uvOrientation": 222,
     "shiftLightness": 2,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "description": "Skewer",
@@ -101570,7 +101572,7 @@
         "shiftSaturation": 2,
         "shiftLightness": 3,
         "castShadows": false,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ],
     "objectIds": [
@@ -101586,7 +101588,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 10,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "description": "Skewer",
@@ -101629,7 +101631,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 10,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "FENCE_DRAKAN01_RUINED01",
       "FENCE_DRAKAN01_RUINED02",
@@ -101651,7 +101653,7 @@
         "shiftSaturation": 2,
         "shiftLightness": 3,
         "castShadows": false,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Red covering",
@@ -101660,14 +101662,14 @@
         "uvType": "BOX",
         "uvScale": 0.5,
         "shiftLightness": 5,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Leaf",
         "colors": "h == 42 && s == 0",
         "baseMaterial": "LEAF_VEINS",
         "uvType": "BOX",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.25,
         "shiftLightness": 20,
         "uvOrientationX": 512
@@ -101680,7 +101682,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 10,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "description": "Grass",
@@ -101693,7 +101695,7 @@
         "shiftSaturation": 2,
         "shiftLightness": 3,
         "castShadows": false,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       },
       {
         "description": "Red covering",
@@ -101718,7 +101720,7 @@
     "uvType": "BOX",
     "uvScale": 0.7,
     "shiftLightness": 6,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "description": "Grass",
@@ -101768,7 +101770,7 @@
     "baseMaterial": "CARPET",
     "uvType": "BOX",
     "uvScale": 0.7,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 12,
     "colorOverrides": [
       {
@@ -101893,7 +101895,7 @@
         "description": "Grain",
         "colors": "h == 0 && s == 2",
         "baseMaterial": "WOOD_GRAIN_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.8
       }
@@ -102153,7 +102155,7 @@
         "description": "Table contents",
         "colors": "s == 0",
         "baseMaterial": "GRUNGE_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "MODEL_XZ",
         "shiftLightness": 4
       }
@@ -102168,7 +102170,7 @@
     "uvType": "BOX",
     "uvScale": 0.2,
     "uvOrientation": -187,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 2,
     "colorOverrides": [
       {
@@ -102184,7 +102186,7 @@
         "baseMaterial": "WOOD_GRAIN_3",
         "uvType": "BOX",
         "uvOrientation": 512,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvScale": 0.8,
         "shiftLightness": 9
       },
@@ -102207,7 +102209,7 @@
     "uvType": "BOX",
     "uvScale": 0.2,
     "uvOrientation": -187,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "colorOverrides": [
       {
         "description": "BLOOD",
@@ -102348,7 +102350,7 @@
       {
         "colors": "h == 0 && s == 3",
         "baseMaterial": "WOOD_GRAIN_3",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.5,
         "shiftLightness": 7
@@ -102449,7 +102451,7 @@
   {
     "description": "Vampyrium - Sugadinti Carpet",
     "baseMaterial": "CARPET",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.65,
     "uvOrientation": 222,
@@ -102636,14 +102638,14 @@
         "uvType": "BOX",
         "uvScale": 0.6,
         "shiftLightness": 8,
-        "undoVanillaShading": false
+        "shadingMode": "NONE"
       }
     ]
   },
   {
     "description": "Sangvesti - Bank Chest Built",
     "baseMaterial": "WOOD_GRAIN_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "shiftLightness": 5,
     "uvScale": 0.7,
@@ -102763,7 +102765,7 @@
     "description": "Maggot King Detritus",
     "uvType": "BOX",
     "baseMaterial": "GRUNGE_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "CORPSE_MAGGOT_DETRITUS01",
       "CORPSE_MAGGOT_DETRITUS02",
@@ -102773,7 +102775,7 @@
       {
         "colors": "h == 2 && s == 7",
         "baseMaterial": "ABYSSAL",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": -1,
         "uvType": "BOX",
         "uvScale": 0.2
@@ -102784,7 +102786,7 @@
     "description": "Maggot King Bones",
     "uvType": "BOX",
     "baseMaterial": "BONE",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "shiftLightness": 3,
     "uvScale": 0.5,
     "objectIds": [
@@ -102796,7 +102798,7 @@
     "description": "Maggot King Bone Wall",
     "uvType": "BOX",
     "baseMaterial": "BONE",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvScale": 0.5,
     "shiftLightness": 6,
     "objectIds": [
@@ -102819,7 +102821,7 @@
   {
     "description": "Maggot King Corpse Pile",
     "uvType": "BOX",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "baseMaterial": "GRUNGE_3",
     "objectIds": [
       "CORPSE_MAGGOT_PILE01",
@@ -102832,7 +102834,7 @@
         "colors": "h == 2 && s > 5",
         "baseMaterial": "ABYSSAL_2",
         "shiftLightness": 4,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.3
       },
@@ -102840,7 +102842,7 @@
         "colors": "h == 5 && s == 5",
         "baseMaterial": "DIRT_1",
         "shiftLightness": 6,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.5
       },
@@ -102872,7 +102874,7 @@
     "baseMaterial": "GRUNGE_3",
     "shiftLightness": 2,
     "shiftSaturation": -1,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.5,
     "maxLightness": 25,
@@ -103033,7 +103035,7 @@
     "uvType": "BOX",
     "uvScale": 0.6,
     "shiftLightness": 3,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "WYRMSCRAIG_SUNSTONE01"
     ],
@@ -103059,7 +103061,7 @@
         "colors": "h == 10",
         "baseMaterial": "METALLIC_1",
         "shiftLightness": 12,
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvScale": 0.15
       }
@@ -103068,7 +103070,7 @@
   {
     "description": "Wyrmscraig - Bank Chest",
     "baseMaterial": "WOOD_GRAIN",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "objectIds": [
       "WYRMSCRAIG_BANK_CHEST_BUILT"
     ],
@@ -103076,7 +103078,7 @@
       {
         "colors": "h == 10",
         "baseMaterial": "METALLIC_1",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "shiftLightness": 12,
         "uvType": "BOX",
         "uvScale": 0.15
@@ -103345,7 +103347,7 @@
   {
     "description": "Wyrmscraig - Cathedral Broken Pews - Climbable",
     "baseMaterial": "WOOD_GRAIN_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientationY": 512,
@@ -103366,7 +103368,7 @@
   {
     "description": "Wyrmscraig - Cathedral Broken Pews - Decorative",
     "baseMaterial": "WOOD_GRAIN_3",
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.75,
     "uvOrientationY": 450,
@@ -103388,7 +103390,7 @@
     "description": "Wyrmscraig - Cathedral Throne",
     "baseMaterial": "WOOD_GRAIN_3",
     "shiftLightness": 10,
-    "undoVanillaShading": false,
+    "shadingMode": "NONE",
     "uvType": "BOX",
     "uvScale": 0.75,
     "objectIds": [
@@ -103406,7 +103408,7 @@
         "description": "Chains",
         "colors": "h == 0",
         "baseMaterial": "METALLIC_1_LIGHT",
-        "undoVanillaShading": false,
+        "shadingMode": "NONE",
         "uvType": "BOX",
         "uvOrientation": 512,
         "uvScale": 0.15


### PR DESCRIPTION
 * Converted existing `undoVanillaShading` -> `shadingMode
 * Unlit Colors Flag enabled at all times
 * SceneUploader now checks the `FaceOverride::ShadingMode`
 * Original Vertex Colours are used due to existing ModelOverrides not being configured for Unlit Vertex Colour Values in Colour Expressions


https://github.com/user-attachments/assets/48cbc106-7cd0-4e99-97d1-3e4a7e85abb7

