### PR TITLE
Provide Exception as Shutdown Reason

### DIFF
--- a/src/main/java/rs117/hd/HdPlugin.java
+++ b/src/main/java/rs117/hd/HdPlugin.java
@@ -440,6 +440,7 @@ public class HdPlugin extends Plugin {
 
 	@Getter
 	private boolean isPluginStopPending;
+	private Throwable shutdownException;
 	@Getter
 	private boolean isActive;
 	private boolean lwjglInitialized;
@@ -818,11 +819,39 @@ public class HdPlugin extends Plugin {
 		});
 	}
 
-	public void requestPluginStop() {
+	public void requestPluginStop() { requestPluginStop(null); }
+
+	public void requestPluginStop(Throwable ex) {
 		if (isPluginStopPending)
 			return;
 		log.debug("Requesting plugin to stop when safe");
 		isPluginStopPending = true;
+		shutdownException = ex;
+	}
+
+	private boolean handleShutdownRequest() {
+		if (!isPluginStopPending)
+			return false;
+
+		try {
+			log.debug("Shutdown has been requested, stopping plugin");
+			stopPlugin();
+
+			final Throwable shutdownException = this.shutdownException;
+			if (shutdownException != null) {
+				clientThread.invoke((Runnable) () -> {
+					log.debug("Reporting exception to RuneLite");
+					RuntimeException reported = new RuntimeException("117HD - Shutdown caused by Exception: " + shutdownException.getMessage(), shutdownException);
+					reported.setStackTrace(shutdownException.getStackTrace());
+					throw reported;
+				});
+			}
+
+			return true;
+		} finally {
+			isPluginStopPending = false;
+			shutdownException = null;
+		}
 	}
 
 	public void stopPlugin() {
@@ -1599,8 +1628,8 @@ public class HdPlugin extends Plugin {
 	}
 
 	/**
-	 * Convert the front framebuffer to an Image
-	 */
+     * Convert the front framebuffer to an Image
+     */
 	public Image screenshot() {
 		if (uiResolution == null)
 			return null;
@@ -1988,16 +2017,11 @@ public class HdPlugin extends Plugin {
 
 	@Subscribe(priority = -1) // Run after the low detail plugin
 	public void onBeforeRender(BeforeRender beforeRender) {
-		SKIP_GL_ERROR_CHECKS = !log.isDebugEnabled() || developerTools.isFrameTimingsOverlayEnabled();
-
-		frame = (frame + 1) & Integer.MAX_VALUE;
-
-		if (isPluginStopPending) {
-			log.debug("Shutdown has been requested, stopping plugin");
-			isPluginStopPending = false;
-			stopPlugin();
+		if(handleShutdownRequest())
 			return;
-		}
+
+		SKIP_GL_ERROR_CHECKS = !log.isDebugEnabled() || developerTools.isFrameTimingsOverlayEnabled();
+		frame = (frame + 1) & Integer.MAX_VALUE;
 
 		if (lastFrameTimeMillis > 0) {
 			deltaTime = (float) ((System.currentTimeMillis() - lastFrameTimeMillis) / 1000.);

--- a/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
+++ b/src/main/java/rs117/hd/renderer/zone/ZoneRenderer.java
@@ -353,7 +353,7 @@ public class ZoneRenderer implements Renderer {
 			frameTimer.end(Timer.DRAW_PRESCENE);
 		} catch (Throwable ex) {
 			log.error("Error in preSceneDraw({}):", scene != null ? scene.getWorldViewId() : null, ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 	}
 
@@ -428,7 +428,7 @@ public class ZoneRenderer implements Renderer {
 				frameTimer.end(Timer.UPDATE_SCENE);
 			} catch (Exception ex) {
 				log.error("Error while updating environment or lights:", ex);
-				plugin.requestPluginStop();
+				plugin.requestPluginStop(ex);
 				return;
 			}
 
@@ -677,7 +677,7 @@ public class ZoneRenderer implements Renderer {
 			frameTimer.end(Timer.DRAW_POSTSCENE);
 		} catch (Throwable ex) {
 			log.error("Error in postSceneDraw({}):", scene != null ? scene.getWorldViewId() : null, ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 	}
 
@@ -902,7 +902,7 @@ public class ZoneRenderer implements Renderer {
 				return zone.inSceneFrustum = true;
 		} catch (Throwable ex) {
 			log.error("Error in zoneInFrustum({}, {}, {}, {}):", zx, zz, maxY, minY, ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 		return false;
 	}
@@ -939,7 +939,7 @@ public class ZoneRenderer implements Renderer {
 			checkGLErrors();
 		} catch (Throwable ex) {
 			log.error("Error in drawZoneOpaque({}, {}, {}):", zx, zz, scene != null ? scene.getWorldViewId() : null, ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 	}
 
@@ -1009,7 +1009,7 @@ public class ZoneRenderer implements Renderer {
 			checkGLErrors();
 		} catch (Throwable ex) {
 			log.error("Error in drawZoneAlpha({}, {}, {}, {}):", zx, zz, level, scene != null ? scene.getWorldViewId() : null, ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 	}
 
@@ -1071,7 +1071,7 @@ public class ZoneRenderer implements Renderer {
 			checkGLErrors();
 		} catch (Throwable ex) {
 			log.error("Error in drawPass({}, {}, {}):", projection, scene != null ? scene.getWorldViewId() : null, pass, ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 	}
 
@@ -1218,7 +1218,7 @@ public class ZoneRenderer implements Renderer {
 			shouldRenderScene = false;
 		} catch (Throwable ex) {
 			log.error("Error in draw({}):", overlayColor, ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 	}
 
@@ -1279,7 +1279,7 @@ public class ZoneRenderer implements Renderer {
 			sceneManager.despawnWorldView(worldView);
 		} catch (Throwable ex) {
 			log.error("Error in despawnWorldView({}):", worldView.getId(), ex);
-			plugin.requestPluginStop();
+			plugin.requestPluginStop(ex);
 		}
 	}
 


### PR DESCRIPTION
 * Added `handleShutdownRequest` which will report the Exception to Runelite Internals via `clientThread.invoke`

Example Shutdown log:
```
20:05:12.455 [Client    ] DEBUG r.h.s.EnvironmentManager       - changing environment from NONE to OVERWORLD (instant: true)
20:05:16.709 [Client    ] ERROR r.h.r.zone.ZoneRenderer        - Error in drawZoneOpaque(11, 10, 0):
java.lang.Exception: drawZoneOpaque - Test Failure
	at rs117.hd.renderer.zone.ZoneRenderer.drawZoneOpaque(ZoneRenderer.java:940)
	at ez.iy(ez.java:25384)
	at ez.dh(ez.java:13436)
	at cz.az(cz.java:214)
	at gp.ae(gp.java:173)
	at gp.ae(gp.java:209)
	at gp.lv(gp.java:66)
	at gp.az(gp.java:57)
	at client.gh(client.java:10270)
	at client.hs(client.java:8762)
	at tq.js(tq.java:486)
	at tq.cb(tq.java)
	at tq.run(tq.java:31825)
	at java.base/java.lang.Thread.run(Thread.java:840)
20:05:16.710 [Client    ] DEBUG rs117.hd.HdPlugin              - Requesting plugin to stop when safe
20:05:16.711 [Client    ] DEBUG rs117.hd.HdPlugin              - Shutdown has been requested, stopping plugin
20:05:16.712 [Client    ] DEBUG rs117.hd.utils.FileWatcher     - Shutting down FileWatcher
20:05:16.718 [Client    ] DEBUG r.hd.utils.jobs.JobSystem      - All workers shutdown successfully
20:05:16.725 [Client    ] DEBUG n.r.c.input.KeyManager         - Unregistered key listener: rs117.hd.utils.DeveloperTools@664d1f2
20:05:17.075 [Client    ] DEBUG injected-client                - Game state changed: LOADING (state: 25, 2 step: false)
20:05:17.078 [AWT-EventQueue-0] DEBUG n.r.c.config.ConfigManager     - Setting configuration value for runelite.hdplugin to false
20:05:17.078 [Client    ] DEBUG rs117.hd.HdPlugin              - Reporting exception to RuneLite
20:05:17.078 [Client    ] WARN  n.r.c.eventbus.EventBus        - Uncaught exception in event subscriber
java.lang.RuntimeException: 117HD - Shutdown caused by Exception: drawZoneOpaque - Test Failure
	at rs117.hd.renderer.zone.ZoneRenderer.drawZoneOpaque(ZoneRenderer.java:940)
	at ez.iy(ez.java:25384)
	at ez.dh(ez.java:13436)
	at cz.az(cz.java:214)
	at gp.ae(gp.java:173)
	at gp.ae(gp.java:209)
	at gp.lv(gp.java:66)
	at gp.az(gp.java:57)
	at client.gh(client.java:10270)
	at client.hs(client.java:8762)
	at tq.js(tq.java:486)
	at tq.cb(tq.java)
	at tq.run(tq.java:31825)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.Exception: drawZoneOpaque - Test Failure
	... 14 common frames omitted
20:05:17.079 [Client    ] DEBUG n.r.client.callback.Hooks      - Graphics reset!
Caused by: java.lang.Exception: drawZoneOpaque - Test Failure

20:05:17.079 [AWT-EventQueue-0] DEBUG n.r.c.p.PluginManager          - Plugin HdPlugin is now stopped
```